### PR TITLE
fix(workflows): grant workflows write permission to Claude Code action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,12 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
+      workflows: write # Required for Claude to create or update workflow files
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Adds `workflows: write` and bumps `contents`/`pull-requests`/`issues`
to `write` so the GitHub App token can create or update workflow files
when Claude pushes changes.

Resolves the blocker reported in issue #40:
  "refusing to allow a GitHub App to create or update workflow without
   workflows permission"

https://claude.ai/code/session_01Jtgsw8GqCzx73iqQtRB3dE