### PR TITLE
fix(workflows): security and CI hardening — backport from develop

### DIFF
--- a/.github/workflows/auto-fix-review-issue.yml
+++ b/.github/workflows/auto-fix-review-issue.yml
@@ -21,6 +21,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Write untrusted issue content to files so it is never interpolated into
+      # the Claude prompt string (prevents prompt injection attacks).
+      - name: Write issue data to files
+        run: |
+          printf '%s' "$ISSUE_TITLE" > /tmp/issue-title.txt
+          printf '%s' "$ISSUE_BODY"  > /tmp/issue-body.txt
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY:  ${{ github.event.issue.body }}
+
       - uses: anthropics/claude-code-action@aee99972d0cfa0c47a4563e6fca42d7a5a0cb9bd  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -28,11 +38,10 @@ jobs:
           prompt: |
             Issue #${{ github.event.issue.number }} has been labeled `auto-fix` and needs to be resolved.
 
-            **Issue title:** ${{ github.event.issue.title }}
+            **Issue title:** (read from /tmp/issue-title.txt)
             **Issue URL:** ${{ github.event.issue.html_url }}
 
-            **Issue body:**
-            ${{ github.event.issue.body }}
+            **Issue body:** (read from /tmp/issue-body.txt)
 
             ---
 
@@ -40,7 +49,8 @@ jobs:
 
             ### Step 1 — Parse the issue
 
-            Read the issue body above. Extract:
+            Run: `cat /tmp/issue-title.txt` and `cat /tmp/issue-body.txt` to read the issue content.
+            From the body, extract:
             - The PR number (look for "PR #NNN" or a GitHub pull request URL)
             - The base branch (look for "**Base branch:** <name>")
 
@@ -82,7 +92,7 @@ jobs:
             e. Leave a comment on the PR so reviewers know the fix landed:
 
                  gh pr comment <PR-number> \
-                   --body "🔧 Pushed a fix for issue #${{ github.event.issue.number }} (_${{ github.event.issue.title }}_) to this branch." \
+                   --body "🔧 Pushed a fix for issue #${{ github.event.issue.number }} to this branch." \
                    --repo ${{ github.repository }}
 
             **If the PR is CLOSED or MERGED (or the head branch no longer exists):**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main, develop]
+  push:
+    branches: [develop]
 
 jobs:
   phpcs:

--- a/.github/workflows/nightly-sync.yml
+++ b/.github/workflows/nightly-sync.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           ref: develop
           fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
 
       - name: Resolve conflicts with Claude
         if: steps.merge.outputs.status == 'conflict'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@aee99972d0cfa0c47a4563e6fca42d7a5a0cb9bd  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |


### PR DESCRIPTION
## Summary

Backports three workflow fixes from `develop` to `main` so they take effect immediately (scheduled and issue-triggered workflows always read from the default branch).

- **Security (#62):** `auto-fix-review-issue.yml` — issue title/body are now written to files via `env:` before the Claude step, removing direct `${{ github.event.issue.* }}` interpolation from the prompt YAML. The workflow has `contents: write` + `pull-requests: write`, so a successful injection could push arbitrary code or open malicious PRs.
- **Supply chain (#63):** `nightly-sync.yml` — replace floating `@v4` / `@v1` action refs with pinned commit SHAs, consistent with every other workflow in the repo.
- **CI coverage (#64):** `ci.yml` — restore `push: branches: [develop]` trigger so nightly-sync bot commits to `develop` are validated by CI.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, verify `auto-fix-review-issue.yml` no longer interpolates issue content into the prompt string
- [ ] Confirm `nightly-sync.yml` uses pinned SHAs in the Actions UI

https://claude.ai/code/session_019rkppUYX1Ruq6cPGj3wZRQ