### PR TITLE
fix(release): add id-token: write permission for claude-code-action

### DIFF
--- a/.github/workflows/build-release-branch.yml
+++ b/.github/workflows/build-release-branch.yml
@@ -26,6 +26,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Adds `id-token: write` to the `build-release-branch.yml` permissions block, required by `anthropics/claude-code-action` for OIDC authentication
- The rest of the conflict-resolution feature (Claude step, Node.js 22 bump) was already merged in #143

## Test plan
- [ ] Trigger `Build Release Branch` with no conflicting PRs — workflow should complete without the OIDC error
- [ ] Trigger with a conflicting cherry-pick — Claude step should resolve and complete