### PR TITLE
chore(claude): update PR base-check hook for direct-to-main workflow

### DIFF
--- a/.claude/hooks/pre-tool-use-pr-base-check.sh
+++ b/.claude/hooks/pre-tool-use-pr-base-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# PreToolUse hook: block mcp__github__create_pull_request if base=main for non-release branches.
-# Feature/fix/chore PRs must target 'develop'. Only release/* and hotfix branches go to main.
+# PreToolUse hook: validate mcp__github__create_pull_request base branch.
+# All PRs (feat/fix/chore) target 'main' directly. There is no develop branch.
 
 input=$(cat)
 tool_name=$(echo "$input" | jq -r '.tool_name // empty')
@@ -10,12 +10,10 @@ if [[ "$tool_name" != "mcp__github__create_pull_request" ]]; then
 fi
 
 base=$(echo "$input" | jq -r '.tool_input.base // empty')
-head=$(echo "$input" | jq -r '.tool_input.head // empty')
 
-if [[ "$base" == "main" && ! "$head" =~ ^release/ && ! "$head" =~ ^hotfix/ ]]; then
-  echo "BLOCKED: PRs for feature/fix/chore branches must target 'develop', not 'main'." >&2
-  echo "Change the 'base' parameter to 'develop' before creating this PR." >&2
-  echo "Only 'release/vX.Y.Z' branches (and emergency hotfixes) target 'main' directly." >&2
+if [[ "$base" != "main" ]]; then
+  echo "BLOCKED: All PRs must target 'main', not '$base'." >&2
+  echo "Change the 'base' parameter to 'main' before creating this PR." >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Summary

- Updates `.claude/hooks/pre-tool-use-pr-base-check.sh` to enforce the new direct-to-main workflow
- Previously the hook blocked any non-release branch from targeting `main`; now it blocks any PR that does NOT target `main`
- Removes the `head` branch variable (no longer needed) and the `release/` / `hotfix/` exceptions

## Test plan

- [ ] Try creating a PR with `base: develop` — should be blocked
- [ ] Try creating a PR with `base: main` — should pass through