### PR TITLE
chore(ci): add stylelint config and suppress phpcs warning-level notices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           key: composer-${{ hashFiles('composer.lock') }}
           restore-keys: composer-
       - run: composer install --no-interaction --prefer-dist
-      - run: ./vendor/bin/phpcs --standard=phpcs.xml.dist
+      - run: ./vendor/bin/phpcs --standard=phpcs.xml.dist --warning-severity=0
 
   phpunit:
     name: PHPUnit

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,9 @@
+{
+	"extends": [ "@wordpress/stylelint-config" ],
+	"rules": {
+		"selector-class-pattern": [
+			"^[a-z][a-z0-9]*(-[a-z0-9]+)*(__[a-z][a-z0-9]*(-[a-z0-9]+)*)?(--[a-z][a-z0-9]*(-[a-z0-9]+)*)?$",
+			{ "message": "Expected BEM-style class name (e.g. block__element--modifier)" }
+		]
+	}
+}


### PR DESCRIPTION
- Add .stylelintrc.json with BEM-compatible class pattern rule
- Pass --warning-severity=0 to phpcs in CI to suppress warnings and only fail on errors

https://claude.ai/code/session_01N2vM9kjf1m2Dv22gdr575Z