### PR TITLE
fix(tokens): add missing --space-9 and --space-12 CSS custom properties

### DIFF
--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -27,7 +27,8 @@
   /* Spacing */
   --space-1: 4px;  --space-2: 8px;  --space-3: 12px;
   --space-4: 16px; --space-5: 20px; --space-6: 24px;
-  --space-7: 28px; --space-8: 32px; --space-10: 40px;
+  --space-7: 28px; --space-8: 32px; --space-9: 36px;
+  --space-10: 40px; --space-12: 48px;
 
   /* Radius */
   --radius-sm: 4px;


### PR DESCRIPTION
## Summary

- Adds `--space-9: 36px` and `--space-12: 48px` to `src/styles/tokens.css`
- `--space-12` was referenced in `UsageDashboard.jsx:18` as an inline `paddingTop` style but was undefined, causing it to silently collapse to `0`
- `--space-9` fills the gap in the spacing scale for completeness

## Test plan

- [ ] Verify the empty-state panel in the Usage Dashboard renders with correct top padding (48px) instead of collapsing to 0
- [ ] Confirm no visual regressions in other components that use spacing tokens