### PR TITLE
fix(workflows): pin actions/github-script to full commit SHA (closes #65)

### DIFF
--- a/.github/workflows/nightly-sync.yml
+++ b/.github/workflows/nightly-sync.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Create and close conflict PR
         if: steps.merge.outputs.status == 'conflict' && steps.complete.outputs.resolved == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const { owner, repo } = context.repo;


### PR DESCRIPTION
Replace floating `actions/github-script@v7` tag with the pinned SHA
`f28e40c7f34bde8b3046d885e986cb6290c5673b` for supply-chain security,
consistent with other actions in this repo.