### PR TITLE
fix(tests): guard putenv cleanup with try/finally

### DIFF
--- a/tests/Unit/Settings/ProviderSettingsTest.php
+++ b/tests/Unit/Settings/ProviderSettingsTest.php
@@ -49,10 +49,12 @@ class ProviderSettingsTest extends TestCase {
         $settings->set_api_key( 'claude', 'sk-ant-from-db' );
 
         putenv( 'CLAUDE_API_KEY=sk-ant-from-env' );
-        $settings2 = new ProviderSettings();
-        $this->assertSame( 'sk-ant-from-env', $settings2->get_api_key( 'claude' ) );
-
-        putenv( 'CLAUDE_API_KEY' ); // clean up.
+        try {
+            $settings2 = new ProviderSettings();
+            $this->assertSame( 'sk-ant-from-env', $settings2->get_api_key( 'claude' ) );
+        } finally {
+            putenv( 'CLAUDE_API_KEY' ); // clean up even if assertion fails.
+        }
     }
 
     public function test_falls_back_to_db_when_env_var_not_set(): void {


### PR DESCRIPTION
## Summary

- Wraps the `putenv` assertion in `ProviderSettingsTest` with a `try/finally` block so the env var is always cleaned up even when the assertion fails, preventing test pollution in subsequent runs.

## Test plan

- [ ] `composer test` passes cleanly
- [ ] Manually break the assertion inside the block and confirm `CLAUDE_API_KEY` is unset afterward

Closes #108