### PR TITLE
feat(workflows): feature-grouping and automated release system

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,3 +100,48 @@ used by `.github/workflows/auto-fix-review-issue.yml` only needs to be
 
 See `RELEASING.md` for the full release checklist.
 Agents must never trigger a release without explicit user instruction.
+
+---
+
+## Feature-Grouping & Release System
+
+The repo uses an automated feature-grouping system. Understand it before touching branches, tags, or labels.
+
+### How it works
+
+1. Feature PRs target `develop` and are merged as **merge commits** (not squash).
+2. On every push to `develop`, `tag-feature-merge.yml` automatically creates an annotated tag `merged/<branch-name>` at each merge commit. The tag annotation contains the PR number: `PR #NN: branch-name`.
+3. The `release-ready` label on a PR signals "include this feature in the next release."
+4. Running the `Build Release Branch` workflow (`workflow_dispatch`) collects all `merged/*` tags whose PR has `release-ready`, cherry-picks them onto a new `release/vX.Y.Z` branch, bumps versions, and opens a PR to `main`.
+5. When that PR merges, `tag-release-merge.yml` creates the `vX.Y.Z` tag → `release.yml` builds the zip.
+
+### Agent rules for this system
+
+- **NEVER apply `release-ready` to a PR automatically.** It is a deliberate human release decision. Only apply it when explicitly instructed by the user.
+- **NEVER trigger `build-release-branch.yml`** (or any release workflow) without explicit user instruction.
+- **NEVER create, move, or delete `merged/*` tags.** They are managed exclusively by `tag-feature-merge.yml`.
+- **NEVER push `v*` tags directly.** Tags are created by `tag-release-merge.yml` on PR merge.
+- PRs from agents targeting `develop` should follow the same Conventional Commits convention as all other PRs — this is critical for `semantic-release` to correctly derive the version bump.
+
+### Querying release state (for agents)
+
+When the user asks "what features are queued for release?" or similar:
+
+```bash
+# List all merged/* tags
+git tag -l 'merged/*' --sort=version:refname
+
+# For each tag, check if its PR has release-ready label
+# (extract PR number from tag annotation first)
+git for-each-ref 'refs/tags/merged/*' --format='%(refname:short) %(contents)'
+
+gh pr view <PR_NUMBER> --repo niklas-joh/wp-ai-mind \
+  --json number,title,labels,state \
+  --jq '{number,title,labels:[.labels[].name],state}'
+```
+
+### PR targets
+
+- Feature work: PR targets `develop`
+- Hotfixes that must bypass `develop`: PR targets `main` directly (document in `RELEASING.md` emergency section)
+- Release branches (`release/vX.Y.Z`): PR targets `main` (created automatically by `build-release-branch.yml`)

--- a/.github/workflows/build-release-branch.yml
+++ b/.github/workflows/build-release-branch.yml
@@ -148,9 +148,11 @@ jobs:
           git checkout -b release/staging origin/main
 
       - name: Cherry-pick release-ready merge commits
+        env:
+          SHAS: ${{ steps.collect.outputs.shas }}
         run: |
           set -euo pipefail
-          for SHA in ${{ steps.collect.outputs.shas }}; do
+          for SHA in $SHAS; do
             echo "Cherry-picking $SHA"
             # -m 1 uses the first parent (main-line) diff for merge commits.
             git cherry-pick -m 1 "$SHA" || {
@@ -183,28 +185,33 @@ jobs:
       # ── Step 5: Update version files ──────────────────────────────────────
 
       - name: Update version in wp-ai-mind.php
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
           # Plugin header — "Version:           X.Y.Z"
           sed -i "s/^\( \* Version:\s*\).*/\1${VERSION}/" wp-ai-mind.php
           # Version constant — define( 'WP_AI_MIND_VERSION', 'X.Y.Z' );
           sed -i "s/define( 'WP_AI_MIND_VERSION', '[^']*' );/define( 'WP_AI_MIND_VERSION', '${VERSION}' );/" wp-ai-mind.php
 
       - name: Update Stable tag in readme.txt
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
           sed -i "s/^Stable tag: .*/Stable tag: ${VERSION}/" readme.txt
 
       - name: Update version in package.json
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+          npm version "$VERSION" --no-git-tag-version
 
       # ── Step 6: Update CHANGELOG.md ───────────────────────────────────────
 
       - name: Update CHANGELOG.md
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          VERSION=${{ steps.version.outputs.version }}
           DATE=$(date -u +%Y-%m-%d)
 
           # Find the last vX.Y.Z tag to bound the log range.
@@ -233,15 +240,17 @@ jobs:
       # ── Step 7: Commit, rename branch, and push ───────────────────────────
 
       - name: Commit version bump
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
           git add wp-ai-mind.php readme.txt package.json package-lock.json CHANGELOG.md
           git commit -m "chore: release v${VERSION}"
 
       - name: Rename branch to release/vX.Y.Z and push
         id: push
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
           BRANCH="release/v${VERSION}"
           git branch -m "release/v${VERSION}"
           git push -u origin "${BRANCH}"
@@ -252,11 +261,10 @@ jobs:
       - name: Open release PR to main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          BRANCH: ${{ steps.push.outputs.branch }}
+          FEATURES: ${{ steps.collect.outputs.feature_list }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
-          BRANCH=${{ steps.push.outputs.branch }}
-          FEATURES="${{ steps.collect.outputs.feature_list }}"
-
           gh pr create \
             --title "chore: release v${VERSION}" \
             --base main \

--- a/.github/workflows/build-release-branch.yml
+++ b/.github/workflows/build-release-branch.yml
@@ -1,0 +1,282 @@
+name: Build Release Branch
+
+# Triggered manually when it's time to cut a release from `develop`.
+#
+# The workflow:
+#   1. Finds all `merged/*` annotated tags whose originating PR carries the
+#      `release-ready` label.
+#   2. Creates a `release/vX.Y.Z` branch from `main` and cherry-picks those
+#      merge commits onto it.
+#   3. Derives the next version automatically via `semantic-release --dry-run`.
+#   4. Bumps version numbers in wp-ai-mind.php (×2), readme.txt, package.json,
+#      and prepends a CHANGELOG entry.
+#   5. Commits, pushes the branch, and opens a PR to `main`.
+#
+# No version input is required — the version comes entirely from conventional
+# commit messages on the cherry-picked commits.
+#
+# After the PR is reviewed and merged, `tag-release-merge.yml` automatically
+# creates the `vX.Y.Z` tag, which triggers the existing `release.yml` to build
+# the zip and publish the GitHub Release.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    name: Build release branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # ── Step 1: Ensure the release-ready label exists ─────────────────────
+
+      - name: Ensure release-ready label exists
+        run: |
+          gh label create "release-ready" \
+            --color "#0e8a16" \
+            --description "Include this feature in the next release branch" \
+            --repo "${{ github.repository }}" 2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── Step 2: Find release-ready merge commits ───────────────────────────
+
+      - name: Collect release-ready merge commits
+        id: collect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git fetch --tags
+
+          # List all merged/* tags, oldest first.
+          TAGS=$(git tag -l 'merged/*' --sort=version:refname)
+
+          if [ -z "$TAGS" ]; then
+            echo "::error::No merged/* tags found. Merge at least one feature branch to develop first."
+            exit 1
+          fi
+
+          SELECTED_SHAS=""
+          FEATURE_LIST=""
+
+          for TAG in $TAGS; do
+            # Read the annotation — format: "PR #NNN: branch-name"
+            ANNOTATION=$(git tag -v "$TAG" 2>&1 | grep -oP '(?<=tagger .{0,80}\n).*' || \
+                         git for-each-ref "refs/tags/$TAG" --format='%(contents)' | head -1)
+
+            # Robust extraction: look for "PR #NNN" anywhere in annotation
+            PR_NUMBER=$(git for-each-ref "refs/tags/$TAG" --format='%(contents)' \
+                        | grep -oP '(?<=PR #)\d+' | head -1 || true)
+
+            if [ -z "$PR_NUMBER" ]; then
+              echo "Warning: could not extract PR number from tag $TAG — skipping."
+              continue
+            fi
+
+            # Check if the PR has the release-ready label.
+            LABELS=$(gh pr view "$PR_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --json labels \
+              --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+
+            if echo "$LABELS" | grep -q "release-ready"; then
+              SHA=$(git rev-list -n 1 "$TAG")
+              BRANCH_NAME=$(git for-each-ref "refs/tags/$TAG" --format='%(contents)' \
+                            | grep -oP '(?<=PR #\d{1,6}: ).+' | head -1 || echo "$TAG")
+              echo "Selected: $TAG (PR #$PR_NUMBER) — SHA $SHA"
+              SELECTED_SHAS="${SELECTED_SHAS} ${SHA}"
+              FEATURE_LIST="${FEATURE_LIST}\n- ${BRANCH_NAME} (PR #${PR_NUMBER})"
+            else
+              echo "Skipping: $TAG (PR #$PR_NUMBER) — no release-ready label"
+            fi
+          done
+
+          if [ -z "$(echo "$SELECTED_SHAS" | tr -d ' ')" ]; then
+            echo "::error::No release-ready features found. Apply the 'release-ready' label to merged PRs before building a release."
+            exit 1
+          fi
+
+          # Sort SHAs by commit date (oldest first) so cherry-picks apply cleanly.
+          SORTED_SHAS=$(echo "$SELECTED_SHAS" | tr ' ' '\n' | grep -v '^$' \
+            | xargs -I{} git log -1 --format="%ct %H" {} \
+            | sort -n | awk '{print $2}')
+
+          # Store as newline-separated; GitHub outputs can't contain raw newlines.
+          echo "shas=$(echo "$SORTED_SHAS" | tr '\n' ' ' | xargs)" >> "$GITHUB_OUTPUT"
+          # Use a delimiter for multiline feature list
+          {
+            echo "feature_list<<EOF_FEATURES"
+            echo -e "$FEATURE_LIST"
+            echo "EOF_FEATURES"
+          } >> "$GITHUB_OUTPUT"
+
+      # ── Step 3: Build release branch from main ────────────────────────────
+
+      - name: Delete stale release/staging branch if it exists
+        run: |
+          git push origin --delete release/staging 2>/dev/null || true
+
+      - name: Create release/staging branch from main
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          git checkout -b release/staging origin/main
+
+      - name: Cherry-pick release-ready merge commits
+        run: |
+          set -euo pipefail
+          for SHA in ${{ steps.collect.outputs.shas }}; do
+            echo "Cherry-picking $SHA"
+            # -m 1 uses the first parent (main-line) diff for merge commits.
+            git cherry-pick -m 1 "$SHA" || {
+              echo "::error::Cherry-pick of $SHA failed — conflicts must be resolved manually."
+              git cherry-pick --abort 2>/dev/null || true
+              exit 1
+            }
+          done
+
+      # ── Step 4: Determine version with semantic-release (dry-run) ─────────
+
+      - name: Determine next version
+        id: version
+        run: |
+          set -euo pipefail
+
+          npx semantic-release --dry-run --no-ci 2>&1 | tee /tmp/sr-output.txt || true
+
+          VERSION=$(grep -oP 'The next release version is \K[^\s]+' /tmp/sr-output.txt | head -1 || true)
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::semantic-release could not determine a next version. Ensure the cherry-picked commits follow Conventional Commits (feat:, fix:, etc.)."
+            cat /tmp/sr-output.txt
+            exit 1
+          fi
+
+          echo "Next version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # ── Step 5: Update version files ──────────────────────────────────────
+
+      - name: Update version in wp-ai-mind.php
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          # Plugin header — "Version:           X.Y.Z"
+          sed -i "s/^\( \* Version:\s*\).*/\1${VERSION}/" wp-ai-mind.php
+          # Version constant — define( 'WP_AI_MIND_VERSION', 'X.Y.Z' );
+          sed -i "s/define( 'WP_AI_MIND_VERSION', '[^']*' );/define( 'WP_AI_MIND_VERSION', '${VERSION}' );/" wp-ai-mind.php
+
+      - name: Update Stable tag in readme.txt
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          sed -i "s/^Stable tag: .*/Stable tag: ${VERSION}/" readme.txt
+
+      - name: Update version in package.json
+        run: |
+          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+
+      # ── Step 6: Update CHANGELOG.md ───────────────────────────────────────
+
+      - name: Update CHANGELOG.md
+        run: |
+          set -euo pipefail
+          VERSION=${{ steps.version.outputs.version }}
+          DATE=$(date -u +%Y-%m-%d)
+
+          # Find the last vX.Y.Z tag to bound the log range.
+          LAST_TAG=$(git describe --tags --abbrev=0 --match "v*" origin/main 2>/dev/null || true)
+
+          if [ -n "$LAST_TAG" ]; then
+            RAW_LOG=$(git log "${LAST_TAG}..HEAD" --pretty="format:- %s" | grep -v "^- Merge " || true)
+          else
+            RAW_LOG=$(git log --pretty="format:- %s" | grep -v "^- Merge " | head -100 || true)
+          fi
+
+          # Write the new entry to a temp file (printf %b expands \n properly).
+          ENTRY_FILE=$(mktemp)
+          printf "## [%s] — %s\n\n%s\n\n" "${VERSION}" "${DATE}" "${RAW_LOG}" > "${ENTRY_FILE}"
+
+          # Prepend: cat entry + existing CHANGELOG into a temp, then replace.
+          CHANGELOG_TMP=$(mktemp)
+          if [ -f CHANGELOG.md ]; then
+            cat "${ENTRY_FILE}" CHANGELOG.md > "${CHANGELOG_TMP}"
+          else
+            cp "${ENTRY_FILE}" "${CHANGELOG_TMP}"
+          fi
+          mv "${CHANGELOG_TMP}" CHANGELOG.md
+          rm -f "${ENTRY_FILE}"
+
+      # ── Step 7: Commit, rename branch, and push ───────────────────────────
+
+      - name: Commit version bump
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          git add wp-ai-mind.php readme.txt package.json package-lock.json CHANGELOG.md
+          git commit -m "chore: release v${VERSION}"
+
+      - name: Rename branch to release/vX.Y.Z and push
+        id: push
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          BRANCH="release/v${VERSION}"
+          git branch -m "release/v${VERSION}"
+          git push -u origin "${BRANCH}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+      # ── Step 8: Open PR to main ────────────────────────────────────────────
+
+      - name: Open release PR to main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          BRANCH=${{ steps.push.outputs.branch }}
+          FEATURES="${{ steps.collect.outputs.feature_list }}"
+
+          gh pr create \
+            --title "chore: release v${VERSION}" \
+            --base main \
+            --head "${BRANCH}" \
+            --body "$(cat <<EOF
+          ## Release v${VERSION}
+
+          ### Features included
+          ${FEATURES}
+
+          ### What happens when this PR merges
+          1. \`tag-release-merge.yml\` automatically creates the \`v${VERSION}\` git tag
+          2. \`release.yml\` triggers on that tag, builds the plugin zip, and publishes the GitHub Release
+
+          ## Test plan
+          - [ ] CI passes on this branch
+          - [ ] Version is correct in \`wp-ai-mind.php\` (header + constant), \`readme.txt\`, \`package.json\`
+          - [ ] CHANGELOG entry is accurate and dated correctly
+          - [ ] No unintended files changed
+
+          > Merge this PR to trigger the automated tag and release build.
+          EOF
+          )"

--- a/.github/workflows/build-release-branch.yml
+++ b/.github/workflows/build-release-branch.yml
@@ -1,0 +1,273 @@
+name: Build Release Branch
+
+# Triggered manually when it's time to cut a release from `develop`.
+#
+# The workflow:
+#   1. Finds all `merged/*` annotated tags whose originating PR carries the
+#      `release-ready` label.
+#   2. Creates a `release/vX.Y.Z` branch from `main` and cherry-picks those
+#      merge commits onto it.
+#   3. Derives the next version automatically via `semantic-release --dry-run`.
+#   4. Bumps version numbers in wp-ai-mind.php (×2), readme.txt, package.json,
+#      and prepends a CHANGELOG entry.
+#   5. Commits, pushes the branch, and opens a PR to `main`.
+#
+# No version input is required — the version comes entirely from conventional
+# commit messages on the cherry-picked commits.
+#
+# After the PR is reviewed and merged, `tag-release-merge.yml` automatically
+# creates the `vX.Y.Z` tag, which triggers the existing `release.yml` to build
+# the zip and publish the GitHub Release.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    name: Build release branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # ── Step 1: Ensure the release-ready label exists ─────────────────────
+
+      - name: Ensure release-ready label exists
+        run: |
+          gh label create "release-ready" \
+            --color "#0e8a16" \
+            --description "Include this feature in the next release branch" \
+            --repo "${{ github.repository }}" 2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── Step 2: Find release-ready merge commits ───────────────────────────
+
+      - name: Collect release-ready merge commits
+        id: collect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git fetch --tags
+
+          # List all merged/* tags, oldest first.
+          TAGS=$(git tag -l 'merged/*' --sort=version:refname)
+
+          if [ -z "$TAGS" ]; then
+            echo "::error::No merged/* tags found. Merge at least one feature branch to develop first."
+            exit 1
+          fi
+
+          SELECTED_SHAS=""
+          FEATURE_LIST=""
+
+          for TAG in $TAGS; do
+            # Read the annotation — format: "PR #NNN: branch-name"
+            ANNOTATION=$(git tag -v "$TAG" 2>&1 | grep -oP '(?<=tagger .{0,80}\n).*' || \
+                         git for-each-ref "refs/tags/$TAG" --format='%(contents)' | head -1)
+
+            # Robust extraction: look for "PR #NNN" anywhere in annotation
+            PR_NUMBER=$(git for-each-ref "refs/tags/$TAG" --format='%(contents)' \
+                        | grep -oP '(?<=PR #)\d+' | head -1 || true)
+
+            if [ -z "$PR_NUMBER" ]; then
+              echo "Warning: could not extract PR number from tag $TAG — skipping."
+              continue
+            fi
+
+            # Check if the PR has the release-ready label.
+            LABELS=$(gh pr view "$PR_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --json labels \
+              --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+
+            if echo "$LABELS" | grep -q "release-ready"; then
+              SHA=$(git rev-list -n 1 "$TAG")
+              BRANCH_NAME=$(git for-each-ref "refs/tags/$TAG" --format='%(contents)' \
+                            | grep -oP '(?<=PR #\d{1,6}: ).+' | head -1 || echo "$TAG")
+              echo "Selected: $TAG (PR #$PR_NUMBER) — SHA $SHA"
+              SELECTED_SHAS="${SELECTED_SHAS} ${SHA}"
+              FEATURE_LIST="${FEATURE_LIST}\n- ${BRANCH_NAME} (PR #${PR_NUMBER})"
+            else
+              echo "Skipping: $TAG (PR #$PR_NUMBER) — no release-ready label"
+            fi
+          done
+
+          if [ -z "$(echo "$SELECTED_SHAS" | tr -d ' ')" ]; then
+            echo "::error::No release-ready features found. Apply the 'release-ready' label to merged PRs before building a release."
+            exit 1
+          fi
+
+          # Sort SHAs by commit date (oldest first) so cherry-picks apply cleanly.
+          SORTED_SHAS=$(echo "$SELECTED_SHAS" | tr ' ' '\n' | grep -v '^$' \
+            | xargs -I{} git log -1 --format="%ct %H" {} \
+            | sort -n | awk '{print $2}')
+
+          # Store as newline-separated; GitHub outputs can't contain raw newlines.
+          echo "shas=$(echo "$SORTED_SHAS" | tr '\n' ' ' | xargs)" >> "$GITHUB_OUTPUT"
+          # Use a delimiter for multiline feature list
+          {
+            echo "feature_list<<EOF_FEATURES"
+            echo -e "$FEATURE_LIST"
+            echo "EOF_FEATURES"
+          } >> "$GITHUB_OUTPUT"
+
+      # ── Step 3: Build release branch from main ────────────────────────────
+
+      - name: Create release/staging branch from main
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          git checkout -b release/staging origin/main
+
+      - name: Cherry-pick release-ready merge commits
+        run: |
+          set -euo pipefail
+          for SHA in ${{ steps.collect.outputs.shas }}; do
+            echo "Cherry-picking $SHA"
+            # -m 1 uses the first parent (main-line) diff for merge commits.
+            git cherry-pick -m 1 "$SHA" || {
+              echo "::error::Cherry-pick of $SHA failed — conflicts must be resolved manually."
+              git cherry-pick --abort 2>/dev/null || true
+              exit 1
+            }
+          done
+
+      # ── Step 4: Determine version with semantic-release (dry-run) ─────────
+
+      - name: Determine next version
+        id: version
+        run: |
+          set -euo pipefail
+
+          npx semantic-release --dry-run --no-ci 2>&1 | tee /tmp/sr-output.txt || true
+
+          VERSION=$(grep -oP 'The next release version is \K[^\s]+' /tmp/sr-output.txt | head -1 || true)
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::semantic-release could not determine a next version. Ensure the cherry-picked commits follow Conventional Commits (feat:, fix:, etc.)."
+            cat /tmp/sr-output.txt
+            exit 1
+          fi
+
+          echo "Next version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # ── Step 5: Update version files ──────────────────────────────────────
+
+      - name: Update version in wp-ai-mind.php
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          # Plugin header — "Version:           X.Y.Z"
+          sed -i "s/^\( \* Version:\s*\).*/\1${VERSION}/" wp-ai-mind.php
+          # Version constant — define( 'WP_AI_MIND_VERSION', 'X.Y.Z' );
+          sed -i "s/define( 'WP_AI_MIND_VERSION', '[^']*' );/define( 'WP_AI_MIND_VERSION', '${VERSION}' );/" wp-ai-mind.php
+
+      - name: Update Stable tag in readme.txt
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          sed -i "s/^Stable tag: .*/Stable tag: ${VERSION}/" readme.txt
+
+      - name: Update version in package.json
+        run: |
+          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+
+      # ── Step 6: Update CHANGELOG.md ───────────────────────────────────────
+
+      - name: Update CHANGELOG.md
+        run: |
+          set -euo pipefail
+          VERSION=${{ steps.version.outputs.version }}
+          DATE=$(date -u +%Y-%m-%d)
+
+          # Find the last vX.Y.Z tag to bound the log range.
+          LAST_TAG=$(git describe --tags --abbrev=0 --match "v*" origin/main 2>/dev/null || true)
+
+          if [ -n "$LAST_TAG" ]; then
+            RAW_LOG=$(git log "${LAST_TAG}..HEAD" --pretty="format:- %s" | grep -v "^- Merge " || true)
+          else
+            RAW_LOG=$(git log --pretty="format:- %s" | grep -v "^- Merge " | head -100 || true)
+          fi
+
+          ENTRY="## [${VERSION}] — ${DATE}\n\n${RAW_LOG}\n"
+
+          # Prepend the entry before the first existing ## heading (or at top).
+          if grep -q "^## " CHANGELOG.md 2>/dev/null; then
+            sed -i "0,/^## /{s/^## /${ENTRY}\n## /}" CHANGELOG.md
+          else
+            printf "%b\n$(cat CHANGELOG.md)" "$ENTRY" > CHANGELOG.md
+          fi
+
+      # ── Step 7: Commit, rename branch, and push ───────────────────────────
+
+      - name: Commit version bump
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          git add wp-ai-mind.php readme.txt package.json package-lock.json CHANGELOG.md
+          git commit -m "chore: release v${VERSION}"
+
+      - name: Rename branch to release/vX.Y.Z and push
+        id: push
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          BRANCH="release/v${VERSION}"
+          git branch -m "release/v${VERSION}"
+          git push -u origin "${BRANCH}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+      # ── Step 8: Open PR to main ────────────────────────────────────────────
+
+      - name: Open release PR to main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          BRANCH=${{ steps.push.outputs.branch }}
+          FEATURES="${{ steps.collect.outputs.feature_list }}"
+
+          gh pr create \
+            --title "chore: release v${VERSION}" \
+            --base main \
+            --head "${BRANCH}" \
+            --body "$(cat <<EOF
+          ## Release v${VERSION}
+
+          ### Features included
+          ${FEATURES}
+
+          ### What happens when this PR merges
+          1. \`tag-release-merge.yml\` automatically creates the \`v${VERSION}\` git tag
+          2. \`release.yml\` triggers on that tag, builds the plugin zip, and publishes the GitHub Release
+
+          ## Test plan
+          - [ ] CI passes on this branch
+          - [ ] Version is correct in \`wp-ai-mind.php\` (header + constant), \`readme.txt\`, \`package.json\`
+          - [ ] CHANGELOG entry is accurate and dated correctly
+          - [ ] No unintended files changed
+
+          > Merge this PR to trigger the automated tag and release build.
+          EOF
+          )"

--- a/.github/workflows/build-release-branch.yml
+++ b/.github/workflows/build-release-branch.yml
@@ -212,14 +212,19 @@ jobs:
             RAW_LOG=$(git log --pretty="format:- %s" | grep -v "^- Merge " | head -100 || true)
           fi
 
-          ENTRY="## [${VERSION}] — ${DATE}\n\n${RAW_LOG}\n"
+          # Write the new entry to a temp file (printf %b expands \n properly).
+          ENTRY_FILE=$(mktemp)
+          printf "## [%s] — %s\n\n%s\n\n" "${VERSION}" "${DATE}" "${RAW_LOG}" > "${ENTRY_FILE}"
 
-          # Prepend the entry before the first existing ## heading (or at top).
-          if grep -q "^## " CHANGELOG.md 2>/dev/null; then
-            sed -i "0,/^## /{s/^## /${ENTRY}\n## /}" CHANGELOG.md
+          # Prepend: cat entry + existing CHANGELOG into a temp, then replace.
+          CHANGELOG_TMP=$(mktemp)
+          if [ -f CHANGELOG.md ]; then
+            cat "${ENTRY_FILE}" CHANGELOG.md > "${CHANGELOG_TMP}"
           else
-            printf "%b\n$(cat CHANGELOG.md)" "$ENTRY" > CHANGELOG.md
+            cp "${ENTRY_FILE}" "${CHANGELOG_TMP}"
           fi
+          mv "${CHANGELOG_TMP}" CHANGELOG.md
+          rm -f "${ENTRY_FILE}"
 
       # ── Step 7: Commit, rename branch, and push ───────────────────────────
 

--- a/.github/workflows/tag-feature-merge.yml
+++ b/.github/workflows/tag-feature-merge.yml
@@ -1,0 +1,98 @@
+name: Tag Feature Merge
+
+# Creates an annotated `merged/<branch>` tag for every merge commit pushed to
+# `develop`.  The annotation stores the PR number so the release-branch builder
+# can later look up the `release-ready` label without needing to scan commit
+# messages at that point.
+#
+# Depends on Part 1: the repo must have squash-merge disabled so that PRs land
+# as actual merge commits (two parents).  Squash commits are silently skipped.
+
+on:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Tag merged feature branches
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Tag each new merge commit
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER:  ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+
+          # Collect new commits in push order (oldest first).
+          COMMITS=$(git log --reverse --format="%H" "${BEFORE}..${AFTER}" 2>/dev/null || true)
+
+          if [ -z "$COMMITS" ]; then
+            echo "No new commits to process."
+            exit 0
+          fi
+
+          TAGGED=0
+
+          for SHA in $COMMITS; do
+            # Count parents — merge commits have exactly 2.
+            PARENT_COUNT=$(git cat-file -p "$SHA" | grep -c "^parent " || true)
+            if [ "$PARENT_COUNT" -ne 2 ]; then
+              echo "Skipping $SHA — not a merge commit (${PARENT_COUNT} parent(s))."
+              continue
+            fi
+
+            MSG=$(git log -1 --format="%s" "$SHA")
+            echo "Processing merge commit $SHA: $MSG"
+
+            # Match: "Merge pull request #NNN from owner/branch-name"
+            if ! echo "$MSG" | grep -qP '^Merge pull request #\d+ from [^/]+/.+'; then
+              echo "Skipping $SHA — commit message does not match expected merge format."
+              continue
+            fi
+
+            PR_NUMBER=$(echo "$MSG" | grep -oP '(?<=pull request #)\d+')
+            # Everything after "owner/" is the branch name.
+            BRANCH=$(echo "$MSG" | grep -oP '(?<=from )[^/]+/\K.+')
+
+            # Sanitise: keep alphanumerics, dots, hyphens, slashes; collapse
+            # anything else to a hyphen; strip leading/trailing hyphens per segment.
+            TAG_SUFFIX=$(echo "$BRANCH" \
+              | tr '[:upper:]' '[:lower:]' \
+              | sed 's/[^a-z0-9./_-]/-/g' \
+              | sed 's/-\+/-/g' \
+              | sed 's/^-//;s/-$//')
+            TAG_NAME="merged/${TAG_SUFFIX}"
+
+            # Idempotency guard — skip if tag already exists.
+            if git rev-parse --verify "refs/tags/${TAG_NAME}" >/dev/null 2>&1; then
+              echo "Tag ${TAG_NAME} already exists — skipping."
+              continue
+            fi
+
+            ANNOTATION="PR #${PR_NUMBER}: ${BRANCH}"
+            echo "Creating tag '${TAG_NAME}' at ${SHA} with annotation: ${ANNOTATION}"
+            git tag -a "${TAG_NAME}" "${SHA}" -m "${ANNOTATION}"
+            TAGGED=$((TAGGED + 1))
+          done
+
+          if [ "$TAGGED" -gt 0 ]; then
+            git push origin --tags
+            echo "Pushed ${TAGGED} new tag(s)."
+          else
+            echo "No new tags to push."
+          fi

--- a/.github/workflows/tag-release-merge.yml
+++ b/.github/workflows/tag-release-merge.yml
@@ -1,0 +1,75 @@
+name: Tag Release on Merge to Main
+
+# When a `release/vX.Y.Z` branch is merged into `main` via PR, this workflow
+# creates the corresponding `vX.Y.Z` git tag at the merge commit SHA.
+#
+# That tag triggers the existing `release.yml` workflow, which builds the plugin
+# zip and publishes the GitHub Release automatically — completing the full chain:
+#
+#   build-release-branch (dispatch)
+#     → PR to main (human approves)
+#       → this workflow creates vX.Y.Z tag
+#         → release.yml builds zip + GitHub Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create release tag
+    # Only fire when a release/* branch is actually merged (not just closed).
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          # release/v0.3.0 → 0.3.0
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/v}"
+
+          # Validate it looks like semver (X.Y.Z or X.Y.Z-suffix).
+          if ! echo "$VERSION" | grep -qP '^\d+\.\d+\.\d+'; then
+            echo "::error::Could not parse version from branch name '${BRANCH}'. Expected 'release/vX.Y.Z'."
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION"    >> "$GITHUB_OUTPUT"
+
+      - name: Guard against duplicate tag
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if git rev-parse --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists — nothing to do."
+            exit 0
+          fi
+
+      - name: Create and push release tag
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          MERGE_SHA="${{ github.event.pull_request.merge_commit_sha }}"
+
+          git fetch --tags
+          git tag "$TAG" "$MERGE_SHA"
+          git push origin "$TAG"
+          echo "Created tag $TAG at $MERGE_SHA — release.yml will now build the zip."

--- a/.github/workflows/tag-release-merge.yml
+++ b/.github/workflows/tag-release-merge.yml
@@ -57,14 +57,16 @@ jobs:
           echo "tag=v$VERSION"    >> "$GITHUB_OUTPUT"
 
       - name: Guard against duplicate tag
+        id: guard
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           if git rev-parse --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
             echo "Tag ${TAG} already exists — nothing to do."
-            exit 0
+            echo "already_exists=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create and push release tag
+        if: steps.guard.outputs.already_exists != 'true'
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           MERGE_SHA="${{ github.event.pull_request.merge_commit_sha }}"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,10 @@
+{
+  "branches": [
+    "main",
+    { "name": "release/**" }
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator"
+  ]
+}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,6 +15,72 @@ Pre-release suffixes: `-beta.1`, `-rc.1` (e.g. `v0.3.0-beta.1`)
 `0.x.y` = development phase (before WP.org stable submission)
 `1.0.0` = first stable WP.org release
 
+## Automated Feature-Grouping Workflow
+
+The standard path from `develop` → `main` is fully automated except two deliberate human decisions: applying the `release-ready` label to a PR, and approving the final release PR.
+
+### One-time repo setup
+
+Run once (requires a token with repo admin scope) to switch `develop` PRs from squash-merge to merge commits, which preserves the source branch name in history:
+
+```bash
+gh api repos/niklas-joh/wp-ai-mind \
+  --method PATCH \
+  --field allow_squash_merge=false \
+  --field allow_rebase_merge=false \
+  --field allow_merge_commit=true \
+  --field merge_commit_title=PR_TITLE \
+  --field merge_commit_message=PR_BODY
+```
+
+### Automated chain
+
+```
+feat/* branch
+  → PR to develop — CI + code review run automatically
+  → Apply release-ready label to the PR (any time — before or after merge)
+  → PR approved + merged (merge commit)
+  → tag-feature-merge.yml fires automatically:
+       creates annotated tag  merged/<branch-name>
+       annotation stores the PR number for later lookup
+
+When ready to cut a release:
+  → Run workflow_dispatch on "Build Release Branch"
+       Finds all merged/* tags whose PR has release-ready label
+       Creates release/vX.Y.Z from main, cherry-picks those commits
+       Runs semantic-release --dry-run to derive the version
+       Updates wp-ai-mind.php (×2), readme.txt, package.json, CHANGELOG.md
+       Commits "chore: release vX.Y.Z"
+       Opens PR to main
+
+  → Review and approve the release PR  ← only human step
+  → PR merged to main
+
+  → tag-release-merge.yml fires automatically:
+       creates vX.Y.Z tag at the merge commit
+  → release.yml fires automatically (triggered by tag):
+       builds plugin zip, publishes GitHub Release
+```
+
+### The `release-ready` label
+
+Apply the `release-ready` label to a PR targeting `develop` to include it in the next release. The label can be added or removed at any time — the release builder re-reads it when triggered.
+
+A PR without `release-ready` is still merged to `develop` normally and tagged with `merged/*`; it simply won't be included until the label is applied.
+
+### Tag conventions
+
+| Tag pattern | Created by | Purpose |
+|---|---|---|
+| `merged/<branch-name>` | `tag-feature-merge.yml` | Feature reference; used by release builder |
+| `v0.3.0`, `v0.3.0-beta.1` | `tag-release-merge.yml` | Triggers zip build + GitHub Release |
+
+### Emergency hotfix releases (bypass `develop`)
+
+For critical hotfixes that must go to `main` without going through `develop`, use the manual checklist below. Branch off `main` directly as `fix/short-description`, fix, PR to `main`, then backport to `develop`.
+
+---
+
 ## Release Checklist
 
 1. Bump version in 4 files: `wp-ai-mind.php` (×2), `readme.txt`, `package.json`
@@ -35,7 +101,7 @@ Pre-release suffixes: `-beta.1`, `-rc.1` (e.g. `v0.3.0-beta.1`)
 | `main` | Production-ready, always deployable |
 | `develop` | Integration branch for next release |
 | `feature/xxx` | Feature branches, merge to `develop` via PR |
-| `release/x.y.z` | Optional release prep branch off `develop` |
+| `release/vx.y.z` | Release prep branch built automatically by `build-release-branch.yml` |
 
 PRs must pass CI (PHPCS + PHPUnit + JS lint) before merge.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "marked": "^17.0.4"
   },
   "devDependencies": {
-    "@wordpress/scripts": "^30.0.0"
+    "@semantic-release/commit-analyzer": "^13.0.0",
+    "@semantic-release/release-notes-generator": "^14.0.0",
+    "@wordpress/scripts": "^30.0.0",
+    "semantic-release": "^24.0.0"
   },
   "wp-scripts-config": {
     "webpack": "./webpack.config.js"


### PR DESCRIPTION
## Summary

Implements a three-part automated feature-grouping and release management system so individual features can be selectively included in a release without squashing all pending work into every release.

- **`tag-feature-merge.yml`** — fires on every push to `develop`; detects merge commits, parses the PR number and branch name from the commit message, and creates an annotated `merged/<branch>` tag (annotation: `PR #NN: branch-name`). Idempotent — skips if the tag already exists.
- **`tag-release-merge.yml`** — fires when a `release/*` branch is merged into `main`; extracts the version from the branch name and pushes the `vX.Y.Z` tag that triggers the existing `release.yml` zip build.
- **`build-release-branch.yml`** — `workflow_dispatch`-only; collects all `merged/*` tags whose PR carries the `release-ready` label, cherry-picks those merge commits onto a new `release/vX.Y.Z` branch (version derived via `semantic-release --dry-run`), bumps all four version files, updates `CHANGELOG.md`, and opens a PR to `main`.
- **`.releaserc.json`** — minimal semantic-release config (commit-analyzer + release-notes-generator only; no publish plugins) so `--dry-run` can derive the next version without any side effects.
- **`package.json`** — adds `semantic-release` and its two required plugins as devDependencies.
- **`RELEASING.md`** — documents the full automated chain, the one-time repo settings bootstrap step (switching `develop` to merge commits), and the `release-ready` label workflow.
- **`.claude/CLAUDE.md`** — adds agent rules: never apply `release-ready` automatically, never trigger the release workflow, never touch `merged/*` tags, and how to query release state.

## Full automated chain

```
feat/* → PR to develop (merge commit) → tag-feature-merge.yml creates merged/<branch>
Human applies release-ready label → triggers build-release-branch.yml (workflow_dispatch)
→ release/vX.Y.Z branch + PR to main
Human merges → tag-release-merge.yml creates vX.Y.Z tag → release.yml builds zip
```

## Test plan

- [ ] CI passes
- [ ] `tag-feature-merge.yml`: merge a test PR to `develop` (after enabling merge commits in repo settings) → `git tag -l 'merged/*'` shows annotated tag; `git tag -v merged/<branch>` shows `PR #NN: ...` annotation
- [ ] `build-release-branch.yml`: apply `release-ready` to a merged PR → trigger manually → `release/vX.Y.Z` branch created, PR opens to `main`, all 4 version files updated, CHANGELOG prepended
- [ ] No-op guard: trigger `build-release-branch.yml` with no `release-ready` PRs → workflow exits with "No release-ready features found"
- [ ] `tag-release-merge.yml`: merge release PR to `main` → `vX.Y.Z` tag created → `release.yml` triggers

https://claude.ai/code/session_01VLrd48Bpmk8vLvpydG2wUv