### PR TITLE
feat: add wp_ai_mind_is_pro filter for local dev override

### DIFF
--- a/includes/Core/ProGate.php
+++ b/includes/Core/ProGate.php
@@ -19,13 +19,25 @@ namespace WP_AI_Mind\Core {
 			// wam_fs() is the Freemius bootstrap function defined in wp-ai-mind.php.
 			if ( function_exists( 'wam_fs' ) ) {
 				try {
-					return \wam_fs()->can_use_premium_code__premium_only(); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+					$result = \wam_fs()->can_use_premium_code__premium_only(); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 				} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 					// Freemius not yet initialised — fall through to option check.
+					$result = 'active' === \get_option( self::OPTION_KEY, '' );
 				}
+			} else {
+				// Fallback: manual licence flag set during activation.
+				$result = 'active' === \get_option( self::OPTION_KEY, '' );
 			}
-			// Fallback: manual licence flag set during activation.
-			return 'active' === \get_option( self::OPTION_KEY, '' );
+
+			/**
+			 * Filters the pro status of the plugin.
+			 *
+			 * Intended for local development only. Use a gitignored mu-plugin to
+			 * override — never define this in production code.
+			 *
+			 * @param bool $result Whether the current install has a valid pro licence.
+			 */
+			return (bool) \apply_filters( 'wp_ai_mind_is_pro', $result );
 		}
 
 		/** Called from Freemius webhook / activation in P6. */


### PR DESCRIPTION
## Summary

- Adds `apply_filters('wp_ai_mind_is_pro', $result)` to `ProGate::is_pro()` after the real Freemius/option check runs
- Enables local pro-mode testing via a gitignored mu-plugin in the site repo — no override code ships in the plugin itself

## Test plan

- [ ] Verify `wp_ai_mind_is_pro()` still returns `false` on a fresh install with no licence
- [ ] Verify a gitignored mu-plugin hooking `add_filter('wp_ai_mind_is_pro', '__return_true')` enables pro features locally
- [ ] Verify removing the mu-plugin restores free behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)