### PR TITLE
chore(ci): remove duplicate post-merge CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main, develop]
   pull_request:
     branches: [main, develop]
 


### PR DESCRIPTION
CI checks were running twice — once on the PR and again on push to
main/develop after merge. Since branch protection requires PRs, the
post-merge run is redundant. Keeping only the pull_request trigger.

https://claude.ai/code/session_01KbVxADnNkj5nrpeDkTZrH5