### PR TITLE
fix(workflows): remove invalid 'workflows: write' permission from claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,7 +24,6 @@ jobs:
       issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
-      workflows: write # Required for Claude to create or update workflow files
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4


### PR DESCRIPTION
'workflows' is not a valid key in the GitHub Actions permissions block —
it caused a workflow validation failure on every run, meaning @claude
mentions have never triggered a response since PR #43.

'contents: write' already covers writing workflow files.

https://claude.ai/code/session_0146GhQBS9fwkWouHGgx8Kd3