### PR TITLE
fix(release): make conflict-resolution status check resilient (hotfix)

### DIFF
--- a/.github/workflows/build-release-branch.yml
+++ b/.github/workflows/build-release-branch.yml
@@ -234,12 +234,32 @@ jobs:
       - name: Check conflict resolution status
         if: steps.cherry_pick.outputs.conflict == 'true'
         run: |
-          STATUS=$(cat /tmp/cherry-pick-status.txt 2>/dev/null || echo "failed: Claude did not write a status")
+          set -euo pipefail
+          STATUS_FILE=/tmp/cherry-pick-status.txt
+
+          if [ -f "$STATUS_FILE" ]; then
+            STATUS=$(cat "$STATUS_FILE")
+            echo "Resolution status (from file): $STATUS"
+          else
+            # Claude didn't write the status file — derive result from git state.
+            echo "Note: $STATUS_FILE not found — checking git state directly."
+            if [ -f .git/CHERRY_PICK_HEAD ]; then
+              STATUS="failed: cherry-pick still in progress after Claude action"
+            elif git diff --name-only --diff-filter=U 2>/dev/null | grep -q .; then
+              UNRESOLVED=$(git diff --name-only --diff-filter=U 2>/dev/null | head -5 | tr '\n' ' ')
+              STATUS="failed: unresolved conflicts remain in: ${UNRESOLVED}"
+            else
+              STATUS="completed"
+              echo "Git state is clean — treating conflict resolution as completed."
+            fi
+          fi
+
           echo "Resolution status: $STATUS"
           if [ "$STATUS" != "completed" ]; then
             echo "::error::Cherry-pick conflict resolution failed — $STATUS"
             exit 1
           fi
+          echo "All conflicts resolved successfully."
 
       # ── Step 4: Determine version with semantic-release (dry-run) ─────────
 


### PR DESCRIPTION
## Problem

`Build Release Branch` fails with:

> Cherry-pick conflict resolution failed — failed: Claude did not write a status

The `Check conflict resolution status` step reads `/tmp/cherry-pick-status.txt` and uses a hardcoded fallback error if the file is missing. Claude can successfully resolve all conflicts and complete the cherry-pick chain, but if it doesn't write that final status file (tool-budget exhaustion, model interruption, etc.) the whole workflow fails despite the work being done correctly.

## Fix

The step now falls back to inspecting actual git state when the file is absent:

| Git state after Claude action | Result |
|---|---|
| `.git/CHERRY_PICK_HEAD` present | `failed` — cherry-pick still in progress |
| `git diff --diff-filter=U` has unresolved files | `failed` — lists the conflicting files |
| Git is clean | `completed` — conflicts were resolved |

The status file is still honoured if Claude writes it — this only activates as a fallback.

## Test plan

- [ ] CI passes on this PR
- [ ] After merging, trigger `Build Release Branch` — the conflict-resolution step passes even if Claude omits the status file write
- [ ] If conflicts remain unresolved, the step still fails with a descriptive message

https://claude.ai/code/session_01LGJ67xdGa9ZPB8ugNZ1nG8