### PR TITLE
fix(ui): migrate all plugin pages to WP admin light colour palette

### DIFF
--- a/docs/superpowers/specs/2026-03-27-seo-images-admin-pages-design.md
+++ b/docs/superpowers/specs/2026-03-27-seo-images-admin-pages-design.md
@@ -1,0 +1,285 @@
+# Design Spec: WP AI Mind — SEO & Images Admin Pages
+
+## Context
+
+Two Pro-gated admin pages are registered in the WordPress sidebar (`wp-ai-mind-seo`, `wp-ai-mind-images`) but currently render nothing — their PHP callbacks return `__return_false`. The REST endpoints and asset-loading PHP are already fully built. This spec defines the React UI for both pages.
+
+**Core user problem:**
+- Bloggers accumulate posts with incomplete SEO metadata and missing featured images.
+- These pages let them scan for gaps at a glance and fill them with AI in one click per post.
+
+Both pages share the same UX pattern: a list-first table showing gap status, with an inline work area that expands per row.
+
+---
+
+## Shared Architecture
+
+### New webpack entries (`webpack.config.js`)
+
+```js
+'seo/index':    path.resolve( __dirname, 'src/seo/index.js' ),
+'images/index': path.resolve( __dirname, 'src/images/index.js' ),
+```
+
+These match exactly what the PHP asset-loading hooks already expect (`assets/seo/index.js`, `assets/images/index.js`).
+
+### Shared component: `src/shared/PostListTable.jsx`
+
+Handles the list + inline expand pattern used by both pages. Responsibilities:
+- Fetch posts and pages via WP core REST API (`/wp/v2/posts` and `/wp/v2/pages`, merged and sorted by date)
+- Pagination (20 per page)
+- Search (client-side filter on title)
+- Tab filter (passed in as prop — each page defines its own tabs and filter logic)
+- Expand/collapse state: one row open at a time; clicking an open row collapses it
+- Renders a work area component (passed as prop) inside the expanded row
+
+Props:
+```js
+PostListTable({
+  tabs,            // [{ label, filter: (post) => bool }]
+  badgeRenderer,   // (post) => <Badge />
+  WorkArea,        // component rendered in expanded row, receives { post, onClose }
+  columns,         // extra column definitions beyond title/type/updated
+})
+```
+
+### Pro gate
+
+Both pages check `window.wpAiMindData.isPro`. Non-Pro users see a lock screen — the list is never rendered. The lock screen contains:
+- Lock icon
+- Feature title + one-sentence value description
+- "Upgrade to Pro →" CTA button
+
+### Design tokens
+
+Inherits `src/styles/tokens.css`. The plugin now uses the WP admin light palette — the dark zinc values have been removed. Key values in use:
+
+| Token | Value | Use |
+|---|---|---|
+| `--color-bg` | `#fff` | Page background |
+| `--color-surface` | `#f8f9fa` | Cards, work area |
+| `--color-surface-2` | `#f0f0f1` | Inputs, hover backgrounds |
+| `--color-border` | `#dcdcde` | Default borders |
+| `--color-text-primary` | `#1d2327` | Body text |
+| `--color-text-secondary` | `#50575e` | Labels, secondary text |
+| `--color-text-muted` | `#787c82` | Placeholders, muted text |
+| `--wp-admin-theme-color` | (WP native) | Accent — buttons, focus rings, highlights |
+
+Use `var(--wp-admin-theme-color)` for all interactive accent elements (primary buttons, selected states, focus borders). Do not hardcode `#3b82f6`.
+
+### Folder structure
+
+```
+src/
+  shared/
+    PostListTable.jsx       ← new
+    MarkdownContent.jsx     ← existing
+  seo/
+    index.js
+    SeoApp.jsx
+    SeoBadge.jsx
+    SeoWorkArea.jsx
+    seo.css
+  images/
+    index.js
+    ImagesApp.jsx
+    ImagesBadge.jsx
+    ImagesWorkArea.jsx
+    images.css
+```
+
+---
+
+## SEO Page (`wp-ai-mind-seo`)
+
+### Purpose
+
+Let editors scan all posts and pages for SEO gaps and fill them with AI-generated metadata — one post at a time, inline.
+
+### List view
+
+**Columns:** Title | Type (`post` / `page` badge) | SEO Status | Updated | Action button
+
+**SEO Status badge** (single aggregate):
+- `Complete` (green) — all four fields present: meta title, OG description, excerpt, featured image alt text
+- `Partial` (amber) — some fields present
+- `Missing` (red) — no fields present
+
+**PHP requirement:** The WP REST API does not expose Yoast/RankMath meta fields by default. The `SeoModule` (or a new `SeoStatusController`) must register a computed `wpaim_seo_status` field on posts and pages via `register_rest_field()`. This field returns an object:
+```json
+{
+  "meta_title":     "filled" | "empty",
+  "og_description": "filled" | "empty",
+  "excerpt":        "filled" | "empty",
+  "alt_text":       "filled" | "empty"
+}
+```
+The React badge derives `Complete` / `Partial` / `Missing` from this object client-side.
+
+Field "filled" logic in PHP:
+- `meta_title`: `filled` if `_yoast_wpseo_title` OR `rank_math_title` post meta is non-empty
+- `og_description`: `filled` if `_yoast_wpseo_metadesc` OR `rank_math_description` post meta is non-empty
+- `excerpt`: `filled` if `post_excerpt` is non-empty
+- `alt_text`: `filled` if the post has a featured image AND `_wp_attachment_image_alt` on that attachment is non-empty
+
+**Tabs:** All | Missing | Partial | Complete
+
+**Search:** Client-side filter on post title. Input in toolbar row alongside tabs.
+
+### Inline work area (expanded row)
+
+**Header:** Post title (truncated) + "✦ Generate SEO" button (right-aligned).
+
+**Fields grid** (2 columns):
+| Field | Notes |
+|---|---|
+| Meta title | Character count display (target: ≤ 60). Single line input. |
+| OG description | Character count display (target: ≤ 160). Single line input. |
+| Excerpt | Full width (spans both columns). Textarea. |
+| Alt text | Full width. Single line input. Label clarifies "featured image alt text". |
+
+After `POST /seo/generate` returns, the four fields populate and highlight (blue border) to signal AI-generated content. All fields are editable before applying.
+
+**Actions (right-aligned):**
+- "Edit post →" — opens Gutenberg in a new tab (`wp-admin/post.php?post={id}&action=edit`)
+- "Discard" — clears fields, collapses row
+- "✓ Apply all" — calls `POST /seo/apply` with the current field values; on success collapses the row and updates the badge
+
+**Loading state:** Generate button shows a spinner and "Generating…" label. Fields show a skeleton shimmer.
+
+**Error state:** Inline error message below the fields. Generate button re-enabled.
+
+### Generate button behaviour
+
+- If the work area has no unsaved AI output: clicking Generate calls the API immediately.
+- If the work area already has AI output (user clicked Generate twice): show a confirm prompt — "Replace current suggestions?"
+
+### Non-Pro state
+
+Lock screen with:
+- Lock icon
+- Title: "AI SEO requires WP AI Mind Pro"
+- Body: "Automatically generate meta titles, OG descriptions, excerpts, and image alt text for every post — in one click."
+- CTA: "Upgrade to Pro →"
+
+---
+
+## Images Page (`wp-ai-mind-images`)
+
+### Purpose
+
+Let editors identify posts and pages without a featured image and generate one with AI — directly setting it on the post without leaving this page.
+
+### List view
+
+**Columns:** Title | Type | Featured Image | Updated | Action button
+
+**Featured Image column:**
+- If post has a featured image: show a 36×36px thumbnail + `Has image` (green) badge
+- If no featured image: `No image` (red) badge
+
+**Tabs:** All | No image | Has image
+
+**Search:** Client-side filter on post title.
+
+**Data source:** `featured_media` field is part of the standard WP REST API post response. No custom PHP needed for the badge. To get the thumbnail URL inline, fetch posts with `?_embed` — the `_embedded['wp:featuredmedia'][0].media_details.sizes.thumbnail.source_url` path provides the URL without a second request.
+
+### Inline work area (expanded row)
+
+**Layout:** Prompt textarea (left, ~70% width) + controls column (right, ~30% width).
+
+**Prompt textarea:**
+- Placeholder: "Describe the image you want to generate…"
+- Free-form text. No AI assistance on the prompt itself.
+
+**Controls column (stacked vertically):**
+1. **Aspect ratio** — select dropdown: `16:9` (default), `1:1`, `4:3`, `9:16`
+2. **Count** — pill toggle: `1` | `2` | `3` (default: `2`)
+3. **✦ Generate** — primary blue button
+
+**Results grid:**
+- Generated images appear as cards in a 3-column grid (or fewer if count < 3)
+- Each card: image thumbnail (correct aspect ratio) + footer with dimensions + "View →" link (media library attachment page, new tab)
+- Click a card to select it (blue border + "✓ Selected" badge)
+- Only one image selectable at a time
+
+**Actions (right-aligned):**
+- "Edit post →" — opens Gutenberg in new tab
+- "Discard" — clears results, collapses row
+- "✓ Set as featured image" — enabled only when an image is selected; calls `PATCH /wp/v2/posts/{id}` (or `/wp/v2/pages/{id}`) with `{ featured_media: attachment_id }`; on success collapses the row and updates the badge + thumbnail in the list
+
+**Loading state:** Generate button shows spinner. Result grid area shows 2–3 placeholder shimmer cards.
+
+**Error state:** Inline error message below the prompt. Generate button re-enabled.
+
+**Partial success (HTTP 207):** If some images failed but at least one succeeded, show the successful ones plus a dismissible warning: "1 of 2 images failed to generate."
+
+### Non-Pro state
+
+Lock screen with:
+- Lock icon
+- Title: "AI image generation requires WP AI Mind Pro"
+- Body: "Generate beautiful featured images from a text prompt and set them directly on any post or page."
+- CTA: "Upgrade to Pro →"
+
+---
+
+## What Is Explicitly Out of Scope
+
+- Bulk generation (selecting multiple posts and generating for all at once)
+- Prompt history or previously generated image gallery
+- nj-seo-essentials integration or upsell
+- Custom post types beyond `post` and `page`
+- Role-based access beyond the existing `edit_posts` capability check
+
+---
+
+## Files to Create / Modify
+
+| File | Action |
+|---|---|
+| `webpack.config.js` | Add `seo/index` and `images/index` entries |
+| `src/shared/PostListTable.jsx` | New — shared list + inline expand component |
+| `src/seo/index.js` | New — entry point, mounts `SeoApp` |
+| `src/seo/SeoApp.jsx` | New — Pro gate + `PostListTable` wiring |
+| `src/seo/SeoBadge.jsx` | New — Complete/Partial/Missing badge |
+| `src/seo/SeoWorkArea.jsx` | New — generate/edit/apply work area |
+| `src/seo/seo.css` | New — page-scoped styles |
+| `src/images/index.js` | New — entry point, mounts `ImagesApp` |
+| `src/images/ImagesApp.jsx` | New — Pro gate + `PostListTable` wiring |
+| `src/images/ImagesBadge.jsx` | New — Has image/No image badge + thumbnail |
+| `src/images/ImagesWorkArea.jsx` | New — prompt/controls/grid/set work area |
+| `src/images/images.css` | New — page-scoped styles |
+| `includes/Modules/Seo/SeoModule.php` | Add `register_rest_field()` for `wpaim_seo_status` on posts and pages |
+
+---
+
+## Verification
+
+1. **SEO page — Pro:**
+   - Navigate to WP AI Mind → SEO. List of posts and pages loads with correct badges.
+   - "Missing" tab filters to only posts with no SEO fields.
+   - Search filters by title.
+   - Click "Generate ▼" on a post → work area expands, other rows stay closed.
+   - "✦ Generate SEO" → spinner appears, fields populate with highlighted AI content.
+   - Edit a field → change persists in the input.
+   - "✓ Apply all" → row collapses, badge updates to Complete (or Partial if some fields were blank).
+   - "Discard" → row collapses, no changes saved.
+   - "Edit post →" opens Gutenberg in a new tab.
+   - Pagination: navigate to page 2 and back.
+
+2. **SEO page — non-Pro:**
+   - Lock screen renders. List is not rendered. "Upgrade to Pro →" button present.
+
+3. **Images page — Pro:**
+   - Navigate to WP AI Mind → Images. List loads with Has image / No image badges. Posts with featured images show thumbnails.
+   - "No image" tab filters correctly.
+   - Click "Generate ▼" → work area expands.
+   - Enter prompt, select aspect ratio and count, click "✦ Generate" → spinner, then image grid appears.
+   - Click an image → selected state (blue border).
+   - "✓ Set as featured image" → row collapses, table cell updates to show new thumbnail + Has image badge.
+   - "View →" on image card opens media library in new tab.
+   - HTTP 207 partial success: warning banner shown, successful images displayed.
+
+4. **Images page — non-Pro:**
+   - Lock screen renders. List is not rendered.

--- a/src/admin/admin.css
+++ b/src/admin/admin.css
@@ -65,6 +65,7 @@
 
 .wpaim-conv-item:hover,
 .wpaim-conv-item.is-active {
+	background: #f0f0f1;
 	background: color-mix(in srgb, var(--wp-admin-theme-color) 8%, #fff);
 }
 
@@ -124,7 +125,9 @@
 }
 
 .wpaim-bubble--error .wpaim-bubble__content {
+	background: #fde8e8;
 	background: color-mix(in srgb, #cc1818 8%, #fff);
+	border-color: #efb8b8;
 	border-color: color-mix(in srgb, #cc1818 30%, #fff);
 	color: var(--wp-components-color-error, #cc1818);
 }
@@ -687,6 +690,7 @@
 	align-items: center;
 	gap: 3px;
 	padding: 2px var(--space-2);
+	background: #f0f0f1;
 	background: color-mix(in srgb, var(--wp-admin-theme-color) 8%, #fff);
 	border: 1px solid rgba(0, 0, 0, 0.1);
 	border-radius: var(--radius-sm);

--- a/src/admin/admin.css
+++ b/src/admin/admin.css
@@ -698,6 +698,60 @@
 }
 
 
+/* ── Toggle switch ── */
+.wpaim-toggle {
+	display: inline-flex;
+	align-items: center;
+	cursor: pointer;
+}
+
+.wpaim-toggle--disabled {
+	cursor: not-allowed;
+}
+
+.wpaim-toggle__input {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	opacity: 0;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+}
+
+.wpaim-toggle__track {
+	display: block;
+	width: 36px;
+	height: 20px;
+	background: var(--color-surface-2);
+	border: 1px solid var(--color-border);
+	border-radius: 999px;
+	position: relative;
+	transition: background 0.15s, border-color 0.15s;
+}
+
+.wpaim-toggle__track::after {
+	content: "";
+	position: absolute;
+	top: 2px;
+	left: 2px;
+	width: 14px;
+	height: 14px;
+	background: var(--color-text-muted);
+	border-radius: 50%;
+	transition: transform 0.15s, background 0.15s;
+}
+
+.wpaim-toggle__input:checked + .wpaim-toggle__track {
+	background: var(--wp-admin-theme-color);
+	border-color: var(--wp-admin-theme-color);
+}
+
+.wpaim-toggle__input:checked + .wpaim-toggle__track::after {
+	background: #fff;
+	transform: translateX(16px);
+}
+
 /* ── "Run setup again" section ── */
 .wpaim-settings-label {
 	font-size: 0.6875rem;

--- a/src/admin/admin.css
+++ b/src/admin/admin.css
@@ -5,8 +5,8 @@
 	display: grid;
 	grid-template-columns: 220px 1fr 240px;
 	height: calc(100vh - 32px);
-	background: #fff;
-	color: #1d2327;
+	background: var(--color-bg);
+	color: var(--color-text-primary);
 	font-family: var(--font-sans);
 	font-size: var(--text-base);
 	overflow: hidden;
@@ -14,8 +14,8 @@
 
 /* ── Sidebar ── */
 .wpaim-sidebar {
-	background: #f0f0f1;
-	border-right: 1px solid #dcdcde;
+	background: var(--color-surface-2);
+	border-right: 1px solid var(--color-border);
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
@@ -26,7 +26,7 @@
 	align-items: center;
 	justify-content: space-between;
 	padding: var(--space-4) var(--space-4) var(--space-3);
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--color-border);
 }
 
 .wpaim-sidebar__title {
@@ -118,8 +118,8 @@
 }
 
 .wpaim-bubble--ai .wpaim-bubble__content {
-	background: #f0f0f1;
-	border: 1px solid #e0e1e6;
+	background: var(--color-surface-2);
+	border: 1px solid var(--color-border-subtle);
 	border-top-left-radius: var(--radius-sm);
 }
 
@@ -150,8 +150,8 @@
 	flex-direction: column;
 	gap: 0;
 	padding: var(--space-4) var(--space-6);
-	border-top: 1px solid #dcdcde;
-	background: #fff;
+	border-top: 1px solid var(--color-border);
+	background: var(--color-bg);
 	position: relative;
 }
 
@@ -163,11 +163,11 @@
 
 .wpaim-composer__input {
 	flex: 1;
-	background: #fff;
-	border: 1px solid #dcdcde;
+	background: var(--color-bg);
+	border: 1px solid var(--color-border);
 	border-radius: var(--radius);
 	padding: var(--space-2) var(--space-3);
-	color: #1d2327;
+	color: var(--color-text-primary);
 	font-family: var(--font-sans);
 	font-size: var(--text-base);
 	resize: none;
@@ -231,8 +231,8 @@
 	bottom: calc(100% + var(--space-2));
 	left: var(--space-6);
 	right: var(--space-6);
-	background: #f8f9fa;
-	border: 1px solid #dcdcde;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border);
 	border-radius: var(--radius-md);
 	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 	z-index: 100;
@@ -244,7 +244,7 @@
 	align-items: center;
 	gap: var(--space-2);
 	padding: var(--space-2) var(--space-3);
-	border-bottom: 1px solid #e0e1e6;
+	border-bottom: 1px solid var(--color-border-subtle);
 }
 
 .wpaim-context-picker__icon {
@@ -257,7 +257,7 @@
 	background: none;
 	border: none;
 	outline: none;
-	color: #1d2327;
+	color: var(--color-text-primary);
 	font-size: var(--text-base);
 	font-family: var(--font-sans);
 }
@@ -302,7 +302,7 @@
 }
 
 .wpaim-context-picker__item:hover {
-	background: #f0f0f1;
+	background: var(--color-surface-2);
 }
 
 .wpaim-context-picker__title {
@@ -316,8 +316,8 @@
 	flex-shrink: 0;
 	font-size: var(--text-xs);
 	color: var(--color-text-muted);
-	background: #f0f0f1;
-	border: 1px solid #e0e1e6;
+	background: var(--color-surface-2);
+	border: 1px solid var(--color-border-subtle);
 	border-radius: var(--radius-sm);
 	padding: 1px var(--space-1);
 }
@@ -366,8 +366,8 @@
 
 /* ── Right panel ── */
 .wpaim-right-panel {
-	background: #f8f9fa;
-	border-left: 1px solid #dcdcde;
+	background: var(--color-surface);
+	border-left: 1px solid var(--color-border);
 	overflow-y: auto;
 	padding: var(--space-4);
 	display: flex;
@@ -425,9 +425,9 @@
 }
 
 .wpaim-quick-action:hover {
-	background: #f0f0f1;
-	border-color: #dcdcde;
-	color: #1d2327;
+	background: var(--color-surface-2);
+	border-color: var(--color-border);
+	color: var(--color-text-primary);
 }
 
 .wpaim-pro-teaser {
@@ -463,10 +463,10 @@
 /* ── Select ── */
 .wpaim-select {
 	width: 100%;
-	background: #fff;
-	border: 1px solid #dcdcde;
+	background: var(--color-bg);
+	border: 1px solid var(--color-border);
 	border-radius: var(--radius-sm);
-	color: #1d2327;
+	color: var(--color-text-primary);
 	font-size: var(--text-sm);
 	padding: 0 var(--space-2);
 	height: 30px;
@@ -544,8 +544,8 @@
 	align-items: center;
 	justify-content: space-between;
 	padding: var(--space-4) var(--space-6);
-	border-bottom: 1px solid #e0e1e6;
-	background: #f8f9fa;
+	border-bottom: 1px solid var(--color-border-subtle);
+	background: var(--color-surface);
 }
 
 .wpaim-settings-title {
@@ -634,8 +634,8 @@
 	flex-direction: column;
 	gap: var(--space-2);
 	padding: var(--space-4);
-	background: #f8f9fa;
-	border: 1px solid #e0e1e6;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border-subtle);
 	border-radius: var(--radius-md);
 	transition: border-color 0.1s;
 }
@@ -748,7 +748,7 @@
 }
 
 .wpaim-toggle__input:checked + .wpaim-toggle__track::after {
-	background: #fff;
+	background: var(--color-bg);
 	transform: translateX(16px);
 }
 
@@ -756,7 +756,7 @@
 .wpaim-settings-label {
 	font-size: 0.6875rem;
 	font-weight: 600;
-	color: #50575e;
+	color: var(--color-text-secondary);
 	text-transform: uppercase;
 	letter-spacing: 0.06em;
 	margin-bottom: var(--space-1);
@@ -776,15 +776,15 @@
 	border-radius: var(--radius-sm);
 	cursor: pointer;
 	font-family: inherit;
-	border: 1px solid #dcdcde;
-	background: #f8f9fa;
-	color: #50575e;
+	border: 1px solid var(--color-border);
+	background: var(--color-surface);
+	color: var(--color-text-secondary);
 	transition: border-color 0.12s, color 0.12s;
 }
 
 .wpaim-btn--secondary:hover {
 	border-color: #8c8f94;
-	color: #1d2327;
+	color: var(--color-text-primary);
 }
 
 /* ════════════════════════════════════════════════
@@ -804,7 +804,7 @@
 
 /* QuickActions — WP admin colour overrides for tertiary Button */
 .wpaim-quick-action.components-button {
-	color: #50575e;
+	color: var(--color-text-secondary);
 	height: auto;
 	padding: var(--space-2) var(--space-3);
 	width: 100%;
@@ -812,8 +812,8 @@
 }
 
 .wpaim-quick-action.components-button:hover:not(:disabled) {
-	color: #1d2327;
-	background: #f0f0f1;
-	border-color: #dcdcde;
+	color: var(--color-text-primary);
+	background: var(--color-surface-2);
+	border-color: var(--color-border);
 }
 

--- a/src/admin/admin.css
+++ b/src/admin/admin.css
@@ -5,8 +5,8 @@
 	display: grid;
 	grid-template-columns: 220px 1fr 240px;
 	height: calc(100vh - 32px);
-	background: var(--color-bg);
-	color: var(--color-text-primary);
+	background: #fff;
+	color: #1d2327;
 	font-family: var(--font-sans);
 	font-size: var(--text-base);
 	overflow: hidden;
@@ -14,8 +14,8 @@
 
 /* ── Sidebar ── */
 .wpaim-sidebar {
-	background: var(--color-surface);
-	border-right: 1px solid var(--color-border-subtle);
+	background: #f0f0f1;
+	border-right: 1px solid #dcdcde;
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
@@ -26,7 +26,7 @@
 	align-items: center;
 	justify-content: space-between;
 	padding: var(--space-4) var(--space-4) var(--space-3);
-	border-bottom: 1px solid var(--color-border-subtle);
+	border-bottom: 1px solid #dcdcde;
 }
 
 .wpaim-sidebar__title {
@@ -65,7 +65,7 @@
 
 .wpaim-conv-item:hover,
 .wpaim-conv-item.is-active {
-	background: var(--color-surface-2);
+	background: color-mix(in srgb, var(--wp-admin-theme-color) 8%, #fff);
 }
 
 .wpaim-conv-item__title {
@@ -118,15 +118,15 @@
 }
 
 .wpaim-bubble--ai .wpaim-bubble__content {
-	background: var(--color-surface-2);
-	border: 1px solid var(--color-border-subtle);
+	background: #f0f0f1;
+	border: 1px solid #e0e1e6;
 	border-top-left-radius: var(--radius-sm);
 }
 
 .wpaim-bubble--error .wpaim-bubble__content {
-	background: #fff5f5;
-	border-color: #f5c6cb;
-	color: #842029;
+	background: color-mix(in srgb, #cc1818 8%, #fff);
+	border-color: color-mix(in srgb, #cc1818 30%, #fff);
+	color: var(--wp-components-color-error, #cc1818);
 }
 
 .wpaim-bubble--user .wpaim-bubble__content {
@@ -150,8 +150,8 @@
 	flex-direction: column;
 	gap: 0;
 	padding: var(--space-4) var(--space-6);
-	border-top: 1px solid var(--color-border-subtle);
-	background: var(--color-surface);
+	border-top: 1px solid #dcdcde;
+	background: #fff;
 	position: relative;
 }
 
@@ -163,11 +163,11 @@
 
 .wpaim-composer__input {
 	flex: 1;
-	background: var(--color-surface-2);
-	border: 1px solid var(--color-border);
+	background: #fff;
+	border: 1px solid #dcdcde;
 	border-radius: var(--radius);
 	padding: var(--space-2) var(--space-3);
-	color: var(--color-text-primary);
+	color: #1d2327;
 	font-family: var(--font-sans);
 	font-size: var(--text-base);
 	resize: none;
@@ -179,6 +179,11 @@
 .wpaim-composer__input:focus {
 	outline: none;
 	border-color: var(--wp-admin-theme-color);
+}
+
+.wpaim-composer__input:focus-visible {
+	outline: 2px solid var(--wp-admin-theme-color);
+	outline-offset: 2px;
 }
 
 .wpaim-composer__input::placeholder {
@@ -226,10 +231,10 @@
 	bottom: calc(100% + var(--space-2));
 	left: var(--space-6);
 	right: var(--space-6);
-	background: var(--color-surface-2);
-	border: 1px solid var(--color-border);
+	background: #f8f9fa;
+	border: 1px solid #dcdcde;
 	border-radius: var(--radius-md);
-	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 	z-index: 100;
 	overflow: hidden;
 }
@@ -239,7 +244,7 @@
 	align-items: center;
 	gap: var(--space-2);
 	padding: var(--space-2) var(--space-3);
-	border-bottom: 1px solid var(--color-border-subtle);
+	border-bottom: 1px solid #e0e1e6;
 }
 
 .wpaim-context-picker__icon {
@@ -252,9 +257,14 @@
 	background: none;
 	border: none;
 	outline: none;
-	color: var(--color-text-primary);
+	color: #1d2327;
 	font-size: var(--text-base);
 	font-family: var(--font-sans);
+}
+
+.wpaim-context-picker__input:focus-visible {
+	outline: 2px solid var(--wp-admin-theme-color);
+	outline-offset: 2px;
 }
 
 .wpaim-context-picker__input::placeholder {
@@ -292,7 +302,7 @@
 }
 
 .wpaim-context-picker__item:hover {
-	background: var(--color-surface);
+	background: #f0f0f1;
 }
 
 .wpaim-context-picker__title {
@@ -306,8 +316,8 @@
 	flex-shrink: 0;
 	font-size: var(--text-xs);
 	color: var(--color-text-muted);
-	background: var(--color-surface);
-	border: 1px solid var(--color-border-subtle);
+	background: #f0f0f1;
+	border: 1px solid #e0e1e6;
 	border-radius: var(--radius-sm);
 	padding: 1px var(--space-1);
 }
@@ -356,8 +366,8 @@
 
 /* ── Right panel ── */
 .wpaim-right-panel {
-	background: var(--color-surface);
-	border-left: 1px solid var(--color-border-subtle);
+	background: #f8f9fa;
+	border-left: 1px solid #dcdcde;
 	overflow-y: auto;
 	padding: var(--space-4);
 	display: flex;
@@ -415,9 +425,9 @@
 }
 
 .wpaim-quick-action:hover {
-	background: var(--color-surface-2);
-	border-color: var(--color-border);
-	color: var(--color-text-primary);
+	background: #f0f0f1;
+	border-color: #dcdcde;
+	color: #1d2327;
 }
 
 .wpaim-pro-teaser {
@@ -453,10 +463,10 @@
 /* ── Select ── */
 .wpaim-select {
 	width: 100%;
-	background: var(--color-surface-2);
-	border: 1px solid var(--color-border);
+	background: #fff;
+	border: 1px solid #dcdcde;
 	border-radius: var(--radius-sm);
-	color: var(--color-text-primary);
+	color: #1d2327;
 	font-size: var(--text-sm);
 	padding: 0 var(--space-2);
 	height: 30px;
@@ -465,6 +475,11 @@
 .wpaim-select:focus {
 	outline: none;
 	border-color: var(--wp-admin-theme-color);
+}
+
+.wpaim-select:focus-visible {
+	outline: 2px solid var(--wp-admin-theme-color);
+	outline-offset: 2px;
 }
 
 .wpaim-select--sm {
@@ -529,8 +544,8 @@
 	align-items: center;
 	justify-content: space-between;
 	padding: var(--space-4) var(--space-6);
-	border-bottom: 1px solid var(--color-border-subtle);
-	background: var(--color-surface);
+	border-bottom: 1px solid #e0e1e6;
+	background: #f8f9fa;
 }
 
 .wpaim-settings-title {
@@ -619,8 +634,8 @@
 	flex-direction: column;
 	gap: var(--space-2);
 	padding: var(--space-4);
-	background: var(--color-surface);
-	border: 1px solid var(--color-border-subtle);
+	background: #f8f9fa;
+	border: 1px solid #e0e1e6;
 	border-radius: var(--radius-md);
 	transition: border-color 0.1s;
 }
@@ -672,8 +687,8 @@
 	align-items: center;
 	gap: 3px;
 	padding: 2px var(--space-2);
-	background: var(--color-surface-2);
-	border: 1px solid var(--color-border);
+	background: color-mix(in srgb, var(--wp-admin-theme-color) 8%, #fff);
+	border: 1px solid rgba(0, 0, 0, 0.1);
 	border-radius: var(--radius-sm);
 	font-size: var(--text-xs);
 	font-weight: 600;
@@ -682,65 +697,12 @@
 	letter-spacing: 0.04em;
 }
 
-/* Toggle switch */
-.wpaim-toggle {
-	display: inline-flex;
-	align-items: center;
-	cursor: pointer;
-}
-
-.wpaim-toggle--disabled {
-	cursor: not-allowed;
-}
-
-.wpaim-toggle__input {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	opacity: 0;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	white-space: nowrap;
-}
-
-.wpaim-toggle__track {
-	display: block;
-	width: 36px;
-	height: 20px;
-	background: var(--color-surface-2);
-	border: 1px solid var(--color-border);
-	border-radius: 999px;
-	position: relative;
-	transition: background 0.15s, border-color 0.15s;
-}
-
-.wpaim-toggle__track::after {
-	content: "";
-	position: absolute;
-	top: 2px;
-	left: 2px;
-	width: 14px;
-	height: 14px;
-	background: var(--color-text-muted);
-	border-radius: 50%;
-	transition: transform 0.15s, background 0.15s;
-}
-
-.wpaim-toggle__input:checked + .wpaim-toggle__track {
-	background: var(--wp-admin-theme-color);
-	border-color: var(--wp-admin-theme-color);
-}
-
-.wpaim-toggle__input:checked + .wpaim-toggle__track::after {
-	background: #fff;
-	transform: translateX(16px);
-}
 
 /* ── "Run setup again" section ── */
 .wpaim-settings-label {
 	font-size: 0.6875rem;
 	font-weight: 600;
-	color: var(--color-text-secondary);
+	color: #50575e;
 	text-transform: uppercase;
 	letter-spacing: 0.06em;
 	margin-bottom: var(--space-1);
@@ -760,15 +722,15 @@
 	border-radius: var(--radius-sm);
 	cursor: pointer;
 	font-family: inherit;
-	border: 1px solid var(--color-border);
-	background: var(--color-surface);
-	color: var(--color-text-secondary);
+	border: 1px solid #dcdcde;
+	background: #f8f9fa;
+	color: #50575e;
 	transition: border-color 0.12s, color 0.12s;
 }
 
 .wpaim-btn--secondary:hover {
-	border-color: var(--color-border-hi, var(--color-border));
-	color: var(--color-text-primary);
+	border-color: #8c8f94;
+	color: #1d2327;
 }
 
 /* ════════════════════════════════════════════════
@@ -786,9 +748,9 @@
 	margin-bottom: 0;
 }
 
-/* QuickActions — dark theme preservation for tertiary Button */
+/* QuickActions — WP admin colour overrides for tertiary Button */
 .wpaim-quick-action.components-button {
-	color: var(--color-text-secondary);
+	color: #50575e;
 	height: auto;
 	padding: var(--space-2) var(--space-3);
 	width: 100%;
@@ -796,8 +758,8 @@
 }
 
 .wpaim-quick-action.components-button:hover:not(:disabled) {
-	color: var(--color-text-primary);
-	background: var(--color-surface-2);
-	border-color: var(--color-border);
+	color: #1d2327;
+	background: #f0f0f1;
+	border-color: #dcdcde;
 }
 

--- a/src/admin/dashboard/dashboard.css
+++ b/src/admin/dashboard/dashboard.css
@@ -4,8 +4,8 @@
 	display: flex;
 	flex-direction: column;
 	min-height: 100vh;
-	background: #fff;
-	color: #1d2327;
+	background: var(--color-bg);
+	color: var(--color-text-primary);
 	font-family: var(--font-sans, -apple-system, sans-serif);
 	-webkit-font-smoothing: antialiased;
 }
@@ -16,7 +16,7 @@
 	align-items: center;
 	justify-content: space-between;
 	padding: var(--space-4) var(--space-6) var(--space-3);
-	border-bottom: 1px solid #e0e1e6;
+	border-bottom: 1px solid var(--color-border-subtle);
 	flex-shrink: 0;
 }
 
@@ -38,9 +38,9 @@
 	font-size: 0.625rem;
 	padding: 3px 8px;
 	border-radius: var(--radius-sm);
-	background: #f8f9fa;
-	border: 1px solid #dcdcde;
-	color: #787c82;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border);
+	color: var(--color-text-muted);
 }
 
 /* ── Status banner ──────────────────────────────────────────────────────────── */
@@ -133,8 +133,8 @@
 }
 
 .wpaim-dash-tile {
-	background: #f8f9fa;
-	border: 1px solid #e0e1e6;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border-subtle);
 	border-radius: var(--radius);
 	padding: var(--space-4) var(--space-4) var(--space-7);
 	cursor: pointer;
@@ -156,8 +156,8 @@
 }
 
 .wpaim-dash-tile:hover {
-	border-color: #dcdcde;
-	background: #f0f0f1;
+	border-color: var(--color-border);
+	background: var(--color-surface-2);
 	transform: translateY(-1px);
 	text-decoration: none;
 }
@@ -204,8 +204,8 @@
 /* ── Resource list ──────────────────────────────────────────────────────────── */
 
 .wpaim-dash-resources {
-	background: #f8f9fa;
-	border: 1px solid #e0e1e6;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border-subtle);
 	border-radius: var(--radius);
 	overflow: hidden;
 }
@@ -214,7 +214,7 @@
 	display: flex;
 	align-items: center;
 	padding: var(--space-3) var(--space-3);
-	border-bottom: 1px solid #e0e1e6;
+	border-bottom: 1px solid var(--color-border-subtle);
 	text-decoration: none;
 	transition: background 0.1s;
 	gap: var(--space-3);
@@ -225,7 +225,7 @@
 }
 
 .wpaim-dash-resource:hover {
-	background: #f0f0f1;
+	background: var(--color-surface-2);
 	text-decoration: none;
 }
 
@@ -265,7 +265,7 @@
 	display: flex;
 	align-items: center;
 	gap: var(--space-3);
-	border-top: 1px solid #e0e1e6;
+	border-top: 1px solid var(--color-border-subtle);
 }
 
 .wpaim-dash-footer__link {
@@ -301,9 +301,9 @@
 	border-radius: var(--radius-sm);
 	cursor: pointer;
 	font-family: inherit;
-	border: 1px solid #dcdcde;
-	background: #f8f9fa;
-	color: #50575e;
+	border: 1px solid var(--color-border);
+	background: var(--color-surface);
+	color: var(--color-text-secondary);
 	text-decoration: none;
 	white-space: nowrap;
 	transition: border-color 0.12s, color 0.12s;
@@ -346,9 +346,9 @@
 .wpaim-ob-test-btn {
 	font-size: 0.6875rem;
 	padding: var(--space-2) var(--space-3);
-	background: #f0f0f1;
-	color: #50575e;
-	border: 1px solid #e0e1e6;
+	background: var(--color-surface-2);
+	color: var(--color-text-secondary);
+	border: 1px solid var(--color-border-subtle);
 	border-radius: var(--radius-sm);
 	cursor: pointer;
 	white-space: nowrap;
@@ -382,7 +382,7 @@
 
 .wpaim-ob-header {
 	padding: var(--space-4) var(--space-5) var(--space-3);
-	border-bottom: 1px solid #e0e1e6;
+	border-bottom: 1px solid var(--color-border-subtle);
 }
 
 .wpaim-ob-pips {
@@ -395,7 +395,7 @@
 	height: 2px;
 	flex: 1;
 	border-radius: 2px;
-	background: #e0e1e6;
+	background: var(--color-border-subtle);
 	transition: background 0.2s;
 }
 
@@ -429,7 +429,7 @@
 
 .wpaim-ob-footer {
 	padding: var(--space-2) var(--space-5) var(--space-3);
-	border-top: 1px solid #e0e1e6;
+	border-top: 1px solid var(--color-border-subtle);
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
@@ -437,20 +437,20 @@
 
 /* Choice radio cards */
 .wpaim-ob-choice {
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--color-border);
 	border-radius: var(--radius);
 	padding: var(--space-2) var(--space-3);
 	display: flex;
 	align-items: flex-start;
 	gap: var(--space-2);
-	background: #fff;
+	background: var(--color-bg);
 	cursor: pointer;
 	transition: border-color 0.12s, background 0.12s;
 }
 
 .wpaim-ob-choice:hover {
 	border-color: #8c8f94;
-	background: #f0f0f1;
+	background: var(--color-surface-2);
 }
 
 .wpaim-ob-choice--selected {
@@ -462,7 +462,7 @@
 	width: 15px;
 	height: 15px;
 	border-radius: 50%;
-	border: 1.5px solid #dcdcde;
+	border: 1.5px solid var(--color-border);
 	margin-top: 1px;
 	flex-shrink: 0;
 	display: flex;
@@ -481,7 +481,7 @@
 	width: 5px;
 	height: 5px;
 	border-radius: 50%;
-	background: #fff;
+	background: var(--color-bg);
 }
 
 .wpaim-ob-choice--selected .wpaim-ob-radio__dot {
@@ -505,7 +505,7 @@
 .wpaim-ob-section-label {
 	font-size: 0.625rem;
 	font-weight: 600;
-	color: #787c82;
+	color: var(--color-text-muted);
 	text-transform: uppercase;
 	letter-spacing: 0.07em;
 	margin-top: var(--space-1);
@@ -519,10 +519,10 @@
 }
 
 .wpaim-ob-provider {
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--color-border);
 	border-radius: var(--radius);
 	padding: var(--space-2) var(--space-2) var(--space-1);
-	background: #fff;
+	background: var(--color-bg);
 	cursor: pointer;
 	display: flex;
 	flex-direction: column;
@@ -581,12 +581,12 @@
 /* API key input */
 .wpaim-ob-key-input {
 	width: 100%;
-	background: #fff;
-	border: 1px solid #dcdcde;
+	background: var(--color-bg);
+	border: 1px solid var(--color-border);
 	border-radius: var(--radius);
 	padding: var(--space-2) var(--space-2);
 	font-size: 0.6875rem;
-	color: #1d2327;
+	color: var(--color-text-primary);
 	font-family: var(--font-mono, monospace);
 	transition: border-color 0.12s;
 }
@@ -611,9 +611,9 @@
 
 /* Optional collapsible */
 .wpaim-ob-optional {
-	border: 1px solid #e0e1e6;
+	border: 1px solid var(--color-border-subtle);
 	border-radius: var(--radius);
-	background: #fff;
+	background: var(--color-bg);
 	overflow: hidden;
 }
 
@@ -641,8 +641,8 @@
 	font-weight: 600;
 	padding: 2px 6px;
 	border-radius: 3px;
-	background: #e0e1e6;
-	color: #787c82;
+	background: var(--color-border-subtle);
+	color: var(--color-text-muted);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 }
@@ -660,7 +660,7 @@
 
 .wpaim-ob-optional__body {
 	padding: var(--space-2) var(--space-3) var(--space-3);
-	border-top: 1px solid #e0e1e6;
+	border-top: 1px solid var(--color-border-subtle);
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-2);

--- a/src/admin/dashboard/dashboard.css
+++ b/src/admin/dashboard/dashboard.css
@@ -1,11 +1,11 @@
-/* ── Dashboard shell ─────────────────────────────────────────────── */
+/* ── Dashboard shell ──────────────────────────────────────────────────────── */
 
 .wpaim-dashboard {
 	display: flex;
 	flex-direction: column;
 	min-height: 100vh;
-	background: var(--color-bg);
-	color: var(--color-text-primary);
+	background: #fff;
+	color: #1d2327;
 	font-family: var(--font-sans, -apple-system, sans-serif);
 	-webkit-font-smoothing: antialiased;
 }
@@ -16,7 +16,7 @@
 	align-items: center;
 	justify-content: space-between;
 	padding: var(--space-4) var(--space-6) var(--space-3);
-	border-bottom: 1px solid var(--color-border-subtle);
+	border-bottom: 1px solid #e0e1e6;
 	flex-shrink: 0;
 }
 
@@ -38,12 +38,12 @@
 	font-size: 0.625rem;
 	padding: 3px 8px;
 	border-radius: var(--radius-sm);
-	background: var(--color-surface);
-	border: 1px solid var(--color-border);
-	color: var(--color-text-muted);
+	background: #f8f9fa;
+	border: 1px solid #dcdcde;
+	color: #787c82;
 }
 
-/* ── Status banner ──────────────────────────────────────────────── */
+/* ── Status banner ──────────────────────────────────────────────────────────── */
 
 .wpaim-dash-banner {
 	margin: var(--space-4) var(--space-6) 0;
@@ -98,7 +98,7 @@
 	flex-shrink: 0;
 }
 
-/* ── Page body ──────────────────────────────────────────────────── */
+/* ── Page body ──────────────────────────────────────────────────────────────── */
 
 .wpaim-dash-body {
 	flex: 1;
@@ -124,7 +124,7 @@
 	font-family: var(--font-mono, monospace);
 }
 
-/* ── Start tiles ────────────────────────────────────────────────── */
+/* ── Start tiles ────────────────────────────────────────────────────────────── */
 
 .wpaim-dash-tiles {
 	display: grid;
@@ -133,10 +133,10 @@
 }
 
 .wpaim-dash-tile {
-	background: var(--color-surface);
-	border: 1px solid var(--color-border-subtle);
+	background: #f8f9fa;
+	border: 1px solid #e0e1e6;
 	border-radius: var(--radius);
-	padding: var(--space-3) var(--space-3) var(--space-7);
+	padding: var(--space-4) var(--space-4) var(--space-7);
 	cursor: pointer;
 	position: relative;
 	overflow: hidden;
@@ -152,12 +152,12 @@
 	left: 0;
 	right: 0;
 	height: 1px;
-	background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.05), transparent);
+	background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.6), transparent);
 }
 
 .wpaim-dash-tile:hover {
-	border-color: var(--color-border);
-	background: var(--color-surface-2);
+	border-color: #dcdcde;
+	background: #f0f0f1;
 	transform: translateY(-1px);
 	text-decoration: none;
 }
@@ -201,11 +201,11 @@
 	padding-right: var(--space-3);
 }
 
-/* ── Resource list ──────────────────────────────────────────────── */
+/* ── Resource list ──────────────────────────────────────────────────────────── */
 
 .wpaim-dash-resources {
-	background: var(--color-surface);
-	border: 1px solid var(--color-border-subtle);
+	background: #f8f9fa;
+	border: 1px solid #e0e1e6;
 	border-radius: var(--radius);
 	overflow: hidden;
 }
@@ -213,8 +213,8 @@
 .wpaim-dash-resource {
 	display: flex;
 	align-items: center;
-	padding: var(--space-2) var(--space-3);
-	border-bottom: 1px solid var(--color-border-subtle);
+	padding: var(--space-3) var(--space-3);
+	border-bottom: 1px solid #e0e1e6;
 	text-decoration: none;
 	transition: background 0.1s;
 	gap: var(--space-3);
@@ -225,7 +225,7 @@
 }
 
 .wpaim-dash-resource:hover {
-	background: var(--color-surface-2);
+	background: #f0f0f1;
 	text-decoration: none;
 }
 
@@ -257,7 +257,7 @@
 	color: var(--wp-admin-theme-color);
 }
 
-/* ── Page footer ────────────────────────────────────────────────── */
+/* ── Page footer ────────────────────────────────────────────────────────────── */
 
 .wpaim-dash-footer {
 	padding: var(--space-3) var(--space-6) var(--space-4);
@@ -265,7 +265,7 @@
 	display: flex;
 	align-items: center;
 	gap: var(--space-3);
-	border-top: 1px solid var(--color-border-subtle);
+	border-top: 1px solid #e0e1e6;
 }
 
 .wpaim-dash-footer__link {
@@ -292,7 +292,7 @@
 	flex-shrink: 0;
 }
 
-/* ── Buttons (shared small) ─────────────────────────────────────── */
+/* ── Buttons (shared small) ─────────────────────────────────────────────────── */
 
 .wpaim-dash-btn {
 	font-size: 0.6875rem;
@@ -301,9 +301,9 @@
 	border-radius: var(--radius-sm);
 	cursor: pointer;
 	font-family: inherit;
-	border: 1px solid var(--color-border);
-	background: var(--color-surface);
-	color: var(--color-text-secondary);
+	border: 1px solid #dcdcde;
+	background: #f8f9fa;
+	color: #50575e;
 	text-decoration: none;
 	white-space: nowrap;
 	transition: border-color 0.12s, color 0.12s;
@@ -346,9 +346,9 @@
 .wpaim-ob-test-btn {
 	font-size: 0.6875rem;
 	padding: var(--space-2) var(--space-3);
-	background: var(--color-surface-2);
-	color: var(--color-text-secondary);
-	border: 1px solid var(--color-border-subtle);
+	background: #f0f0f1;
+	color: #50575e;
+	border: 1px solid #e0e1e6;
 	border-radius: var(--radius-sm);
 	cursor: pointer;
 	white-space: nowrap;
@@ -382,7 +382,7 @@
 
 .wpaim-ob-header {
 	padding: var(--space-4) var(--space-5) var(--space-3);
-	border-bottom: 1px solid var(--color-border-subtle);
+	border-bottom: 1px solid #e0e1e6;
 }
 
 .wpaim-ob-pips {
@@ -395,7 +395,7 @@
 	height: 2px;
 	flex: 1;
 	border-radius: 2px;
-	background: var(--color-border-subtle);
+	background: #e0e1e6;
 	transition: background 0.2s;
 }
 
@@ -429,7 +429,7 @@
 
 .wpaim-ob-footer {
 	padding: var(--space-2) var(--space-5) var(--space-3);
-	border-top: 1px solid var(--color-border-subtle);
+	border-top: 1px solid #e0e1e6;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
@@ -437,32 +437,32 @@
 
 /* Choice radio cards */
 .wpaim-ob-choice {
-	border: 1px solid var(--color-border-subtle);
+	border: 1px solid #dcdcde;
 	border-radius: var(--radius);
 	padding: var(--space-2) var(--space-3);
 	display: flex;
 	align-items: flex-start;
 	gap: var(--space-2);
-	background: var(--color-bg);
+	background: #fff;
 	cursor: pointer;
 	transition: border-color 0.12s, background 0.12s;
 }
 
 .wpaim-ob-choice:hover {
-	border-color: var(--color-border);
-	background: var(--color-surface-2);
+	border-color: #8c8f94;
+	background: #f0f0f1;
 }
 
 .wpaim-ob-choice--selected {
-	border-color: rgba(var(--wp-admin-theme-color--rgb), 0.3);
-	background: rgba(var(--wp-admin-theme-color--rgb), 0.12);
+	border-color: var(--wp-admin-theme-color);
+	background: color-mix(in srgb, var(--wp-admin-theme-color) 6%, #fff);
 }
 
 .wpaim-ob-radio {
 	width: 15px;
 	height: 15px;
 	border-radius: 50%;
-	border: 1.5px solid var(--color-border);
+	border: 1.5px solid #dcdcde;
 	margin-top: 1px;
 	flex-shrink: 0;
 	display: flex;
@@ -505,7 +505,7 @@
 .wpaim-ob-section-label {
 	font-size: 0.625rem;
 	font-weight: 600;
-	color: var(--color-text-muted);
+	color: #787c82;
 	text-transform: uppercase;
 	letter-spacing: 0.07em;
 	margin-top: var(--space-1);
@@ -519,10 +519,10 @@
 }
 
 .wpaim-ob-provider {
-	border: 1px solid var(--color-border-subtle);
+	border: 1px solid #dcdcde;
 	border-radius: var(--radius);
 	padding: var(--space-2) var(--space-2) var(--space-1);
-	background: var(--color-bg);
+	background: #fff;
 	cursor: pointer;
 	display: flex;
 	flex-direction: column;
@@ -532,12 +532,12 @@
 }
 
 .wpaim-ob-provider:hover {
-	border-color: var(--color-border);
+	border-color: #8c8f94;
 }
 
 .wpaim-ob-provider--selected {
-	border-color: rgba(var(--wp-admin-theme-color--rgb), 0.3);
-	background: rgba(var(--wp-admin-theme-color--rgb), 0.12);
+	border-color: var(--wp-admin-theme-color);
+	background: color-mix(in srgb, var(--wp-admin-theme-color) 6%, #fff);
 }
 
 .wpaim-ob-provider__check {
@@ -581,19 +581,24 @@
 /* API key input */
 .wpaim-ob-key-input {
 	width: 100%;
-	background: var(--color-bg);
-	border: 1px solid var(--color-border);
+	background: #fff;
+	border: 1px solid #dcdcde;
 	border-radius: var(--radius);
 	padding: var(--space-2) var(--space-2);
 	font-size: 0.6875rem;
-	color: var(--color-text-primary);
+	color: #1d2327;
 	font-family: var(--font-mono, monospace);
 	transition: border-color 0.12s;
 }
 
 .wpaim-ob-key-input:focus {
 	outline: none;
-	border-color: rgba(var(--wp-admin-theme-color--rgb), 0.3);
+	border-color: var(--wp-admin-theme-color);
+}
+
+.wpaim-ob-key-input:focus-visible {
+	outline: 2px solid var(--wp-admin-theme-color);
+	outline-offset: 2px;
 }
 
 .wpaim-ob-key-input::placeholder {
@@ -606,9 +611,9 @@
 
 /* Optional collapsible */
 .wpaim-ob-optional {
-	border: 1px solid var(--color-border-subtle);
+	border: 1px solid #e0e1e6;
 	border-radius: var(--radius);
-	background: var(--color-bg);
+	background: #fff;
 	overflow: hidden;
 }
 
@@ -636,8 +641,8 @@
 	font-weight: 600;
 	padding: 2px 6px;
 	border-radius: 3px;
-	background: var(--color-border-subtle);
-	color: var(--color-text-muted);
+	background: #e0e1e6;
+	color: #787c82;
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 }
@@ -655,7 +660,7 @@
 
 .wpaim-ob-optional__body {
 	padding: var(--space-2) var(--space-3) var(--space-3);
-	border-top: 1px solid var(--color-border-subtle);
+	border-top: 1px solid #e0e1e6;
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-2);
@@ -683,7 +688,7 @@
 }
 
 .wpaim-ob-devnote code {
-	background: rgba(0, 0, 0, 0.3);
+	background: rgba(0, 0, 0, 0.08);
 	padding: 1px 4px;
 	border-radius: 3px;
 	font-size: 0.5625rem;

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -3,8 +3,8 @@
 /* ── Sidebar container ──────────────────────────────────────────────── */
 .wpaim-editor-sidebar {
 	padding: var(--space-4);
-	background: var(--color-surface-1, var(--color-surface));
-	color: var(--color-text-primary);
+	background: #fff;
+	color: #1d2327;
 	font-size: var(--text-base);
 }
 
@@ -47,8 +47,8 @@
 }
 
 .wpaim-editor-mini-chat__bubble--ai {
-	background: var(--color-surface-2);
-	color: var(--color-text-primary);
+	background: #f0f0f1;
+	color: #1d2327;
 	align-self: flex-start;
 	max-width: 92%;
 }
@@ -63,14 +63,19 @@
 
 .wpaim-editor-mini-chat__input {
 	flex: 1;
-	border: 1px solid var(--color-border);
+	border: 1px solid #dcdcde;
 	border-radius: var(--radius-sm);
-	background: var(--color-surface-2);
-	color: var(--color-text-primary);
+	background: #fff;
+	color: #1d2327;
 	font-size: var(--text-sm);
 	padding: var(--space-2) var(--space-3);
 	outline: none;
 	transition: border-color 0.15s ease;
+}
+
+.wpaim-editor-mini-chat__input:focus-visible {
+	outline: 2px solid var(--wp-admin-theme-color);
+	outline-offset: 2px;
 }
 
 .wpaim-editor-mini-chat__input:focus {
@@ -131,9 +136,9 @@
 	width: 100%;
 	text-align: left;
 	background: transparent;
-	border: 1px solid var(--color-border);
+	border: 1px solid #dcdcde;
 	border-radius: var(--radius-sm);
-	color: var(--color-text-primary);
+	color: #1d2327;
 	font-size: var(--text-sm);
 	padding: var(--space-2) var(--space-3);
 	cursor: pointer;
@@ -143,7 +148,7 @@
 }
 
 .wpaim-block-actions__btn:hover {
-	background: var(--color-surface-2);
+	background: #f0f0f1;
 	border-color: rgba(var(--wp-admin-theme-color--rgb), 0.3);
 }
 

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -3,8 +3,8 @@
 /* ── Sidebar container ──────────────────────────────────────────────── */
 .wpaim-editor-sidebar {
 	padding: var(--space-4);
-	background: #fff;
-	color: #1d2327;
+	background: var(--color-bg);
+	color: var(--color-text-primary);
 	font-size: var(--text-base);
 }
 
@@ -47,8 +47,8 @@
 }
 
 .wpaim-editor-mini-chat__bubble--ai {
-	background: #f0f0f1;
-	color: #1d2327;
+	background: var(--color-surface-2);
+	color: var(--color-text-primary);
 	align-self: flex-start;
 	max-width: 92%;
 }
@@ -63,10 +63,10 @@
 
 .wpaim-editor-mini-chat__input {
 	flex: 1;
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--color-border);
 	border-radius: var(--radius-sm);
-	background: #fff;
-	color: #1d2327;
+	background: var(--color-bg);
+	color: var(--color-text-primary);
 	font-size: var(--text-sm);
 	padding: var(--space-2) var(--space-3);
 	outline: none;
@@ -136,9 +136,9 @@
 	width: 100%;
 	text-align: left;
 	background: transparent;
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--color-border);
 	border-radius: var(--radius-sm);
-	color: #1d2327;
+	color: var(--color-text-primary);
 	font-size: var(--text-sm);
 	padding: var(--space-2) var(--space-3);
 	cursor: pointer;
@@ -148,7 +148,7 @@
 }
 
 .wpaim-block-actions__btn:hover {
-	background: #f0f0f1;
+	background: var(--color-surface-2);
 	border-color: rgba(var(--wp-admin-theme-color--rgb), 0.3);
 }
 

--- a/src/generator/generator.css
+++ b/src/generator/generator.css
@@ -5,7 +5,7 @@
 	margin: 0 auto;
 	padding: var(--space-6);
 	font-family: var(--font-sans);
-	color: #1d2327;
+	color: var(--color-text-primary);
 }
 
 .wpaim-generator__header {
@@ -52,8 +52,8 @@
 	width: 20px;
 	height: 20px;
 	border-radius: 50%;
-	background: #f0f0f1;
-	border: 1px solid #dcdcde;
+	background: var(--color-surface-2);
+	border: 1px solid var(--color-border);
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -70,8 +70,8 @@
 
 /* Card */
 .wpaim-generator__card {
-	background: #f8f9fa;
-	border: 1px solid #e0e1e6;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border-subtle);
 	border-radius: var(--radius-md);
 	padding: var(--space-6);
 }
@@ -88,14 +88,14 @@
 /* Preview */
 .wpaim-generator__preview {
 	white-space: pre-wrap;
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--color-border);
 	border-radius: var(--radius);
-	background: #f0f0f1;
+	background: var(--color-surface-2);
 	padding: var(--space-4);
 	overflow: auto;
 	max-height: 400px;
 	font-size: var(--text-sm);
-	color: #50575e;
+	color: var(--color-text-secondary);
 	line-height: 1.7;
 }
 

--- a/src/generator/generator.css
+++ b/src/generator/generator.css
@@ -5,7 +5,7 @@
 	margin: 0 auto;
 	padding: var(--space-6);
 	font-family: var(--font-sans);
-	color: var(--color-text-primary);
+	color: #1d2327;
 }
 
 .wpaim-generator__header {
@@ -52,8 +52,8 @@
 	width: 20px;
 	height: 20px;
 	border-radius: 50%;
-	background: var(--color-surface-2);
-	border: 1px solid var(--color-border);
+	background: #f0f0f1;
+	border: 1px solid #dcdcde;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -70,8 +70,8 @@
 
 /* Card */
 .wpaim-generator__card {
-	background: var(--color-surface);
-	border: 1px solid var(--color-border);
+	background: #f8f9fa;
+	border: 1px solid #e0e1e6;
 	border-radius: var(--radius-md);
 	padding: var(--space-6);
 }
@@ -88,14 +88,14 @@
 /* Preview */
 .wpaim-generator__preview {
 	white-space: pre-wrap;
-	border: 1px solid var(--color-border);
+	border: 1px solid #dcdcde;
 	border-radius: var(--radius);
-	background: var(--color-surface-2);
+	background: #f0f0f1;
 	padding: var(--space-4);
 	overflow: auto;
 	max-height: 400px;
 	font-size: var(--text-sm);
-	color: var(--color-text-secondary);
+	color: #50575e;
 	line-height: 1.7;
 }
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,17 +1,17 @@
 /* Root tokens — define once in admin.css, use everywhere */
 :root {
 
-	/* Neutrals (zinc scale) */
-	--color-bg: #09090b;   /* zinc-950 — page background */
-	--color-surface: #18181b;   /* zinc-900 — card/panel background */
-	--color-surface-2: #27272a;   /* zinc-800 — input/hover background */
-	--color-border: #3f3f46;   /* zinc-700 — default border */
-	--color-border-subtle: #27272a; /* zinc-800 — subtle dividers */
+	/* Neutrals — WP admin light palette */
+	--color-bg: #fff;                  /* page background */
+	--color-surface: #f8f9fa;          /* card/panel background */
+	--color-surface-2: #f0f0f1;        /* input/hover background */
+	--color-border: #dcdcde;           /* default border */
+	--color-border-subtle: #e0e1e6;    /* subtle dividers */
 
-	/* Text */
-	--color-text-primary: #fafafa;  /* zinc-50 */
-	--color-text-secondary: #a1a1aa;  /* zinc-400 */
-	--color-text-muted: #52525b;  /* zinc-600 */
+	/* Text — WP admin standard */
+	--color-text-primary: #1d2327;     /* primary text */
+	--color-text-secondary: #50575e;   /* secondary / label text */
+	--color-text-muted: #787c82;       /* muted / placeholder text */
 
 	/* Semantic */
 	--color-success: #16a34a;   /* green-600 */

--- a/src/usage/usage.css
+++ b/src/usage/usage.css
@@ -5,7 +5,7 @@
 	max-width: 900px;
 	margin: 0 auto;
 	padding: var(--space-8) var(--space-6);
-	color: #1d2327;
+	color: var(--color-text-primary);
 	font-family: var(--font-sans);
 	font-size: var(--text-base);
 }
@@ -30,11 +30,11 @@
 /* ── Period badge ── */
 .wpaim-usage__period {
 	display: inline-block;
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--color-border);
 	border-radius: var(--radius);
 	padding: 2px var(--space-2);
 	font-size: var(--text-xs);
-	color: #50575e;
+	color: var(--color-text-secondary);
 	line-height: 1.6;
 }
 
@@ -48,8 +48,8 @@
 
 /* ── Stat card ── */
 .wpaim-usage__stat-card {
-	background: #f8f9fa;
-	border: 1px solid #e0e1e6;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border-subtle);
 	border-radius: var(--radius-md);
 	padding: var(--space-5);
 	text-align: center;

--- a/src/usage/usage.css
+++ b/src/usage/usage.css
@@ -5,7 +5,7 @@
 	max-width: 900px;
 	margin: 0 auto;
 	padding: var(--space-8) var(--space-6);
-	color: var(--color-text-primary);
+	color: #1d2327;
 	font-family: var(--font-sans);
 	font-size: var(--text-base);
 }
@@ -30,11 +30,11 @@
 /* ── Period badge ── */
 .wpaim-usage__period {
 	display: inline-block;
-	border: 1px solid var(--color-border);
+	border: 1px solid #dcdcde;
 	border-radius: var(--radius);
 	padding: 2px var(--space-2);
 	font-size: var(--text-xs);
-	color: var(--color-text-secondary);
+	color: #50575e;
 	line-height: 1.6;
 }
 
@@ -48,8 +48,8 @@
 
 /* ── Stat card ── */
 .wpaim-usage__stat-card {
-	background: var(--color-surface);
-	border: 1px solid var(--color-border);
+	background: #f8f9fa;
+	border: 1px solid #e0e1e6;
 	border-radius: var(--radius-md);
 	padding: var(--space-5);
 	text-align: center;


### PR DESCRIPTION
Replace the dark zinc-scale design tokens with WordPress admin light palette variables (--wp-admin-theme-color, --wp-admin-theme-color--rgb) so the plugin UI aligns visually with the host WP admin. Affects admin dashboard, chat, editor sidebar, generator, and usage pages.

Also adds design spec for SEO and Images pages
(docs/superpowers/specs/2026-03-27-seo-images-admin-pages-design.md).

https://claude.ai/code/session_01N2vM9kjf1m2Dv22gdr575Z