### PR TITLE
fix: address all code review issues from PR #11

### DIFF
--- a/includes/Admin/TestKeyRestController.php
+++ b/includes/Admin/TestKeyRestController.php
@@ -68,7 +68,7 @@ class TestKeyRestController {
 						],
 						'body'    => wp_json_encode(
 							[
-								'model'      => 'claude-haiku-4-5-20251001',
+								'model'      => apply_filters( 'wp_ai_mind_test_key_claude_model', 'claude-haiku-4-5-20251001' ),
 								'max_tokens' => 1,
 								'messages'   => [
 									[

--- a/includes/Modules/Seo/SeoModule.php
+++ b/includes/Modules/Seo/SeoModule.php
@@ -297,8 +297,11 @@ class SeoModule {
 		$yoast_desc     = \get_post_meta( $post_id, '_yoast_wpseo_metadesc', true );
 		$og_description = $yoast_desc ? $yoast_desc : \get_post_meta( $post_id, 'rank_math_description', true );
 
-		$post    = \get_post( $post_id );
-		$excerpt = $post->post_excerpt ?? '';
+		$post = \get_post( $post_id );
+		if ( ! $post instanceof \WP_Post ) {
+			return [];
+		}
+		$excerpt = $post->post_excerpt;
 
 		$thumb_id = \get_post_thumbnail_id( $post_id );
 		$alt_text = $thumb_id

--- a/src/images/ImagesWorkArea.jsx
+++ b/src/images/ImagesWorkArea.jsx
@@ -1,6 +1,7 @@
 import { useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { Loader2 } from 'lucide-react';
+import DOMPurify from 'dompurify';
 
 const { nonce, restUrl, adminUrl = '/wp-admin/' } = window.wpAiMindData ?? {};
 
@@ -59,12 +60,14 @@ export default function ImagesWorkArea( { post, onClose, onUpdate } ) {
 		setSetting( true );
 		setError( null );
 		try {
-			const endpoint =
-				post.type === 'page'
-					? `/wp/v2/pages/${ post.id }`
-					: `/wp/v2/posts/${ post.id }`;
+			const selfHref = post._links?.self?.[ 0 ]?.href;
+			if ( ! selfHref ) {
+				throw new Error(
+					`Cannot determine the REST endpoint for post type "${ post.type }".`
+				);
+			}
 			await apiFetch( {
-				path: endpoint,
+				url: selfHref,
 				method: 'POST',
 				data: { featured_media: selectedId },
 			} );
@@ -106,7 +109,9 @@ export default function ImagesWorkArea( { post, onClose, onUpdate } ) {
 			<div className="wpaim-work-header">
 				<span
 					className="wpaim-work-title"
-					dangerouslySetInnerHTML={ { __html: post.title.rendered } }
+					dangerouslySetInnerHTML={ {
+						__html: DOMPurify.sanitize( post.title.rendered ),
+					} }
 				/>
 			</div>
 

--- a/src/seo/SeoWorkArea.jsx
+++ b/src/seo/SeoWorkArea.jsx
@@ -1,6 +1,7 @@
 import { useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { Loader2 } from 'lucide-react';
+import DOMPurify from 'dompurify';
 
 const { nonce, restUrl, adminUrl = '/wp-admin/' } = window.wpAiMindData ?? {};
 
@@ -14,6 +15,7 @@ const EMPTY_FIELDS = {
 export default function SeoWorkArea( { post, onClose, onUpdate } ) {
 	const [ fields, setFields ] = useState( EMPTY_FIELDS );
 	const [ hasGenerated, setHasGenerated ] = useState( false );
+	const [ confirmReplace, setConfirmReplace ] = useState( false );
 	const [ generating, setGenerating ] = useState( false );
 	const [ applying, setApplying ] = useState( false );
 	const [ error, setError ] = useState( null );
@@ -24,12 +26,11 @@ export default function SeoWorkArea( { post, onClose, onUpdate } ) {
 		setFields( ( f ) => ( { ...f, [ key ]: e.target.value } ) );
 
 	const handleGenerate = async () => {
-		if (
-			hasGenerated &&
-			! window.confirm( 'Replace current suggestions?' ) // eslint-disable-line no-alert
-		) {
+		if ( hasGenerated && ! confirmReplace ) {
+			setConfirmReplace( true );
 			return;
 		}
+		setConfirmReplace( false );
 		setGenerating( true );
 		setError( null );
 		try {
@@ -91,7 +92,9 @@ export default function SeoWorkArea( { post, onClose, onUpdate } ) {
 			<div className="wpaim-work-header">
 				<span
 					className="wpaim-work-title"
-					dangerouslySetInnerHTML={ { __html: post.title.rendered } }
+					dangerouslySetInnerHTML={ {
+						__html: DOMPurify.sanitize( post.title.rendered ),
+					} }
 				/>
 				<button
 					className="button button-primary"
@@ -108,6 +111,24 @@ export default function SeoWorkArea( { post, onClose, onUpdate } ) {
 					) }
 				</button>
 			</div>
+
+			{ confirmReplace && (
+				<div className="wpaim-confirm-replace">
+					<span>Replace current suggestions?</span>
+					<button
+						className="button button-small"
+						onClick={ handleGenerate }
+					>
+						Yes, replace
+					</button>
+					<button
+						className="button button-small"
+						onClick={ () => setConfirmReplace( false ) }
+					>
+						Cancel
+					</button>
+				</div>
+			) }
 
 			<div className="wpaim-seo-fields-grid">
 				<div className="wpaim-field">

--- a/src/shared/PostListTable.jsx
+++ b/src/shared/PostListTable.jsx
@@ -28,8 +28,12 @@ export default function PostListTable( { tabs, WorkArea, columns = [] } ) {
 				};
 
 				const [ postsRes, pagesRes ] = await Promise.all( [
-					fetchEndpoint( '/wp/v2/posts?per_page=100&_embed=1&context=edit' ),
-					fetchEndpoint( '/wp/v2/pages?per_page=100&_embed=1&context=edit' ),
+					fetchEndpoint(
+						'/wp/v2/posts?per_page=100&_embed=1&context=edit'
+					),
+					fetchEndpoint(
+						'/wp/v2/pages?per_page=100&_embed=1&context=edit'
+					),
 				] );
 
 				const merged = [ ...postsRes.data, ...pagesRes.data ].sort(
@@ -37,7 +41,8 @@ export default function PostListTable( { tabs, WorkArea, columns = [] } ) {
 				);
 				setPosts( merged );
 
-				const totalFetched = postsRes.data.length + pagesRes.data.length;
+				const totalFetched =
+					postsRes.data.length + pagesRes.data.length;
 				const totalAvailable = postsRes.total + pagesRes.total;
 				if ( totalAvailable > totalFetched ) {
 					setTruncated( true );
@@ -97,8 +102,8 @@ export default function PostListTable( { tabs, WorkArea, columns = [] } ) {
 		<div className="wpaim-post-list">
 			{ truncated && (
 				<div className="wpaim-list-notice">
-					⚠ Showing the 100 most recent posts and pages. Your site has
-					more content that is not listed here.
+					⚠ Showing the 100 most recent posts and pages. Your site
+					has more content that is not listed here.
 				</div>
 			) }
 			<div className="wpaim-list-toolbar">

--- a/src/shared/PostListTable.jsx
+++ b/src/shared/PostListTable.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import DOMPurify from 'dompurify';
 
 const PER_PAGE = 20;
 
@@ -11,18 +12,36 @@ export default function PostListTable( { tabs, WorkArea, columns = [] } ) {
 	const [ search, setSearch ] = useState( '' );
 	const [ page, setPage ] = useState( 1 );
 	const [ expandedId, setExpandedId ] = useState( null );
+	const [ truncated, setTruncated ] = useState( false );
 
 	useEffect( () => {
 		const fetchAll = async () => {
 			try {
+				const fetchEndpoint = async ( path ) => {
+					const response = await apiFetch( { path, parse: false } );
+					const data = await response.json();
+					const total = parseInt(
+						response.headers.get( 'X-WP-Total' ) ?? '0',
+						10
+					);
+					return { data, total };
+				};
+
 				const [ postsRes, pagesRes ] = await Promise.all( [
-					apiFetch( { path: '/wp/v2/posts?per_page=100&_embed=1' } ),
-					apiFetch( { path: '/wp/v2/pages?per_page=100&_embed=1' } ),
+					fetchEndpoint( '/wp/v2/posts?per_page=100&_embed=1&context=edit' ),
+					fetchEndpoint( '/wp/v2/pages?per_page=100&_embed=1&context=edit' ),
 				] );
-				const merged = [ ...postsRes, ...pagesRes ].sort(
+
+				const merged = [ ...postsRes.data, ...pagesRes.data ].sort(
 					( a, b ) => new Date( b.modified ) - new Date( a.modified )
 				);
 				setPosts( merged );
+
+				const totalFetched = postsRes.data.length + pagesRes.data.length;
+				const totalAvailable = postsRes.total + pagesRes.total;
+				if ( totalAvailable > totalFetched ) {
+					setTruncated( true );
+				}
 			} catch ( e ) {
 				setError( e.message ?? 'Failed to load posts.' );
 			} finally {
@@ -76,6 +95,12 @@ export default function PostListTable( { tabs, WorkArea, columns = [] } ) {
 
 	return (
 		<div className="wpaim-post-list">
+			{ truncated && (
+				<div className="wpaim-list-notice">
+					⚠ Showing the 100 most recent posts and pages. Your site has
+					more content that is not listed here.
+				</div>
+			) }
 			<div className="wpaim-list-toolbar">
 				<div className="wpaim-list-tabs">
 					{ tabs.map( ( tab ) => (
@@ -193,7 +218,9 @@ function PostRow( {
 		<>
 			<tr className={ expanded ? 'is-expanded' : '' }>
 				<td
-					dangerouslySetInnerHTML={ { __html: post.title.rendered } }
+					dangerouslySetInnerHTML={ {
+						__html: DOMPurify.sanitize( post.title.rendered ),
+					} }
 				/>
 				<td>
 					<span className="wpaim-type-badge">{ post.type }</span>

--- a/tests/Unit/Modules/Seo/SeoStatusFieldTest.php
+++ b/tests/Unit/Modules/Seo/SeoStatusFieldTest.php
@@ -26,7 +26,7 @@ class SeoStatusFieldTest extends TestCase {
 		Functions\when( 'get_post_meta' )->justReturn( '' );
 		Functions\when( 'get_post_thumbnail_id' )->justReturn( 0 );
 
-		$post               = new \stdClass();
+		$post               = new \WP_Post();
 		$post->post_excerpt = '';
 		Functions\when( 'get_post' )->justReturn( $post );
 
@@ -49,7 +49,7 @@ class SeoStatusFieldTest extends TestCase {
 			->with( 42, 'rank_math_description', true )
 			->andReturn( '' );
 		Functions\when( 'get_post_thumbnail_id' )->justReturn( 0 );
-		$post               = new \stdClass();
+		$post               = new \WP_Post();
 		$post->post_excerpt = '';
 		Functions\when( 'get_post' )->justReturn( $post );
 
@@ -65,7 +65,7 @@ class SeoStatusFieldTest extends TestCase {
 				return '';
 			} );
 		Functions\when( 'get_post_thumbnail_id' )->justReturn( 0 );
-		$post               = new \stdClass();
+		$post               = new \WP_Post();
 		$post->post_excerpt = '';
 		Functions\when( 'get_post' )->justReturn( $post );
 
@@ -77,7 +77,7 @@ class SeoStatusFieldTest extends TestCase {
 	public function test_excerpt_detected_as_filled(): void {
 		Functions\when( 'get_post_meta' )->justReturn( '' );
 		Functions\when( 'get_post_thumbnail_id' )->justReturn( 0 );
-		$post               = new \stdClass();
+		$post               = new \WP_Post();
 		$post->post_excerpt = 'A nice summary.';
 		Functions\when( 'get_post' )->justReturn( $post );
 
@@ -93,7 +93,7 @@ class SeoStatusFieldTest extends TestCase {
 				return '';
 			} );
 		Functions\when( 'get_post_thumbnail_id' )->justReturn( 99 );
-		$post               = new \stdClass();
+		$post               = new \WP_Post();
 		$post->post_excerpt = '';
 		Functions\when( 'get_post' )->justReturn( $post );
 
@@ -105,7 +105,7 @@ class SeoStatusFieldTest extends TestCase {
 	public function test_alt_text_empty_when_no_featured_image(): void {
 		Functions\when( 'get_post_meta' )->justReturn( '' );
 		Functions\when( 'get_post_thumbnail_id' )->justReturn( 0 );
-		$post               = new \stdClass();
+		$post               = new \WP_Post();
 		$post->post_excerpt = '';
 		Functions\when( 'get_post' )->justReturn( $post );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,6 +33,15 @@ if ( ! class_exists( 'WP_Error' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WP_Post' ) ) {
+	class WP_Post {
+		public int    $ID           = 0;
+		public string $post_title   = '';
+		public string $post_content = '';
+		public string $post_excerpt = '';
+	}
+}
+
 if ( ! class_exists( 'WP_REST_Request' ) ) {
 	class WP_REST_Request {
 		private array $params     = [];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,13 +3,13 @@ declare( strict_types=1 );
 
 // Define constants required for Plugin class in test context.
 if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 }
 if ( ! defined( 'WP_AI_MIND_BASENAME' ) ) {
-    define( 'WP_AI_MIND_BASENAME', 'wp-ai-mind/wp-ai-mind.php' );
+	define( 'WP_AI_MIND_BASENAME', 'wp-ai-mind/wp-ai-mind.php' );
 }
 if ( ! defined( 'WP_AI_MIND_HTTP_TIMEOUT' ) ) {
-    define( 'WP_AI_MIND_HTTP_TIMEOUT', 60 );
+	define( 'WP_AI_MIND_HTTP_TIMEOUT', 60 );
 }
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
@@ -23,47 +23,47 @@ if ( ! defined( 'ARRAY_N' ) )  { define( 'ARRAY_N',  'ARRAY_N' ); }
 // WP stubs — Brain Monkey provides them when you call Monkey\setUp().
 
 if ( ! class_exists( 'WP_Error' ) ) {
-    class WP_Error {
-        public string $code;
-        public string $message;
-        public function __construct( string $code = '', string $message = '', $data = null ) {
-            $this->code    = $code;
-            $this->message = $message;
-        }
-    }
+	class WP_Error {
+		public string $code;
+		public string $message;
+		public function __construct( string $code = '', string $message = '', $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+	}
 }
 
 if ( ! class_exists( 'WP_REST_Request' ) ) {
-    class WP_REST_Request {
-        private array $params     = [];
-        private array $url_params = [];
-        public function __construct( string $method = 'GET', string $route = '' ) {}
-        public function get_param( string $key ) {
-            return $this->url_params[ $key ] ?? $this->params[ $key ] ?? null;
-        }
-        public function get_json_params(): array { return $this->params; }
-        public function get_params(): array { return array_merge( $this->params, $this->url_params ); }
-        public function set_body_params( array $params ): void { $this->params = array_merge( $this->params, $params ); }
-        public function set_url_params( array $params ): void { $this->url_params = array_merge( $this->url_params, $params ); }
-        public function set_param( string $key, mixed $value ): void { $this->params[ $key ] = $value; }
-    }
+	class WP_REST_Request {
+		private array $params     = [];
+		private array $url_params = [];
+		public function __construct( string $method = 'GET', string $route = '' ) {}
+		public function get_param( string $key ) {
+			return $this->url_params[ $key ] ?? $this->params[ $key ] ?? null;
+		}
+		public function get_json_params(): array { return $this->params; }
+		public function get_params(): array { return array_merge( $this->params, $this->url_params ); }
+		public function set_body_params( array $params ): void { $this->params = array_merge( $this->params, $params ); }
+		public function set_url_params( array $params ): void { $this->url_params = array_merge( $this->url_params, $params ); }
+		public function set_param( string $key, mixed $value ): void { $this->params[ $key ] = $value; }
+	}
 }
 
 if ( ! class_exists( 'WP_REST_Response' ) ) {
-    class WP_REST_Response {
-        public function __construct( public mixed $data = null, public int $status = 200 ) {}
-        public function get_status(): int { return $this->status; }
-    }
+	class WP_REST_Response {
+		public function __construct( public mixed $data = null, public int $status = 200 ) {}
+		public function get_status(): int { return $this->status; }
+	}
 }
 
 if ( ! class_exists( 'WP_REST_Server' ) ) {
-    class WP_REST_Server {
-        const READABLE  = 'GET';
-        const CREATABLE = 'POST';
-        const DELETABLE = 'DELETE';
-    }
+	class WP_REST_Server {
+		const READABLE  = 'GET';
+		const CREATABLE = 'POST';
+		const DELETABLE = 'DELETE';
+	}
 }
 
 if ( ! function_exists( 'rest_ensure_response' ) ) {
-    function rest_ensure_response( $data ) { return new \WP_REST_Response( $data ); }
+	function rest_ensure_response( $data ) { return new \WP_REST_Response( $data ); }
 }


### PR DESCRIPTION
Fixes all issues raised in the code review for PR #11 (issue #12):

- **XSS gap**: wrap `post.title.rendered` with `DOMPurify.sanitize()` in PostListTable, ImagesWorkArea, and SeoWorkArea
- **100-post limit**: read `X-WP-Total` header and show a notice banner when content is truncated
- **Null dereference**: guard `get_post()` with `instanceof WP_Post` in SeoModule::get_seo_status()
- **CPT endpoint**: use `post._links.self[0].href` for REST endpoint resolution
- **Hard-coded model**: wrap in `apply_filters()` for overridability
- **window.confirm**: replaced with inline confirmation UI
- **Indentation**: tabs throughout tests/bootstrap.php

Closes #12

Generated with [Claude Code](https://claude.ai/code)