### PR TITLE
chore: allow GitHub MCP label tools in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__github__add_labels_to_issue",
+      "mcp__github__remove_labels_from_issue",
+      "mcp__github__create_label",
+      "mcp__github__update_label",
+      "mcp__github__delete_label",
+      "mcp__github__list_labels"
+    ]
+  }
+}


### PR DESCRIPTION
Adds permissions for mcp__github__ label-related tools so Claude can
create, add, remove, and manage labels on issues without prompting.

https://claude.ai/code/session_01KGvik1XRRQLuTaxFX3rhNk