### PR TITLE
fix(workflows): apply auto-fix label in separate step to trigger auto-fix workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -85,11 +85,17 @@ jobs:
 
             Example command for a blocking issue:
 
-              gh issue create \
+              ISSUE_URL=$(gh issue create \
                 --title "<concise title for the finding>" \
                 --body "Found during review of PR #${{ github.event.pull_request.number }}\n\n**PR:** ${{ github.event.pull_request.html_url }}\n**Base branch:** ${{ github.event.pull_request.base.ref }}\n\n## Description\n\n<details>" \
-                --label "code-review,blocking,auto-fix" \
-                --repo ${{ github.repository }}
+                --label "code-review,blocking" \
+                --repo ${{ github.repository }})
+              ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+              gh issue edit "$ISSUE_NUMBER" --add-label "auto-fix" --repo ${{ github.repository }}
+
+            The two-step label approach is required: labels applied at issue creation do not
+            fire the `issues: labeled` event, so the auto-fix workflow would never trigger.
+            Adding `auto-fix` in a separate `gh issue edit` call fires that event correctly.
 
             Capture the URL returned by each `gh issue create` call.
 


### PR DESCRIPTION
## Summary

Fixes the `auto-fix-review-issue.yml` workflow never being triggered by issues created during code review.

**Root cause:** `gh issue create --label "...,auto-fix"` applies all labels atomically at creation. GitHub only fires the `issues: labeled` event when a label is added to an *already-open* issue — labels applied at creation only fire `issues: opened`. Since `auto-fix-review-issue.yml` triggers on `issues: labeled` where `label.name == 'auto-fix'`, it was silently never invoked.

**Fix:** Split into two steps for blocking issues:
1. `gh issue create` with `code-review,blocking` only
2. `gh issue edit --add-label "auto-fix"` — this fires `issues: labeled` and correctly triggers the auto-fix workflow

Also adds an inline comment in the prompt explaining the reason, so future edits don't accidentally collapse it back to one step.

## Test plan

- [ ] CI passes
- [ ] Open a PR with a blocking finding → code-review workflow runs → issue created → `auto-fix` label applied via separate `gh issue edit` → `auto-fix-review-issue.yml` triggers and Claude opens a fix PR

https://claude.ai/code/session_01VLrd48Bpmk8vLvpydG2wUv