### PR TITLE
feat(settings): check env vars before DB for provider API keys

### DIFF
--- a/includes/Settings/ProviderSettings.php
+++ b/includes/Settings/ProviderSettings.php
@@ -7,6 +7,11 @@ class ProviderSettings {
 	private const OPTION_KEY      = 'wp_ai_mind_provider_keys';
 	private const CIPHER          = 'AES-256-CBC';
 	private const VALID_PROVIDERS = [ 'claude', 'openai', 'gemini', 'ollama' ];
+	private const ENV_VARS        = [
+		'claude' => 'CLAUDE_API_KEY',
+		'openai' => 'OPENAI_API_KEY',
+		'gemini' => 'GEMINI_API_KEY',
+	];
 
 	private array $keys;
 
@@ -16,6 +21,14 @@ class ProviderSettings {
 	}
 
 	public function get_api_key( string $provider ): string {
+		$env_var = self::ENV_VARS[ $provider ] ?? null;
+		if ( $env_var ) {
+			$env_value = getenv( $env_var );
+			if ( false !== $env_value && '' !== $env_value ) {
+				return $env_value;
+			}
+		}
+
 		if ( ! isset( $this->keys[ $provider ] ) ) {
 			return '';
 		}

--- a/tests/Unit/Settings/ProviderSettingsTest.php
+++ b/tests/Unit/Settings/ProviderSettingsTest.php
@@ -37,6 +37,40 @@ class ProviderSettingsTest extends TestCase {
         $this->assertSame( 'sk-ant-test-key', $settings2->get_api_key( 'claude' ) );
     }
 
+    public function test_env_var_takes_priority_over_db_value(): void {
+        $stored = [];
+        Functions\when( 'get_option' )->alias( function( $k, $d = null ) use ( &$stored ) { return $stored[ $k ] ?? $d; } );
+        Functions\when( 'update_option' )->alias( function( $k, $v ) use ( &$stored ) {
+            $stored[ $k ] = $v;
+            return true;
+        } );
+
+        $settings = new ProviderSettings();
+        $settings->set_api_key( 'claude', 'sk-ant-from-db' );
+
+        putenv( 'CLAUDE_API_KEY=sk-ant-from-env' );
+        $settings2 = new ProviderSettings();
+        $this->assertSame( 'sk-ant-from-env', $settings2->get_api_key( 'claude' ) );
+
+        putenv( 'CLAUDE_API_KEY' ); // clean up.
+    }
+
+    public function test_falls_back_to_db_when_env_var_not_set(): void {
+        $stored = [];
+        Functions\when( 'get_option' )->alias( function( $k, $d = null ) use ( &$stored ) { return $stored[ $k ] ?? $d; } );
+        Functions\when( 'update_option' )->alias( function( $k, $v ) use ( &$stored ) {
+            $stored[ $k ] = $v;
+            return true;
+        } );
+
+        putenv( 'CLAUDE_API_KEY' ); // ensure unset.
+        $settings = new ProviderSettings();
+        $settings->set_api_key( 'claude', 'sk-ant-from-db' );
+
+        $settings2 = new ProviderSettings();
+        $this->assertSame( 'sk-ant-from-db', $settings2->get_api_key( 'claude' ) );
+    }
+
     public function test_api_key_is_not_stored_in_plaintext(): void {
         $stored = [];
         Functions\when( 'get_option' )->alias( function( $k, $d = null ) use ( &$stored ) { return $stored[ $k ] ?? $d; } );


### PR DESCRIPTION
Adds a CLAUDE_API_KEY (and OPENAI_API_KEY / GEMINI_API_KEY) environment-
variable lookup at the top of get_api_key(). When the env var is set and
non-empty it takes priority over the encrypted database value, making it
easy to inject keys in CI or containerised environments without touching
the WordPress admin.

https://claude.ai/code/session_0136AHRscX4mv3hFmpFgyJcg