### PR TITLE
fix(seo): disable Generate button during confirm and add alertdialog role

### DIFF
--- a/src/seo/SeoWorkArea.jsx
+++ b/src/seo/SeoWorkArea.jsx
@@ -99,7 +99,7 @@ export default function SeoWorkArea( { post, onClose, onUpdate } ) {
 				<button
 					className="button button-primary"
 					onClick={ handleGenerate }
-					disabled={ generating }
+					disabled={ generating || confirmReplace }
 				>
 					{ generating ? (
 						<>
@@ -113,11 +113,17 @@ export default function SeoWorkArea( { post, onClose, onUpdate } ) {
 			</div>
 
 			{ confirmReplace && (
-				<div className="wpaim-confirm-replace">
+				<div
+					className="wpaim-confirm-replace"
+					role="alertdialog"
+					aria-live="assertive"
+					aria-label="Replace confirmation"
+				>
 					<span>Replace current suggestions?</span>
 					<button
 						className="button button-small"
 						onClick={ handleGenerate }
+						autoFocus
 					>
 						Yes, replace
 					</button>

--- a/src/seo/SeoWorkArea.jsx
+++ b/src/seo/SeoWorkArea.jsx
@@ -1,4 +1,4 @@
-import { useState } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { Loader2 } from 'lucide-react';
 import DOMPurify from 'dompurify';
@@ -19,6 +19,14 @@ export default function SeoWorkArea( { post, onClose, onUpdate } ) {
 	const [ generating, setGenerating ] = useState( false );
 	const [ applying, setApplying ] = useState( false );
 	const [ error, setError ] = useState( null );
+
+	const yesButtonRef = useRef( null );
+
+	useEffect( () => {
+		if ( confirmReplace && yesButtonRef.current ) {
+			yesButtonRef.current.focus();
+		}
+	}, [ confirmReplace ] );
 
 	const editUrl = `${ adminUrl }post.php?post=${ post.id }&action=edit`;
 
@@ -123,7 +131,7 @@ export default function SeoWorkArea( { post, onClose, onUpdate } ) {
 					<button
 						className="button button-small"
 						onClick={ handleGenerate }
-						autoFocus
+						ref={ yesButtonRef }
 					>
 						Yes, replace
 					</button>

--- a/src/shared/PostListTable.jsx
+++ b/src/shared/PostListTable.jsx
@@ -45,7 +45,8 @@ export default function PostListTable( { tabs, WorkArea, columns = [] } ) {
 							} ).then( ( r ) => r.json() )
 						);
 					}
-					const remainingData = await Promise.all( remainingRequests );
+					const remainingData =
+						await Promise.all( remainingRequests );
 					return [ firstData, ...remainingData ].flat();
 				};
 


### PR DESCRIPTION
## Summary

Fixes #29

Originally reported during review of PR #27. Replaces #76 (which contained 16 unrelated commits).

- **Generate button bypass**: Added `disabled={generating || confirmReplace}` to the Generate button so it cannot be clicked while the confirmation banner is visible, preventing the guard condition from being satisfied without the explicit "Yes, replace" confirmation.
- **Accessibility**: Added `role="alertdialog"`, `aria-live="assertive"`, and `aria-label="Replace confirmation"` to the confirmation container. Added `autoFocus` to the "Yes, replace" button so keyboard and screen-reader users are immediately notified and focused when the banner appears.

## Test plan

- [ ] CI passes
- [ ] Click Generate → fields populate → click Generate again → confirmation appears → Generate button is now disabled/greyed out
- [ ] Clicking "Yes, replace" triggers a new generation; "Cancel" dismisses the banner and re-enables Generate
- [ ] Tab through the UI with keyboard: when confirmation appears, focus moves to the "Yes, replace" button
- [ ] Screen reader announces the alertdialog when it appears