### PR TITLE
fix: address PR#7 review comments

### DIFF
--- a/includes/Admin/ChatPage.php
+++ b/includes/Admin/ChatPage.php
@@ -38,9 +38,8 @@ class ChatPage {
 			$default_models      = $default_provider->get_models();
 			$default_model_id    = $default_provider->get_default_model();
 			$default_model_label = $default_models[ $default_model_id ] ?? ucfirst( $default_slug );
-		} catch ( \Throwable $e ) {
+		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// Leave default label as 'AI' if factory fails.
-			unset( $e );
 		}
 
 		wp_localize_script(

--- a/includes/Core/ProGate.php
+++ b/includes/Core/ProGate.php
@@ -14,6 +14,10 @@ namespace WP_AI_Mind\Core {
 
 		private const OPTION_KEY = 'wp_ai_mind_licence_status';
 
+		private static function is_licence_active(): bool {
+			return 'active' === \get_option( self::OPTION_KEY, '' );
+		}
+
 		public static function is_pro(): bool {
 			// When Freemius SDK is loaded, delegate to it.
 			// wam_fs() is the Freemius bootstrap function defined in wp-ai-mind.php.
@@ -22,11 +26,11 @@ namespace WP_AI_Mind\Core {
 					$result = \wam_fs()->can_use_premium_code__premium_only(); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 				} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 					// Freemius not yet initialised — fall through to option check.
-					$result = 'active' === \get_option( self::OPTION_KEY, '' );
+					$result = self::is_licence_active();
 				}
 			} else {
 				// Fallback: manual licence flag set during activation.
-				$result = 'active' === \get_option( self::OPTION_KEY, '' );
+				$result = self::is_licence_active();
 			}
 
 			/**

--- a/tests/Unit/Core/ProGateTest.php
+++ b/tests/Unit/Core/ProGateTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace WP_AI_Mind\Tests\Unit\Core;
 
 use Brain\Monkey;
+use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use WP_AI_Mind\Core\ProGate;
 use PHPUnit\Framework\TestCase;
@@ -20,6 +21,14 @@ class ProGateTest extends TestCase {
 
 	public function test_is_pro_returns_true_when_option_set(): void {
 		Functions\when( 'get_option' )->justReturn( 'active' );
+		$this->assertTrue( ProGate::is_pro() );
+	}
+
+	public function test_filter_can_override_pro_status(): void {
+		Functions\when( 'get_option' )->justReturn( false );
+		Filters\expectApplied( 'wp_ai_mind_is_pro' )
+			->once()
+			->andReturn( true );
 		$this->assertTrue( ProGate::is_pro() );
 	}
 


### PR DESCRIPTION
## Summary

Addresses the three review comments left on PR #7.

- **ChatPage.php**: Replace `unset($e)` with a `// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch` inline comment on the catch line. This is more honest — `unset($e)` implied the exception was being handled, when it was only silencing a PHPCS violation. Matches the existing pattern in `ProGate.php`.
- **ProGate.php**: Extract the duplicated `'active' === \get_option( self::OPTION_KEY, '' )` expression into a private `is_licence_active()` helper, used in both the catch and else branches.
- **ProGateTest.php**: Add `test_filter_can_override_pro_status()` to cover the `wp_ai_mind_is_pro` filter override path (previously untested).

## Test plan

- [ ] `./vendor/bin/phpunit tests/Unit/Core/ProGateTest.php` — all 4 tests pass, including the new filter test
- [ ] `./vendor/bin/phpcs --standard=phpcs.xml.dist --warning-severity=0` — no new violations; `ChatPage.php` catch block now clean

https://claude.ai/code/session_01Qu5DFe7BhzA7eLVp5G61Ps