### PR TITLE
fix(ci): skip lockfile PRs and make Claude Code Review non-blocking

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,11 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    paths-ignore:
+      - "package-lock.json"
+      - "composer.lock"
+      - "yarn.lock"
+      - "*.lock"
 
 jobs:
   claude-review:
@@ -17,8 +16,9 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+
     runs-on: ubuntu-latest
+    continue-on-error: true  # review is informational; never block merges
     permissions:
       contents: read
       pull-requests: write
@@ -85,11 +85,17 @@ jobs:
 
             Example command for a blocking issue:
 
-              gh issue create \
+              ISSUE_URL=$(gh issue create \
                 --title "<concise title for the finding>" \
                 --body "Found during review of PR #${{ github.event.pull_request.number }}\n\n**PR:** ${{ github.event.pull_request.html_url }}\n**Base branch:** ${{ github.event.pull_request.base.ref }}\n\n## Description\n\n<details>" \
-                --label "code-review,blocking,auto-fix" \
-                --repo ${{ github.repository }}
+                --label "code-review,blocking" \
+                --repo ${{ github.repository }})
+              ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+              gh issue edit "$ISSUE_NUMBER" --add-label "auto-fix" --repo ${{ github.repository }}
+
+            The two-step label approach is required: labels applied at issue creation do not
+            fire the `issues: labeled` event, so the auto-fix workflow would never trigger.
+            Adding `auto-fix` in a separate `gh issue edit` call fires that event correctly.
 
             Capture the URL returned by each `gh issue create` call.
 
@@ -110,4 +116,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
           claude_args: "--allowedTools Bash(gh:*),Read,Glob,Grep"
-


### PR DESCRIPTION
## Summary

- Add `paths-ignore` for lock files so trivial dependency-sync PRs skip the AI review entirely
- Add `continue-on-error: true` so validation/auth failures never block merges (review is informational)
- Sync the two-step auto-fix labeling approach to `main` — this was added in PR #78 but never landed here, causing `anthropics/claude-code-action`'s security validation to fail on every PR

## Root Cause

`anthropics/claude-code-action` validates that the workflow file on the PR's HEAD branch is byte-for-byte identical to `main`. The two-step labeling change from PR #78 was never synced to `main`, so every PR (including the trivial package-lock.json sync in #92) failed with: _"Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch."_

## Test Plan

- [ ] This PR has only 1 file changed (`claude-code-review.yml`) — verify the diff
- [ ] The Claude Code Review check on this PR should pass or be neutral (due to `continue-on-error: true`)
- [ ] After merge, future PR branches will pass the workflow validation check

https://claude.ai/code/session_01RNbLZQ4n37s47XqCL8nzjV