### PR TITLE
fix(review): use PAT so auto-fix label fires issues:labeled event

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,6 +50,12 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         id: claude-review
         uses: anthropics/claude-code-action@aee99972d0cfa0c47a4563e6fca42d7a5a0cb9bd  # v1
+        env:
+          # Use a PAT so that `gh issue edit --add-label auto-fix` fires the
+          # issues:labeled webhook event. GITHUB_TOKEN is silently blocked from
+          # triggering new workflow runs (GitHub anti-loop protection), which
+          # would prevent auto-fix-review-issue.yml from ever starting.
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |


### PR DESCRIPTION
## Summary

- Adds `GH_TOKEN: ${{ secrets.GH_PAT }}` to the `Run Claude Code Review` step in `claude-code-review.yml`

## Root cause

GitHub's `GITHUB_TOKEN` is intentionally blocked from triggering new workflow runs (anti-loop protection). When `claude-code-review.yml` called `gh issue edit --add-label "auto-fix"`, the `issues: labeled` webhook event was silently suppressed — so `auto-fix-review-issue.yml` never started and the issue was never fixed (as seen in #108).

Setting `GH_TOKEN` to a PAT makes the label API call look like a regular user action, which fires the webhook correctly.

## Prerequisite (manual step)

A repository secret named `GH_PAT` with `repo` scope must be created in Settings → Secrets and variables → Actions if it doesn't already exist.

## Test plan

- [ ] Add the `GH_PAT` secret to the repo (if not already present)
- [ ] Merge this PR
- [ ] Open a new PR to trigger `claude-code-review.yml`
- [ ] Confirm that when the `auto-fix` label is applied to a created issue, the `Auto-fix Code Review Issues` workflow starts within ~1 minute

https://claude.ai/code/session_011APn2SAWGB2BkC6EoLx9Kv