### PR TITLE
fix(workflows): handle Conventional Commits merge message format in tag-feature-merge

### DIFF
--- a/.github/workflows/backfill-merged-tags.yml
+++ b/.github/workflows/backfill-merged-tags.yml
@@ -1,0 +1,88 @@
+name: Backfill merged/* Tags (one-shot)
+
+# Run once manually to create merged/* tags for all historical merge commits
+# on develop that were missed before tag-feature-merge.yml was fixed.
+# Safe to re-run: tags are only created if they don't already exist.
+# DELETE THIS WORKFLOW after it has been successfully run.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  backfill:
+    name: Create missing merged/* tags
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create backfill tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          sanitize_branch() {
+            echo "$1" | tr '[:upper:]' '[:lower:]' \
+              | sed 's/[^a-z0-9./_-]/-/g' \
+              | sed 's/-\+/-/g' \
+              | sed 's/^-//;s/-$//'
+          }
+
+          create_tag() {
+            local SHA="$1" PR="$2" BRANCH="$3"
+            local SUFFIX TAG ANNOTATION
+            SUFFIX=$(sanitize_branch "$BRANCH")
+            TAG="merged/${SUFFIX}"
+            ANNOTATION="PR #${PR}: ${BRANCH}"
+            if git rev-parse --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+              echo "SKIP (exists): ${TAG}"
+            else
+              git tag -a "${TAG}" "${SHA}" -m "${ANNOTATION}"
+              echo "CREATED: ${TAG} → ${SHA}"
+            fi
+          }
+
+          # PR #1 & #2 — old GitHub-default merge message format
+          create_tag 82efed259767bbe2945899bcec9b6329ad1ec72a   1 "claude/sharp-spence"
+          create_tag 0e1979fccf2715d03802097c43bc79488a50a0a6   2 "add-claude-github-actions-1774700440038"
+
+          # Conventional-Commits format merges (oldest → newest)
+          create_tag 8e8c1b293122354427385572137e3c6f4a6a6b43  47 "dependabot/npm_and_yarn/npm_and_yarn-8383658b49"
+          create_tag cd510d41a8f6c94780af0f63eb5d3bfbded76fd3  50 "fix/wp-admin-light-palette"
+          create_tag 1d7f2c618a09941e0ae9de84a19a9e71c2aec385  71 "fix/issue-68-sanitize-html-url-interpolation"
+          create_tag 0911459e36d9598ad6cf991db70b59669f6b48f3  72 "fix/issue-23-postlisttable-parse-false-error"
+          create_tag 594df7a5d9f2cf03e360f7ec61480d1a2b6da08d  73 "fix/issue-30-seo-exception-leak"
+          create_tag 6d24b227ad7b89ea6eba83a7337a7bc9efdd6858  74 "fix/issue-35-hardcoded-en-gb-locale"
+          create_tag 957891099d5c4b26c09689f1b9489351273741a6  75 "fix/issue-31-seo-status-extra-db-queries"
+          create_tag fc557a3801f5d8c1b965cb2021d4c39cf687d3bb  77 "fix/issue-26-postlisttable-pagination"
+          create_tag 4fe38284cb7950d38b7a24cff42cca0f7648f9a6  78 "feat/feature-grouping-release-system"
+          create_tag efcc6894832d2dfdb5435180bd9ee45efaf25b2e  79 "fix/claude-yml-bot-sender-guard"
+          create_tag 3fb7ef81bae6dcaef969f4ccb2c502a4fe7e5580  91 "fix/auto-fix-label-trigger"
+          create_tag 3e81721754b57b1840b213459a21ea8825393951  92 "claude-auto-fix-ci-develop"
+          create_tag a0e343d551a4ceab098bed7b1121e8d705922b18  94 "fix/claude-code-review-non-blocking"
+          create_tag caf25a927f260566c4b2c84089a0d79b7ec228d7  95 "claude/debug-workflow-issue-NvqDM"
+          create_tag 459a55e71e4f9c40caababd3256abbce6996824c  96 "claude/fix-issue-65-HTu1r"
+          create_tag 0b891c63485d79a2111bec6bdba019b15b850eea  99 "claude/push-workflow-fix-NcCSw"
+          create_tag 8d382ce17fbb19bce952675e9f11d16e16b4dcf2 101 "claude/fix-duplicate-autolabel-34HEx"
+          create_tag 0c75348291e2045e373c5bc3c8be9f2eeec551f7 102 "fix/issue-29-seoworkarea-confirm-ux-clean"
+          create_tag 622b500de6395dcfc4d2f7c969a701bc9e2d98ee 103 "claude/fix-workflow-validation-KapDF"
+          create_tag cba75d94f4dfd0ba0cf86019d09ab415363881f8 107 "claude/api-key-env-fallback-XIeCp"
+          create_tag 23072366f5320a7cfd5383dd0e87d5121d363cca 110 "fix/auto-fix-pat-token"
+          create_tag 634fd5e3d25a610957baa688ffa88f5e13a5ad95 111 "claude/fix-pr-base-branch-2pTEQ"
+          create_tag 7bafa81003aec175e0bf4973aca39bc5146316b5 112 "claude/fix-wordpress-element-dep-lDeAB"
+          create_tag bc800f734792fa7ade28f052fcdb63a50caef5b8 113 "fix/pr-base-branch-rule"
+
+          git push origin --tags
+          echo "Backfill complete."

--- a/.github/workflows/tag-feature-merge.yml
+++ b/.github/workflows/tag-feature-merge.yml
@@ -35,6 +35,7 @@ jobs:
         env:
           BEFORE: ${{ github.event.before }}
           AFTER:  ${{ github.event.after }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -59,15 +60,26 @@ jobs:
             MSG=$(git log -1 --format="%s" "$SHA")
             echo "Processing merge commit $SHA: $MSG"
 
-            # Match: "Merge pull request #NNN from owner/branch-name"
-            if ! echo "$MSG" | grep -qP '^Merge pull request #\d+ from [^/]+/.+'; then
-              echo "Skipping $SHA — commit message does not match expected merge format."
+            # Format 1 (GitHub default): "Merge pull request #NNN from owner/branch-name"
+            if echo "$MSG" | grep -qP '^Merge pull request #\d+ from [^/]+/.+'; then
+              PR_NUMBER=$(echo "$MSG" | grep -oP '(?<=pull request #)\d+')
+              # Everything after "owner/" is the branch name.
+              BRANCH=$(echo "$MSG" | grep -oP '(?<=from )[^/]+/\K.+')
+
+            # Format 2 (Conventional Commits): "description (#NNN)"
+            elif echo "$MSG" | grep -qP '\(#\d+\)$'; then
+              PR_NUMBER=$(echo "$MSG" | grep -oP '(?<=\(#)\d+(?=\)$)')
+              # Fetch branch name from GitHub API since it's not in the commit message.
+              BRANCH=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName --jq '.headRefName' 2>/dev/null || true)
+              if [ -z "$BRANCH" ]; then
+                echo "Could not determine branch name for PR #${PR_NUMBER} — skipping."
+                continue
+              fi
+
+            else
+              echo "Skipping $SHA — commit message format not recognized."
               continue
             fi
-
-            PR_NUMBER=$(echo "$MSG" | grep -oP '(?<=pull request #)\d+')
-            # Everything after "owner/" is the branch name.
-            BRANCH=$(echo "$MSG" | grep -oP '(?<=from )[^/]+/\K.+')
 
             # Sanitise: keep alphanumerics, dots, hyphens, slashes; collapse
             # anything else to a hyphen; strip leading/trailing hyphens per segment.


### PR DESCRIPTION
The workflow was silently skipping all merge commits because the repo
uses PR titles (Conventional Commits format) as merge commit messages,
e.g. "fix(scope): description (#113)", rather than GitHub's default
"Merge pull request #NNN from owner/branch-name" format.

Add a second pattern that extracts the PR number from (#NNN) at the
end of the commit subject and then fetches the source branch name via
the GitHub API (gh pr view) since it is not present in the message.
The original pattern is retained for any legacy-format merges.

https://claude.ai/code/session_01J4XqBDRZivC2R8N9CBvFiL