### PR TITLE
fix(chat): return full conversation on create; 500 on DB failure

### DIFF
--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -126,8 +126,17 @@ class ChatRestController {
 	}
 
 	public function list_conversations( \WP_REST_Request $request ): \WP_REST_Response { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by WP_REST_Server callback signature.
-		$store = $this->make_store();
-		return rest_ensure_response( $store->list_for_user( get_current_user_id() ) );
+		$store         = $this->make_store();
+		$conversations = $store->list_for_user( get_current_user_id() );
+		$response      = array_map(
+			fn( $c ) => [
+				'id'         => (int) $c['id'],
+				'title'      => $c['title'],
+				'updated_at' => $c['updated_at'],
+			],
+			$conversations
+		);
+		return rest_ensure_response( $response );
 	}
 
 	public function create_conversation( \WP_REST_Request $request ): \WP_REST_Response {
@@ -144,7 +153,11 @@ class ChatRestController {
 		if ( null === $conversation ) {
 			return new \WP_REST_Response( [ 'message' => __( 'Failed to retrieve conversation.', 'wp-ai-mind' ) ], 500 );
 		}
-		return rest_ensure_response( $conversation );
+		return rest_ensure_response( [
+			'id'         => (int) $conversation['id'],
+			'title'      => $conversation['title'],
+			'updated_at' => $conversation['updated_at'],
+		] );
 	}
 
 	public function get_messages( \WP_REST_Request $request ): \WP_REST_Response {

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -137,7 +137,11 @@ class ChatRestController {
 			$request->get_param( 'title' ),
 			! empty( $post_id_param ) ? (int) $post_id_param : null
 		);
-		return rest_ensure_response( [ 'id' => $id ] );
+		$conversation = $store->get_conversation( $id );
+		if ( null === $conversation ) {
+			return new \WP_REST_Response( new \WP_Error( 'create_failed', __( 'Failed to create conversation.', 'wp-ai-mind' ) ), 500 );
+		}
+		return rest_ensure_response( $conversation );
 	}
 
 	public function get_messages( \WP_REST_Request $request ): \WP_REST_Response {

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -139,7 +139,7 @@ class ChatRestController {
 		);
 		$conversation = $store->get_conversation( $id );
 		if ( null === $conversation ) {
-			return new \WP_REST_Response( new \WP_Error( 'create_failed', __( 'Failed to create conversation.', 'wp-ai-mind' ) ), 500 );
+			return new \WP_REST_Response( [ 'message' => __( 'Failed to create conversation.', 'wp-ai-mind' ) ], 500 );
 		}
 		return rest_ensure_response( $conversation );
 	}

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -141,6 +141,9 @@ class ChatRestController {
 			return new \WP_REST_Response( [ 'message' => __( 'Failed to create conversation.', 'wp-ai-mind' ) ], 500 );
 		}
 		$conversation = $store->get_conversation( $id );
+		if ( null === $conversation ) {
+			return new \WP_REST_Response( [ 'message' => __( 'Failed to retrieve conversation.', 'wp-ai-mind' ) ], 500 );
+		}
 		return rest_ensure_response( $conversation );
 	}
 

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -153,11 +153,13 @@ class ChatRestController {
 		if ( null === $conversation ) {
 			return new \WP_REST_Response( [ 'message' => __( 'Failed to retrieve conversation.', 'wp-ai-mind' ) ], 500 );
 		}
-		return rest_ensure_response( [
-			'id'         => (int) $conversation['id'],
-			'title'      => $conversation['title'],
-			'updated_at' => $conversation['updated_at'],
-		] );
+		return rest_ensure_response(
+			[
+				'id'         => (int) $conversation['id'],
+				'title'      => $conversation['title'],
+				'updated_at' => $conversation['updated_at'],
+			]
+		);
 	}
 
 	public function get_messages( \WP_REST_Request $request ): \WP_REST_Response {

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -142,7 +142,7 @@ class ChatRestController {
 	public function create_conversation( \WP_REST_Request $request ): \WP_REST_Response {
 		$store         = $this->make_store();
 		$post_id_param = $request->get_param( 'post_id' );
-		$id = $store->create(
+		$id            = $store->create(
 			$request->get_param( 'title' ),
 			! empty( $post_id_param ) ? (int) $post_id_param : null
 		);

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -153,12 +153,13 @@ class ChatRestController {
 		if ( null === $conversation ) {
 			return new \WP_REST_Response( [ 'message' => __( 'Failed to retrieve conversation.', 'wp-ai-mind' ) ], 500 );
 		}
-		return rest_ensure_response(
+		return new \WP_REST_Response(
 			[
 				'id'         => (int) $conversation['id'],
 				'title'      => $conversation['title'],
 				'updated_at' => $conversation['updated_at'],
-			]
+			],
+			201
 		);
 	}
 

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -133,14 +133,14 @@ class ChatRestController {
 	public function create_conversation( \WP_REST_Request $request ): \WP_REST_Response {
 		$store         = $this->make_store();
 		$post_id_param = $request->get_param( 'post_id' );
-		$id            = $store->create(
+		$id = $store->create(
 			$request->get_param( 'title' ),
 			! empty( $post_id_param ) ? (int) $post_id_param : null
 		);
-		$conversation = $store->get_conversation( $id );
-		if ( null === $conversation ) {
+		if ( 0 === $id ) {
 			return new \WP_REST_Response( [ 'message' => __( 'Failed to create conversation.', 'wp-ai-mind' ) ], 500 );
 		}
+		$conversation = $store->get_conversation( $id );
 		return rest_ensure_response( $conversation );
 	}
 

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -95,6 +95,39 @@ class ChatRestControllerTest extends TestCase {
         $this->assertArrayHasKey( 'message', $response->data );
     }
 
+    public function test_create_conversation_returns_500_when_get_conversation_returns_null(): void {
+        Functions\when( '__' )->alias( fn( $s ) => $s );
+
+        $store_mock = $this->createMock( \WP_AI_Mind\DB\ConversationStore::class );
+        $store_mock->method( 'create' )->willReturn( 7 );
+        $store_mock->method( 'get_conversation' )->with( 7 )->willReturn( null );
+
+        $controller = new class( $this->tool_registry, $this->tool_executor, $store_mock ) extends ChatRestController {
+            private \WP_AI_Mind\DB\ConversationStore $store_override;
+            public function __construct(
+                ToolRegistry $tr,
+                ToolExecutor $te,
+                \WP_AI_Mind\DB\ConversationStore $store
+            ) {
+                parent::__construct( $tr, $te );
+                $this->store_override = $store;
+            }
+            protected function make_store(): \WP_AI_Mind\DB\ConversationStore {
+                return $this->store_override;
+            }
+        };
+
+        $request = new \WP_REST_Request( 'POST' );
+        $request->set_body_params( [ 'title' => 'My convo', 'post_id' => 0 ] );
+
+        $response = $controller->create_conversation( $request );
+
+        $this->assertInstanceOf( \WP_REST_Response::class, $response );
+        $this->assertSame( 500, $response->get_status() );
+        $this->assertIsArray( $response->data );
+        $this->assertArrayHasKey( 'message', $response->data );
+    }
+
     // ── Route registration ─────────────────────────────────────────────────────
 
     public function test_register_routes_registers_expected_endpoints(): void {

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -91,7 +91,8 @@ class ChatRestControllerTest extends TestCase {
 
         $this->assertInstanceOf( \WP_REST_Response::class, $response );
         $this->assertSame( 500, $response->get_status() );
-        $this->assertInstanceOf( \WP_Error::class, $response->data );
+        $this->assertIsArray( $response->data );
+        $this->assertArrayHasKey( 'message', $response->data );
     }
 
     // ── Route registration ─────────────────────────────────────────────────────

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -26,6 +26,74 @@ class ChatRestControllerTest extends TestCase {
         parent::tearDown();
     }
 
+    // ── create_conversation ───────────────────────────────────────────────────
+
+    public function test_create_conversation_returns_200_with_conversation_data(): void {
+        $store_mock = $this->createMock( \WP_AI_Mind\DB\ConversationStore::class );
+        $store_mock->method( 'create' )->willReturn( 7 );
+        $store_mock->method( 'get_conversation' )->with( 7 )->willReturn(
+            [ 'id' => 7, 'title' => 'My convo', 'updated_at' => '2026-01-01 00:00:00' ]
+        );
+
+        $controller = new class( $this->tool_registry, $this->tool_executor, $store_mock ) extends ChatRestController {
+            private \WP_AI_Mind\DB\ConversationStore $store_override;
+            public function __construct(
+                ToolRegistry $tr,
+                ToolExecutor $te,
+                \WP_AI_Mind\DB\ConversationStore $store
+            ) {
+                parent::__construct( $tr, $te );
+                $this->store_override = $store;
+            }
+            protected function make_store(): \WP_AI_Mind\DB\ConversationStore {
+                return $this->store_override;
+            }
+        };
+
+        $request = new \WP_REST_Request( 'POST' );
+        $request->set_body_params( [ 'title' => 'My convo', 'post_id' => 0 ] );
+
+        $response = $controller->create_conversation( $request );
+
+        $this->assertInstanceOf( \WP_REST_Response::class, $response );
+        $this->assertSame( 200, $response->get_status() );
+        $this->assertArrayHasKey( 'id', $response->data );
+        $this->assertArrayHasKey( 'title', $response->data );
+        $this->assertArrayHasKey( 'updated_at', $response->data );
+    }
+
+    public function test_create_conversation_returns_500_when_db_insert_fails(): void {
+        Functions\when( '__' )->alias( fn( $s ) => $s );
+
+        $store_mock = $this->createMock( \WP_AI_Mind\DB\ConversationStore::class );
+        $store_mock->method( 'create' )->willReturn( 0 );
+        $store_mock->method( 'get_conversation' )->willReturn( null );
+
+        $controller = new class( $this->tool_registry, $this->tool_executor, $store_mock ) extends ChatRestController {
+            private \WP_AI_Mind\DB\ConversationStore $store_override;
+            public function __construct(
+                ToolRegistry $tr,
+                ToolExecutor $te,
+                \WP_AI_Mind\DB\ConversationStore $store
+            ) {
+                parent::__construct( $tr, $te );
+                $this->store_override = $store;
+            }
+            protected function make_store(): \WP_AI_Mind\DB\ConversationStore {
+                return $this->store_override;
+            }
+        };
+
+        $request = new \WP_REST_Request( 'POST' );
+        $request->set_body_params( [ 'title' => '', 'post_id' => 0 ] );
+
+        $response = $controller->create_conversation( $request );
+
+        $this->assertInstanceOf( \WP_REST_Response::class, $response );
+        $this->assertSame( 500, $response->get_status() );
+        $this->assertInstanceOf( \WP_Error::class, $response->data );
+    }
+
     // ── Route registration ─────────────────────────────────────────────────────
 
     public function test_register_routes_registers_expected_endpoints(): void {

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -26,6 +26,112 @@ class ChatRestControllerTest extends TestCase {
         parent::tearDown();
     }
 
+    // ── list_conversations ────────────────────────────────────────────────────
+
+    public function test_list_conversations_returns_only_expected_keys(): void {
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+        // Store returns rows with extra internal columns that must not be exposed.
+        $store_mock = $this->createMock( \WP_AI_Mind\DB\ConversationStore::class );
+        $store_mock->method( 'list_for_user' )->with( 1 )->willReturn( [
+            [
+                'id'         => '5',
+                'title'      => 'Hello',
+                'updated_at' => '2026-01-10 12:00:00',
+                'user_id'    => '1',
+                'post_id'    => '42',
+            ],
+        ] );
+
+        $controller = new class( $this->tool_registry, $this->tool_executor, $store_mock ) extends ChatRestController {
+            private \WP_AI_Mind\DB\ConversationStore $store_override;
+            public function __construct(
+                ToolRegistry $tr,
+                ToolExecutor $te,
+                \WP_AI_Mind\DB\ConversationStore $store
+            ) {
+                parent::__construct( $tr, $te );
+                $this->store_override = $store;
+            }
+            protected function make_store(): \WP_AI_Mind\DB\ConversationStore {
+                return $this->store_override;
+            }
+        };
+
+        $request  = new \WP_REST_Request( 'GET' );
+        $response = $controller->list_conversations( $request );
+
+        $this->assertInstanceOf( \WP_REST_Response::class, $response );
+        $this->assertSame( 200, $response->get_status() );
+        $this->assertIsArray( $response->data );
+        $this->assertCount( 1, $response->data );
+
+        $item = $response->data[0];
+        $this->assertArrayHasKey( 'id', $item );
+        $this->assertArrayHasKey( 'title', $item );
+        $this->assertArrayHasKey( 'updated_at', $item );
+        $this->assertArrayNotHasKey( 'user_id', $item, 'user_id must not be exposed in the response.' );
+        $this->assertArrayNotHasKey( 'post_id', $item, 'post_id must not be exposed in the response.' );
+    }
+
+    public function test_list_conversations_casts_id_to_int(): void {
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+        $store_mock = $this->createMock( \WP_AI_Mind\DB\ConversationStore::class );
+        $store_mock->method( 'list_for_user' )->willReturn( [
+            [ 'id' => '99', 'title' => 'Test', 'updated_at' => '2026-02-01 00:00:00', 'user_id' => '1' ],
+        ] );
+
+        $controller = new class( $this->tool_registry, $this->tool_executor, $store_mock ) extends ChatRestController {
+            private \WP_AI_Mind\DB\ConversationStore $store_override;
+            public function __construct(
+                ToolRegistry $tr,
+                ToolExecutor $te,
+                \WP_AI_Mind\DB\ConversationStore $store
+            ) {
+                parent::__construct( $tr, $te );
+                $this->store_override = $store;
+            }
+            protected function make_store(): \WP_AI_Mind\DB\ConversationStore {
+                return $this->store_override;
+            }
+        };
+
+        $request  = new \WP_REST_Request( 'GET' );
+        $response = $controller->list_conversations( $request );
+
+        $this->assertSame( 99, $response->data[0]['id'], 'id must be cast to int, not returned as a string.' );
+    }
+
+    public function test_list_conversations_returns_empty_array_when_no_conversations(): void {
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+        $store_mock = $this->createMock( \WP_AI_Mind\DB\ConversationStore::class );
+        $store_mock->method( 'list_for_user' )->willReturn( [] );
+
+        $controller = new class( $this->tool_registry, $this->tool_executor, $store_mock ) extends ChatRestController {
+            private \WP_AI_Mind\DB\ConversationStore $store_override;
+            public function __construct(
+                ToolRegistry $tr,
+                ToolExecutor $te,
+                \WP_AI_Mind\DB\ConversationStore $store
+            ) {
+                parent::__construct( $tr, $te );
+                $this->store_override = $store;
+            }
+            protected function make_store(): \WP_AI_Mind\DB\ConversationStore {
+                return $this->store_override;
+            }
+        };
+
+        $request  = new \WP_REST_Request( 'GET' );
+        $response = $controller->list_conversations( $request );
+
+        $this->assertInstanceOf( \WP_REST_Response::class, $response );
+        $this->assertSame( 200, $response->get_status() );
+        $this->assertSame( [], $response->data );
+    }
+
     // ── create_conversation ───────────────────────────────────────────────────
 
     public function test_create_conversation_returns_200_with_conversation_data(): void {

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -134,7 +134,7 @@ class ChatRestControllerTest extends TestCase {
 
     // ── create_conversation ───────────────────────────────────────────────────
 
-    public function test_create_conversation_returns_200_with_conversation_data(): void {
+    public function test_create_conversation_returns_201_with_conversation_data(): void {
         $store_mock = $this->createMock( \WP_AI_Mind\DB\ConversationStore::class );
         $store_mock->method( 'create' )->willReturn( 7 );
         $store_mock->method( 'get_conversation' )->with( 7 )->willReturn(
@@ -162,7 +162,7 @@ class ChatRestControllerTest extends TestCase {
         $response = $controller->create_conversation( $request );
 
         $this->assertInstanceOf( \WP_REST_Response::class, $response );
-        $this->assertSame( 200, $response->get_status() );
+        $this->assertSame( 201, $response->get_status() );
         $this->assertArrayHasKey( 'id', $response->data );
         $this->assertArrayHasKey( 'title', $response->data );
         $this->assertArrayHasKey( 'updated_at', $response->data );


### PR DESCRIPTION
## Summary

- `create_conversation` now fetches the full conversation row after insert and returns it directly, giving the client `id`, `title`, and `updated_at` in a single round-trip (eliminates the need for a follow-up GET)
- Adds a `500` guard when the DB insert silently fails (returns `null`), previously this would return a bare `{ id: null }` with a 200

## Test plan

- [ ] Create a new conversation — response body should include `id`, `title`, and `updated_at`
- [ ] Simulate a DB failure (stub `create()` to return null) — endpoint should return 500
- [ ] `composer test` passes

Closes #120