### PR TITLE
fix(workflows): prevent bot-created issues from triggering claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,13 @@ on:
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    if: >
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Fixes a feedback loop where `claude-code-review.yml` indirectly triggered `claude.yml` on every PR that touched workflow files, causing a 0s failure with no log output.

**Root cause:** `claude-code-review.yml` creates GitHub issues for security findings. When Claude reviews workflow files it consistently creates an issue describing the "`workflows: write` permission exposed to untrusted `@claude` trigger" vulnerability (evidence: issue #44). That issue body contains the literal string `@claude`. This fires the `issues: opened` event → `claude.yml` triggers → `contains(github.event.issue.body, '@claude')` evaluates to **TRUE** → the `claude` job runs → the `claude-code-action` fails immediately in its pre-step (built-in loop-prevention rejects bot-originated triggers before any logs are written).

**Fix:** Add `github.event.sender.type != 'Bot'` as the first guard in the `if` condition. `sender.type` is `'Bot'` for all GitHub Apps (`claude[bot]`, `github-actions[bot]`, `dependabot[bot]`) and `'User'` for human accounts. Also switches the multi-line scalar from `|` (literal) to `>` (folded) to avoid trailing-newline ambiguity in expression evaluation.

## Test plan

- [ ] CI passes
- [ ] Push a PR that touches workflow files → `claude-code-review.yml` runs and may create an issue mentioning `@claude` → `claude.yml` is triggered but the `claude` job is now **skipped** (not failed) → Actions tab shows green
- [ ] Comment `@claude what changed?` on any PR → `claude.yml` triggers and the job **runs** (human sender, condition passes)

https://claude.ai/code/session_01VLrd48Bpmk8vLvpydG2wUv