### PR TITLE
chore(ci): hybrid review — PR comment + linked issues for follow-ups

### DIFF
--- a/.claude/commands/brainstorming.md
+++ b/.claude/commands/brainstorming.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/brainstorming/SKILL.md

--- a/.claude/commands/bug-fix.md
+++ b/.claude/commands/bug-fix.md
@@ -1,0 +1,1 @@
+../../.agents/_core/workflows/bug-fix.md

--- a/.claude/commands/content-update.md
+++ b/.claude/commands/content-update.md
@@ -1,0 +1,1 @@
+../../.agents/profiles/wordpress/workflows/content-update.md

--- a/.claude/commands/dispatching-parallel-agents.md
+++ b/.claude/commands/dispatching-parallel-agents.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/dispatching-parallel-agents/SKILL.md

--- a/.claude/commands/emergency-rollback.md
+++ b/.claude/commands/emergency-rollback.md
@@ -1,0 +1,1 @@
+../../.agents/_core/workflows/emergency-rollback.md

--- a/.claude/commands/executing-plans.md
+++ b/.claude/commands/executing-plans.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/executing-plans/SKILL.md

--- a/.claude/commands/finishing-a-development-branch.md
+++ b/.claude/commands/finishing-a-development-branch.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/finishing-a-development-branch/SKILL.md

--- a/.claude/commands/new-feature.md
+++ b/.claude/commands/new-feature.md
@@ -1,0 +1,1 @@
+../../.agents/_core/workflows/new-feature.md

--- a/.claude/commands/plugin-development.md
+++ b/.claude/commands/plugin-development.md
@@ -1,0 +1,1 @@
+../../.agents/profiles/wordpress/workflows/plugin-development.md

--- a/.claude/commands/receiving-code-review.md
+++ b/.claude/commands/receiving-code-review.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/receiving-code-review/SKILL.md

--- a/.claude/commands/requesting-code-review.md
+++ b/.claude/commands/requesting-code-review.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/requesting-code-review/SKILL.md

--- a/.claude/commands/subagent-driven-development.md
+++ b/.claude/commands/subagent-driven-development.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/subagent-driven-development/SKILL.md

--- a/.claude/commands/superpowers.md
+++ b/.claude/commands/superpowers.md
@@ -1,0 +1,1 @@
+../../.agents/profiles/wordpress/workflows/superpowers.md

--- a/.claude/commands/systematic-debugging.md
+++ b/.claude/commands/systematic-debugging.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/systematic-debugging/SKILL.md

--- a/.claude/commands/test-driven-development.md
+++ b/.claude/commands/test-driven-development.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/test-driven-development/SKILL.md

--- a/.claude/commands/theme-modification.md
+++ b/.claude/commands/theme-modification.md
@@ -1,0 +1,1 @@
+../../.agents/profiles/wordpress/workflows/theme-modification.md

--- a/.claude/commands/using-git-worktrees.md
+++ b/.claude/commands/using-git-worktrees.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/using-git-worktrees/SKILL.md

--- a/.claude/commands/using-superpowers.md
+++ b/.claude/commands/using-superpowers.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/using-superpowers/SKILL.md

--- a/.claude/commands/verification-before-completion.md
+++ b/.claude/commands/verification-before-completion.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/verification-before-completion/SKILL.md

--- a/.claude/commands/writing-plans.md
+++ b/.claude/commands/writing-plans.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/writing-plans/SKILL.md

--- a/.claude/commands/writing-skills.md
+++ b/.claude/commands/writing-skills.md
@@ -1,0 +1,1 @@
+../../.agents/_core/skills/writing-skills/SKILL.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+.agents/profiles/wordpress/.cursorrules

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
       id-token: write
     
@@ -41,25 +41,44 @@ jobs:
             PR NUMBER: ${{ github.event.pull_request.number }}
             PR URL: ${{ github.event.pull_request.html_url }}
 
-            Please review this pull request and provide feedback on:
+            Review this pull request against the repository's CLAUDE.md conventions. Be constructive and helpful.
+
+            Cover:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
             - Security concerns
             - Test coverage
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            ### Step 1 — Create issues for follow-up items (do this FIRST to capture URLs)
 
-            Instead of commenting on the PR, create a GitHub Issue using:
+            For any finding that warrants independent follow-up (bug, non-trivial improvement,
+            security concern, missing test coverage), create a GitHub issue:
+
               gh issue create \
-                --title "Code Review: PR #${{ github.event.pull_request.number }} — <short summary of findings>" \
-                --body "@claude\n\n<your full review here>\n\n---\nPR: ${{ github.event.pull_request.html_url }}" \
+                --title "<concise title for the finding>" \
+                --body "Found during review of PR #${{ github.event.pull_request.number }}\n\n<details>\n\nPR: ${{ github.event.pull_request.html_url }}" \
                 --label "code-review" \
                 --repo ${{ github.repository }}
 
-            Include the PR link in the issue body so it remains traceable.
+            Capture the URL returned by each `gh issue create` call.
+            Cosmetic / style / minor nit findings do NOT need issues — include them only in the PR comment.
+
+            ### Step 2 — Post the review comment on the PR
+
+            Post a single comment on the PR:
+
+              gh pr comment ${{ github.event.pull_request.number }} \
+                --body "<your full review>" \
+                --repo ${{ github.repository }}
+
+            Structure the comment as:
+            1. **Summary** — 1–3 sentence overview of the PR
+            2. **Findings** — grouped by severity (bugs → improvements → nits). For any finding that
+               has an associated issue, include the issue URL inline, e.g. "See #42 for tracking."
+            3. **Verdict** — Approved / Needs changes / Needs discussion
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue create:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh issue create:*),Bash(gh issue list:*)"'
 

--- a/includes/Admin/TestKeyRestController.php
+++ b/includes/Admin/TestKeyRestController.php
@@ -1,0 +1,127 @@
+<?php
+declare( strict_types=1 );
+namespace WP_AI_Mind\Admin;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class TestKeyRestController {
+
+	public static function register_routes(): void {
+		register_rest_route(
+			'wp-ai-mind/v1',
+			'/test-key',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ self::class, 'handle' ],
+				'permission_callback' => [ self::class, 'check_permission' ],
+				'args'                => [
+					'provider' => [
+						'type'     => 'string',
+						'required' => true,
+						'enum'     => [ 'openai', 'claude', 'gemini' ],
+					],
+					'api_key'  => [
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Makes a minimal live API call to validate the given key.
+	 *
+	 * @param WP_REST_Request $request
+	 * @return WP_REST_Response|\WP_Error
+	 */
+	public static function handle( WP_REST_Request $request ): WP_REST_Response|\WP_Error {
+		$provider = $request->get_param( 'provider' );
+		$api_key  = $request->get_param( 'api_key' );
+
+		switch ( $provider ) {
+			case 'openai':
+				$result = wp_remote_get(
+					'https://api.openai.com/v1/models',
+					[
+						'headers' => [ 'Authorization' => 'Bearer ' . $api_key ],
+						'timeout' => 10,
+					]
+				);
+				break;
+
+			case 'claude':
+				$result = wp_remote_post(
+					'https://api.anthropic.com/v1/messages',
+					[
+						'headers' => [
+							'x-api-key'         => $api_key,
+							'anthropic-version' => '2023-06-01',
+							'Content-Type'      => 'application/json',
+						],
+						'body'    => wp_json_encode(
+							[
+								'model'      => 'claude-haiku-4-5-20251001',
+								'max_tokens' => 1,
+								'messages'   => [
+									[
+										'role'    => 'user',
+										'content' => 'hi',
+									],
+								],
+							]
+						),
+						'timeout' => 10,
+					]
+				);
+				break;
+
+			case 'gemini':
+				$result = wp_remote_get(
+					'https://generativelanguage.googleapis.com/v1beta/models?key=' . rawurlencode( $api_key ),
+					[ 'timeout' => 10 ]
+				);
+				break;
+
+			default:
+				return new \WP_Error( 'unsupported_provider', __( 'Unsupported provider.', 'wp-ai-mind' ), [ 'status' => 400 ] );
+		}
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_Error( 'request_failed', $result->get_error_message(), [ 'status' => 502 ] );
+		}
+
+		$code = wp_remote_retrieve_response_code( $result );
+		if ( 200 === $code ) {
+			return new WP_REST_Response( [ 'success' => true ], 200 );
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $result ), true );
+		$msg  = $body['error']['message']
+			?? $body['error']['code']
+			?? /* translators: generic API key error */ __( 'Invalid API key.', 'wp-ai-mind' );
+
+		return new \WP_Error( 'invalid_key', $msg, [ 'status' => 400 ] );
+	}
+
+	/**
+	 * @return bool|\WP_Error
+	 */
+	public static function check_permission(): bool|\WP_Error {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to manage plugin settings.', 'wp-ai-mind' ),
+				[ 'status' => 403 ]
+			);
+		}
+		return true;
+	}
+}


### PR DESCRIPTION
## Summary

Revises the Claude code review workflow to a hybrid approach:

- **Always** posts a review comment directly on the PR (primary feedback)
- **Conditionally** creates `code-review`-labelled issues for findings that warrant follow-up (bugs, non-trivial improvements, security), with issue URLs linked back in the PR comment

Supersedes the pure-issue approach from #10 (which lost inline PR context).

## Changes

- `pull-requests: read` → `pull-requests: write` (required to post PR comments)
- Two-phase prompt: Step 1 creates issues (to capture URLs), Step 2 posts the PR comment with those links inline
- `claude_args` now allows `gh pr comment` instead of the old issue-only toolset

## Test plan

- [ ] Merge this (and #10) to `main`
- [ ] Open a test PR
- [ ] Confirm `claude-code-review.yml` posts a comment on the PR
- [ ] Confirm follow-up findings appear as `code-review` issues with the PR linked
- [ ] Confirm issue URLs appear inline in the PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)