### PR TITLE
fix(workflow): remove auto-fix from initial issue labels to prevent duplicate labeling

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -66,7 +66,7 @@ jobs:
             security concern, missing test coverage), create a GitHub issue.
 
             Classify each finding:
-            - **blocking** (bug, security flaw, data loss risk) → labels: `code-review,blocking,auto-fix`
+            - **blocking** (bug, security flaw, data loss risk) → labels: `code-review,blocking`
             - **improvement** (non-trivial refactor, missing tests, performance) → labels: `code-review,enhancement`
             - **nit/style** → no issue, PR comment only
 


### PR DESCRIPTION
The classification table told Claude to include `auto-fix` in the `gh issue create
--label` argument for blocking findings. The example command already correctly
omitted `auto-fix` at creation time and added it only via a separate `gh issue edit`
call (which fires the `issues: labeled` event). The table and the example were
inconsistent, causing Claude to apply `auto-fix` twice.

Removing `auto-fix` from the classification table makes it consistent with the
example and ensures the label is only applied once, via the event-triggering
`gh issue edit` step.

Closes #34

https://claude.ai/code/session_01DZXhiZU9TXJfJssV7zLvCw