### PR TITLE
fix: add @wordpress/element as peer dependency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
+	rules: {
+		// @wordpress/* packages are provided by WordPress core at runtime and
+		// externalized by @wordpress/scripts webpack. They are not installed as
+		// npm packages, so the module resolver cannot find them.
+		'import/no-unresolved': [ 'error', { ignore: [ '^@wordpress/' ] } ],
+	},
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "lucide-react": "^0.474.0",
     "marked": "^17.0.4"
   },
+  "peerDependencies": {
+    "@wordpress/element": ">=6.0.0"
+  },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/release-notes-generator": "^14.0.0",

--- a/src/seo/SeoWorkArea.jsx
+++ b/src/seo/SeoWorkArea.jsx
@@ -131,8 +131,8 @@ export default function SeoWorkArea( { post, onClose, onUpdate } ) {
 					<button
 						className="button button-small"
 						onClick={ handleGenerate }
-					ref={ yesButtonRef }
-				>
+						ref={ yesButtonRef }
+					>
 						Yes, replace
 					</button>
 					<button


### PR DESCRIPTION
## Summary

Two ESLint lint errors have been blocking CI on every run:

- **`import/no-extraneous-dependencies`** — `@wordpress/element` was used across source files but not declared in `package.json`. Fixed by adding it to `peerDependencies` (it's a WordPress core runtime global, externalized by `@wordpress/scripts` webpack).
- **`import/no-unresolved`** — `@wordpress/api-fetch`, `@wordpress/components`, `@wordpress/data`, etc. are WordPress core externals that are never installed as npm packages, so the ESLint module resolver can't find them. Fixed by adding `.eslintrc.js` with `ignore: ['^@wordpress/']` for that rule.

## Test plan

- [ ] `npm run lint:js` passes with no `import/no-extraneous-dependencies` or `import/no-unresolved` errors
- [ ] `npm run build` completes successfully