### PR TITLE
fix(claude): correct PR base branch rule and add enforcement hook

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,7 +34,7 @@ the compiled `assets/` whenever `src/` files are committed. No manual build step
 
 ### Pull Request Rules
 
-- Every PR targets `main` (default base branch).
+- Feature/fix/chore PRs target `develop`. Only hotfixes and `release/vX.Y.Z` branches target `main` directly (see "PR targets" section below).
 - PR title must follow Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`.
 - Include a short summary and a test plan in the PR body.
 - Request review before merging — do not self-merge without explicit user instruction.

--- a/.claude/hooks/pre-tool-use-pr-base-check.sh
+++ b/.claude/hooks/pre-tool-use-pr-base-check.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# PreToolUse hook: block mcp__github__create_pull_request if base=main for non-release branches.
+# Feature/fix/chore PRs must target 'develop'. Only release/* and hotfix branches go to main.
+
+input=$(cat)
+tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+
+if [[ "$tool_name" != "mcp__github__create_pull_request" ]]; then
+  exit 0
+fi
+
+base=$(echo "$input" | jq -r '.tool_input.base // empty')
+head=$(echo "$input" | jq -r '.tool_input.head // empty')
+
+if [[ "$base" == "main" && ! "$head" =~ ^release/ ]]; then
+  echo "BLOCKED: PRs for feature/fix/chore branches must target 'develop', not 'main'." >&2
+  echo "Change the 'base' parameter to 'develop' before creating this PR." >&2
+  echo "Only 'release/vX.Y.Z' branches (and emergency hotfixes) target 'main' directly." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,5 +12,18 @@
       "mcp__github__list_issues",
       "mcp__github__search_issues"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__github__create_pull_request",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-tool-use-pr-base-check.sh"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
CLAUDE.md line 37 contradicted line 112 — it said "Every PR targets main" while the Feature-Grouping section correctly says "Feature PRs target develop". Claude read the first rule and followed it literally, causing PR #107 to target main instead of develop.

Changes:
- Fix CLAUDE.md: clarify that feature/fix/chore PRs target develop, only release/* branches and hotfixes target main directly
- Add PreToolUse hook (.claude/hooks/pre-tool-use-pr-base-check.sh) that blocks mcp__github__create_pull_request when base=main and head is not a release/ branch
- Register the hook in .claude/settings.json

https://claude.ai/code/session_016PxoxvAUb9txKyYj7mSp1t