### PR TITLE
fix(ci): add id-token: write to auto-fix workflow permissions

### DIFF
--- a/.github/workflows/auto-fix-ci.yml
+++ b/.github/workflows/auto-fix-ci.yml
@@ -17,6 +17,7 @@ jobs:
       contents: write
       pull-requests: write
       actions: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4

--- a/.github/workflows/auto-fix-ci.yml
+++ b/.github/workflows/auto-fix-ci.yml
@@ -17,6 +17,9 @@ jobs:
       contents: write
       pull-requests: write
       actions: read
+      # Required by anthropics/claude-code-action when using claude_code_oauth_token:
+      # the action fetches a GitHub OIDC token internally to verify the workflow's
+      # identity before accepting the OAuth token.
       id-token: write
 
     steps:

--- a/.github/workflows/auto-fix-review-issue.yml
+++ b/.github/workflows/auto-fix-review-issue.yml
@@ -15,6 +15,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4

--- a/.github/workflows/auto-fix-review-issue.yml
+++ b/.github/workflows/auto-fix-review-issue.yml
@@ -15,6 +15,9 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      # Required by anthropics/claude-code-action when using claude_code_oauth_token:
+      # the action fetches a GitHub OIDC token internally to verify the workflow's
+      # identity before accepting the OAuth token.
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary

`anthropics/claude-code-action` fails to start when using `claude_code_oauth_token` unless the job has `id-token: write`. The action fetches a GitHub OIDC token internally to verify the workflow's identity before accepting the OAuth token. Two workflows were missing this permission.

## Changes

- `auto-fix-ci.yml` — added `id-token: write` with an inline comment explaining why
- `auto-fix-review-issue.yml` — same

## Why `id-token: write` is needed

The permission is not speculative. `anthropics/claude-code-action` uses it internally as part of its OAuth token flow — it requests a GitHub-signed JWT to prove the request originates from a legitimate Actions run before accepting the `claude_code_oauth_token`. Without it, the action exits immediately with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

A comment has been added to both files to make this explicit and satisfy the principle-of-least-privilege concern raised in review.

## Test plan

- [ ] Trigger `auto-fix-ci.yml` by letting a CI run fail on a branch — confirm the job no longer fails at the OIDC step
- [ ] Apply the `auto-fix` label to an issue — confirm `auto-fix-review-issue.yml` proceeds past the token-fetch step

https://claude.ai/code/session_01PyJCFrgJFuqf4g7PrdFrRT