### PR TITLE
docs(architecture): add JWT/proxy overhaul technical specification and phased implementation plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test-results/
 .phpunit.result.cache
 .agents/
 .superpowers/
+.worktrees/
 .artifacts/
 .claude/agents/
 .claude/commands/

--- a/docs/superpowers/plans/2026-04-17-wp-ai-mind-architecture-overhaul.md
+++ b/docs/superpowers/plans/2026-04-17-wp-ai-mind-architecture-overhaul.md
@@ -68,7 +68,7 @@ Week 5–7                                      ████ Phase 6: React UI
 | User account storage | Cloudflare D1 (SQLite) | Co-located with Worker; zero extra infra; free at low volume |
 | Password hashing | PBKDF2-SHA256, 100k iterations | bcrypt unavailable in Web Crypto API; PBKDF2 is the standard alternative |
 | JWT implementation | HMAC-SHA256 via Web Crypto API | No external library deps; native in CF Workers |
-| Token storage (WP) | `wp_options` for both tokens | Consistent with existing ProviderSettings pattern |
+| Token storage (WP) | `wp_options` for both tokens | Consistent with existing ProviderSettings pattern. **Design constraint: one NJ account per WordPress site** — all WP users share the same token; `POST /nj/logout` ends the session site-wide. Intentional for single-owner installs; see phase-2 Risk Notes for multi-user migration path. |
 | Entitlement caching | 1-hour WP transient | Matches JWT expiry window; balances freshness vs HTTP overhead |
 | Proxy routing | `ProxyProvider` implements `ProviderInterface` | Plugs into existing provider pattern; zero changes to ChatRestController |
 | `nj_resolve_provider()` | Global function loaded eagerly | Same pattern as `wp_ai_mind_is_pro()` was; available to all code |

--- a/docs/superpowers/plans/2026-04-17-wp-ai-mind-architecture-overhaul.md
+++ b/docs/superpowers/plans/2026-04-17-wp-ai-mind-architecture-overhaul.md
@@ -2,11 +2,26 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace the Freemius-gated, user-API-key model with a thin-client JWT/proxy architecture. Free/trial users route through a Cloudflare Worker proxy; Pro users retain their own API keys; all enforcement lives server-side.
+**Goal:** Replace the Freemius-gated, user-API-key model with a thin-client JWT/proxy architecture across **three tiers**: (1) Free users route through a Cloudflare Worker proxy with monthly token limits; (2) Pro Managed users route through the same Worker but at higher limits with model selection; (3) Pro BYOK users bypass the Worker entirely and use their own API keys. All enforcement lives server-side.
 
-**Architecture:** The WordPress plugin becomes a UI-only thin client storing a JWT and rendering entitlement-aware UI. A Cloudflare Worker handles authentication (email+password with PBKDF2, JWT issuance), plan enforcement (Cloudflare KV rate limits), and proxies requests to Anthropic. User accounts live in Cloudflare D1 (SQLite). Payments handled via LemonSqueezy webhooks updating D1 directly.
+**Architecture:** The WordPress plugin becomes a UI-only thin client storing a JWT and rendering entitlement-aware UI. A Cloudflare Worker handles authentication (email+password with PBKDF2, JWT issuance), tier enforcement (rate limits and model allowlists via a single `src/tier-config.ts` config module), and proxies requests to AI providers. User accounts live in Cloudflare D1 (SQLite). Payments handled via LemonSqueezy webhooks updating D1 directly. Provider routing is abstracted via a `ProviderAdapter` interface so adding/switching providers requires no changes to routing logic.
 
-**Tech Stack:** Cloudflare Workers (TypeScript), Cloudflare D1 (SQLite), Cloudflare KV, Wrangler CLI, Web Crypto API (HMAC-SHA256 JWTs, PBKDF2 passwords), LemonSqueezy, PHP 8.1+ (WordPress plugin), React/JSX (@wordpress/element), @wordpress/api-fetch.
+**Tech Stack:** Cloudflare Workers (TypeScript), Cloudflare D1 (SQLite), Cloudflare KV, Cloudflare Durable Objects, Wrangler CLI, Web Crypto API (HMAC-SHA256 JWTs, PBKDF2 passwords), LemonSqueezy, PHP 8.1+ (WordPress plugin), React/JSX (@wordpress/element), @wordpress/api-fetch.
+
+---
+
+## Architecture Principles
+
+These principles govern every implementation decision across all phases. An agentic worker **must** apply them before writing any new code.
+
+| Principle | Rule |
+|-----------|------|
+| **Reuse first** | Before writing any new code, audit existing files for reusable logic. Never recreate something that already exists — extend or adapt it. |
+| **KISS** | The simplest solution that satisfies the acceptance criteria is the right one. No speculative abstractions, no future-proofing beyond the stated requirements. |
+| **SRP** | Each module/class/function has exactly one reason to change. Auth logic lives in `NJ_Auth`. Tier config lives in `tier-config.ts`. Routing logic lives in `nj_resolve_provider()`. |
+| **Module-based** | Each concern is a discrete, independently testable module. No cross-cutting logic scattered across files. |
+| **Provider-agnostic** | AI provider specifics are encapsulated in `ProviderAdapter` implementations (`anthropic.ts`, `openai.ts`, `gemini.ts`). No provider-specific code outside the adapter files. |
+| **Config-driven tiers** | Features, token limits, and allowed models per tier are defined in **one place**: `src/tier-config.ts` (Worker) and a PHP equivalent. Adding/removing a feature = edit one file only. |
 
 ---
 
@@ -61,6 +76,19 @@ Week 5–7                                      ████ Phase 6: React UI
 
 ---
 
+## Tier Model
+
+| Tier | Plan value in D1 | Monthly token limit | Allowed models | Routing | Payment |
+|------|-----------------|--------------------|--------------------|---------|---------|
+| **Free** | `free` | 50,000 | Claude Haiku only | → Worker (platform key) | None |
+| **Trial** | `trial` | 300,000 | Claude Haiku only | → Worker (platform key) | None (7-day window) |
+| **Pro Managed** | `pro_managed` | 2,000,000 | Haiku + Sonnet + Opus (configurable) | → Worker (platform key) | LemonSqueezy |
+| **Pro BYOK** | `pro` | Unlimited (own cost) | Any model | → Direct provider | LemonSqueezy |
+
+> **Tier config is the single source of truth.** Limits, allowed models, and feature flags are defined in `src/tier-config.ts` (Worker) and the PHP equivalent. To change what a tier can do, edit only that file.
+
+---
+
 ## Key Design Decisions
 
 | Decision | Choice | Rationale |
@@ -73,12 +101,14 @@ Week 5–7                                      ████ Phase 6: React UI
 | Proxy routing | `ProxyProvider` implements `ProviderInterface` | Plugs into existing provider pattern; zero changes to ChatRestController |
 | `nj_resolve_provider()` | Global function loaded eagerly | Same pattern as `wp_ai_mind_is_pro()` was; available to all code |
 | Trial → Free demotion | Happens at token-request time in Worker | No cron needed; transparently enforced on next login |
-| Free user model | Claude Haiku via shared proxy key | Cheapest capable model; qualitative upgrade incentive |
-| Pro routing | Direct to provider (own key), bypasses Worker | Worker pays nothing for Pro usage |
+| Free/trial model | Claude Haiku via shared proxy key | Cheapest capable model; qualitative incentive to upgrade |
+| Pro Managed model selection | Allowed models list from `tier-config.ts` | Worker enforces the allowlist; PHP UI shows available models from entitlement payload |
+| Pro BYOK routing | Direct to provider (own key), bypasses Worker | Worker pays nothing for Pro BYOK usage |
 | LemonSqueezy integration | Webhooks update D1 plan directly | No Freemius dependency; EU VAT handled; clean webhooks |
 | UsageLogger removal | Delete entirely; KV is the source of truth | Logging in plugin can be bypassed; Worker KV is authoritative |
 | `ProGate` replacement | `nj_feature( $key )` helper + `NJ_Entitlement::feature()` | Drop-in replacement at all 13 call sites |
 | Freemius removal trigger | After Phase 4 is in production | Pro users must have migrated before old gate is removed |
+| Feature/tier flexibility | All per-tier capabilities in `tier-config.ts` | To add a feature flag or change a limit, edit one file — no scattered `if plan === 'pro'` checks |
 
 ---
 
@@ -104,15 +134,16 @@ Week 5–7                                      ████ Phase 6: React UI
 ### Phase 1 — CF Worker: Auth + D1 Foundation
 **Duration estimate:** 1–2 weeks · **Scope:** Greenfield `wp-ai-mind-proxy/` TypeScript project.
 
-Creates the Cloudflare Worker project from scratch. Implements user registration, login, token refresh, and entitlement endpoint. Nothing in the WordPress plugin changes. Phases 2 and 3 are **blocked** until this is deployed to Cloudflare.
+Creates the Cloudflare Worker project from scratch. Implements user registration, login, token refresh, and entitlement endpoint. Introduces `src/tier-config.ts` as the single source of truth for per-tier features, limits, and allowed models. Nothing in the WordPress plugin changes. Phases 2 and 3 are **blocked** until this is deployed to Cloudflare.
 
 **Key deliverables:**
 - `wp-ai-mind-proxy/` project with Wrangler config
-- D1 `users` table migration
+- `src/tier-config.ts` — single source of truth for all four tiers (`free`, `trial`, `pro_managed`, `pro`)
+- D1 `users` table migration (plan column supports all four tier values)
 - `POST /v1/auth/register` — creates trial account (7-day `plan_expires`)
 - `POST /v1/auth/token` — verifies password, returns JWT pair, demotes expired trials
 - `POST /v1/auth/refresh` — returns new access token
-- `GET /v1/entitlement` — returns plan, features, token usage
+- `GET /v1/entitlement` — returns plan, features, token usage, allowed models
 - All unit tests passing (Vitest)
 
 **Acceptance criteria:** See [phase-1-cf-worker-foundation.md](phases/phase-1-cf-worker-foundation.md)
@@ -138,11 +169,11 @@ Adds `NJ_Auth` and `NJ_Entitlement` PHP classes and REST endpoints so WordPress 
 ### Phase 3 — CF Worker: Chat + LemonSqueezy Webhooks
 **Duration estimate:** 1 week · **Scope:** Worker only; no PHP changes. Runs in parallel with Phase 2.
 
-Replaces the 501 stub `handleChat` and `handleLemonSqueezy` functions from Phase 1 with real implementations. Free/trial users are limited by KV token counters. LemonSqueezy webhook sets `plan='pro'` in D1.
+Replaces the 501 stub `handleChat` and `handleLemonSqueezy` functions from Phase 1 with real implementations. Free/trial users are limited by KV token counters (limits from `tier-config.ts`). `pro_managed` users are limited at higher thresholds and may select from approved models. LemonSqueezy webhook sets `plan='pro_managed'` or `plan='pro'` in D1.
 
 **Key deliverables:**
-- `POST /v1/chat` — enforces KV limits, proxies to Anthropic, updates KV usage
-- `POST /webhooks/lemonsqueezy` — HMAC verification, D1 plan updates
+- `POST /v1/chat` — reads limits from `tier-config.ts`, enforces token limits, validates requested model against tier allowlist, proxies to Anthropic (default), updates KV usage
+- `POST /webhooks/lemonsqueezy` — HMAC verification, D1 plan updates (supports `pro_managed` and `pro`)
 - Vitest tests for both handlers
 
 **Acceptance criteria:** See [phase-3-cf-worker-chat-webhooks.md](phases/phase-3-cf-worker-chat-webhooks.md)
@@ -152,11 +183,15 @@ Replaces the 501 stub `handleChat` and `handleLemonSqueezy` functions from Phase
 ### Phase 4 — PHP: ProxyProvider + ProviderFactory Routing
 **Duration estimate:** 1 week · **Scope:** New PHP classes + targeted modifications to 3 existing files.
 
-Free/trial users transparently route through `ProxyProvider` → Worker. Pro users continue using direct providers unchanged. `nj_resolve_provider()` is the single routing decision point. `AbstractProvider::maybe_log()` removed (KV is the source of truth now).
+Free/trial/pro_managed users transparently route through `ProxyProvider` → Worker. Pro BYOK users continue using direct providers unchanged. `nj_resolve_provider()` is the single routing decision point. `AbstractProvider::maybe_log()` removed (KV is the source of truth now).
+
+Routing rules in `nj_resolve_provider()`:
+- `own_key` feature enabled → direct provider with user's own API key
+- `pro_managed` / `trial` / `free` → `ProxyProvider` (Worker enforces limits and model allowlist)
 
 **Key deliverables:**
-- `includes/Proxy/NJ_Proxy_Client.php` — wraps Worker `/v1/chat` call
-- `includes/Providers/ProxyProvider.php` — implements `ProviderInterface`
+- `includes/Proxy/NJ_Proxy_Client.php` — wraps Worker `/v1/chat` call; passes requested model and provider
+- `includes/Providers/ProxyProvider.php` — implements `ProviderInterface`; respects `model_selection` feature flag; for `pro_managed` passes the user-requested model through; for free/trial forces Haiku
 - `nj_resolve_provider()` global function
 - `ProviderFactory::make_default()` delegates to `nj_resolve_provider()`
 - `AbstractProvider` — `maybe_log()` removed
@@ -185,13 +220,14 @@ Free/trial users transparently route through `ProxyProvider` → Worker. Pro use
 ### Phase 6 — React: Auth UI + Usage Components
 **Duration estimate:** 1–2 weeks · **Scope:** New React components; modifications to existing React apps.
 
-All React admin apps are wrapped in `AuthProvider`. Unauthenticated users see a login/signup form instead of the AI interface. `UsageMeter` and `UsageWarning` appear on all AI pages. `UpgradeModal` shown on any 429 response. `ProvidersTab` hides API key inputs for non-Pro users.
+All React admin apps are wrapped in `AuthProvider`. Unauthenticated users see a login/signup form instead of the AI interface. `UsageMeter` and `UsageWarning` appear on all AI pages (hidden for `pro` BYOK). `UpgradeModal` shown on any 429 response. `ProvidersTab` hides API key inputs for non-Pro-BYOK users. `ModelSelector` shown for `pro_managed` users and hidden for free/trial.
 
 **Key deliverables:**
 - `src/admin/auth/` — `AuthContext.jsx`, `AuthApp.jsx`, `LoginForm.jsx`, `SignupForm.jsx`
-- `src/admin/shared/` — `UsageMeter.jsx`, `UpgradeModal.jsx`, `UsageWarning.jsx`, `constants.js`
+- `src/admin/shared/` — `UsageMeter.jsx`, `UpgradeModal.jsx`, `UsageWarning.jsx`, `ModelSelector.jsx`, `constants.js`
 - `src/admin/index.js` — auth gate wrapping all roots
-- `ProvidersTab.jsx` — conditional API key section
+- `ProvidersTab.jsx` — conditional API key section (Pro BYOK only)
+- All UI feature decisions driven by `entitlement.features.*` flags — no hardcoded plan-name checks in JSX
 
 **Acceptance criteria:** See [phase-6-react-auth-ui.md](phases/phase-6-react-auth-ui.md)
 
@@ -200,16 +236,38 @@ All React admin apps are wrapped in `AuthProvider`. Unauthenticated users see a 
 ### Phase 7 — CF Worker: Hardening
 **Duration estimate:** 1–2 weeks · **Scope:** Worker only; can start any time after Phase 3.
 
-Adds brute-force rate limiting on auth endpoints, real SSE streaming via `TransformStream`, multi-provider routing (OpenAI + Gemini), structured JSON error logging, and a staging environment in `wrangler.toml`.
+Adds brute-force rate limiting on auth endpoints, real SSE streaming via `TransformStream`, multi-provider routing (OpenAI + Gemini) via the `ProviderAdapter` interface, structured JSON error logging, and a staging environment in `wrangler.toml`. All provider-specific logic lives exclusively in the adapter files (`src/providers/`).
 
 **Key deliverables:**
-- `src/ratelimit.ts` — 10 attempts / 15 min per IP via KV
-- `src/providers/` — `anthropic.ts`, `openai.ts`, `gemini.ts`, `types.ts`
-- `chat.ts` — provider routing + `TransformStream` passthrough for `stream:true`
+- `src/ratelimit.ts` + `src/rate-limiter-do.ts` — Durable Object-backed rate limiter (strongly consistent)
+- `src/providers/types.ts` — `ProviderAdapter` interface (provider-agnostic contract)
+- `src/providers/anthropic.ts`, `openai.ts`, `gemini.ts` — provider-specific adapters only
+- `chat.ts` — routing via adapters + `TransformStream` passthrough for `stream:true`; limits from `tier-config.ts`
 - `wrangler.toml` — `[env.staging]` block
 - Vitest tests passing; smoke test confirming rate limit at attempt 11
 
 **Acceptance criteria:** See [phase-7-cf-worker-hardening.md](phases/phase-7-cf-worker-hardening.md)
+
+---
+
+---
+
+## Code Reuse Policy
+
+This applies to **every phase**. Agentic workers must follow this policy before and after implementation.
+
+### Pre-implementation (start of each phase)
+1. Run `grep -r "class\|function\|interface" --include="*.php" includes/` and review existing PHP abstractions that may apply.
+2. For Worker phases: read `src/` files in `wp-ai-mind-proxy/` and list any existing utilities (`utils.ts`, `db.ts`, `middleware.ts`) that can be called instead of reimplemented.
+3. Check `ProviderInterface` / `AbstractProvider` before creating any new PHP class that touches AI providers.
+4. Check `ProviderAdapter` interface (Phase 7 onward) before adding any provider-specific Worker code.
+5. Document which existing files/functions you are reusing in the phase commit message.
+
+### Post-implementation (end of each phase)
+1. `grep -r "PLAN_LIMITS\|PLAN_FEATURES\|plan === 'pro'\|plan === 'free'" src/` → must return 0 matches (all logic must be in `tier-config.ts`).
+2. Confirm no class/function from an earlier phase has been reimplemented inline.
+3. Confirm all new modules have a single responsibility and are independently testable.
+4. Confirm provider-specific logic lives only in `src/providers/*.ts` (Worker) or `includes/Providers/*Provider.php` (PHP).
 
 ---
 
@@ -245,13 +303,16 @@ Run these checks before declaring the overhaul complete.
 - [ ] `npx vitest run` (in `wp-ai-mind-proxy/`) — all pass
 
 ### E2E flow checks
-- [ ] Login → free chat → see UsageMeter → hit 429 → see UpgradeModal
-- [ ] Pro user → chat → routes direct (no Worker involvement, verify via network log)
+- [ ] Login (free) → chat → see UsageMeter → hit 429 → see UpgradeModal; `ModelSelector` absent
+- [ ] Login (`pro_managed`) → chat → see `ModelSelector` with multiple options; select Sonnet → Sonnet used; UsageMeter visible
+- [ ] Login (`pro_managed`) → request disallowed model (one not in `allowed_models`) → 403
+- [ ] Login (Pro BYOK) → chat → routes direct (no Worker involvement, verify via network log); `ModelSelector` absent; UsageMeter absent
 - [ ] Logout → auth card shown, not AI interface
-- [ ] D1 `users` table exists with correct schema (check via Cloudflare dashboard or `wrangler d1 execute`)
-- [ ] LemonSqueezy test webhook delivery → D1 plan updates to `pro`
+- [ ] D1 `users` table exists with correct schema including `CHECK(plan IN ('free','trial','pro_managed','pro'))`
+- [ ] LemonSqueezy test webhook delivery → D1 plan updates to `pro_managed` (or `pro` for BYOK product)
 - [ ] JWT expiry: wait for access token to expire → refresh path exercises silently on next request
 - [ ] Rate limiting: 11 rapid login attempts from same IP → 429 on attempt 11
+- [ ] `grep -rn "PLAN_LIMITS\|50_000\|300_000" src/ --include="*.ts" | grep -v tier-config` → 0 matches
 
 ---
 
@@ -282,3 +343,4 @@ Run these checks before declaring the overhaul complete.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-04-17 | Niklas Johansson | Initial plan created |
+| 2026-04-17 | Claude | Added `pro_managed` tier; tier-config module as single source of truth; architecture principles (KISS, SRP, module-based, provider-agnostic, reuse-first); code reuse policy; updated phase summaries |

--- a/docs/superpowers/plans/2026-04-17-wp-ai-mind-architecture-overhaul.md
+++ b/docs/superpowers/plans/2026-04-17-wp-ai-mind-architecture-overhaul.md
@@ -1,0 +1,284 @@
+# WP AI Mind — Architecture Overhaul: Master Tracking Document
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Freemius-gated, user-API-key model with a thin-client JWT/proxy architecture. Free/trial users route through a Cloudflare Worker proxy; Pro users retain their own API keys; all enforcement lives server-side.
+
+**Architecture:** The WordPress plugin becomes a UI-only thin client storing a JWT and rendering entitlement-aware UI. A Cloudflare Worker handles authentication (email+password with PBKDF2, JWT issuance), plan enforcement (Cloudflare KV rate limits), and proxies requests to Anthropic. User accounts live in Cloudflare D1 (SQLite). Payments handled via LemonSqueezy webhooks updating D1 directly.
+
+**Tech Stack:** Cloudflare Workers (TypeScript), Cloudflare D1 (SQLite), Cloudflare KV, Wrangler CLI, Web Crypto API (HMAC-SHA256 JWTs, PBKDF2 passwords), LemonSqueezy, PHP 8.1+ (WordPress plugin), React/JSX (@wordpress/element), @wordpress/api-fetch.
+
+---
+
+## Phase Status Tracker
+
+| Phase | Name | Phase Document | Depends on | Status |
+|-------|------|---------------|-----------|--------|
+| **1** | CF Worker: Auth + D1 Foundation | [phase-1-cf-worker-foundation.md](phases/phase-1-cf-worker-foundation.md) | — | ⬜ Not started |
+| **2** | PHP: Auth + Entitlement Layer | [phase-2-php-auth-entitlement.md](phases/phase-2-php-auth-entitlement.md) | Phase 1 deployed | ⬜ Not started |
+| **3** | CF Worker: Chat + LemonSqueezy Webhooks | [phase-3-cf-worker-chat-webhooks.md](phases/phase-3-cf-worker-chat-webhooks.md) | Phase 1 deployed | ⬜ Not started |
+| **4** | PHP: ProxyProvider + ProviderFactory Routing | [phase-4-php-proxy-routing.md](phases/phase-4-php-proxy-routing.md) | Phase 2 + 3 complete | ⬜ Not started |
+| **5** | PHP: Freemius + ProGate + UsageLogger Removal | [phase-5-php-legacy-removal.md](phases/phase-5-php-legacy-removal.md) | Phase 4 in production | ⬜ Not started |
+| **6** | React: Auth UI + Usage Components | [phase-6-react-auth-ui.md](phases/phase-6-react-auth-ui.md) | Phase 2 + 5 complete | ⬜ Not started |
+| **7** | CF Worker: Hardening (streaming, multi-provider, rate limits) | [phase-7-cf-worker-hardening.md](phases/phase-7-cf-worker-hardening.md) | Phase 3 complete | ⬜ Not started |
+
+**Update this table as phases progress.** Use: ⬜ Not started · 🔵 In progress · ✅ Complete · ❌ Blocked
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (CF Worker: Auth + D1)
+        │
+        ├──────────────────────────────────┐
+        ▼                                  ▼
+Phase 2 (PHP Auth + Entitlement)    Phase 3 (CF Worker: Chat + Webhooks)
+        │                                  │
+        └──────────────────────┬───────────┘
+                               ▼
+                      Phase 4 (PHP ProxyProvider)
+                               │
+                               ▼
+                      Phase 5 (Freemius Removal)
+                               │
+                               ▼
+                      Phase 6 (React Auth UI)
+
+Phase 7 (Worker Hardening) ← can start any time after Phase 3
+```
+
+### Parallel Execution Windows
+
+```
+Week 1–2   ████ Phase 1: CF Worker Auth + D1
+Week 2–3        ████ Phase 2: PHP Auth      ████ Phase 3: CF Chat + Webhooks
+Week 3–4                  ████ Phase 4: PHP ProxyProvider
+Week 4–5                            ████ Phase 5: Freemius Removal
+Week 5–7                                      ████ Phase 6: React UI
+                                              ████ Phase 7: Worker Hardening (starts ~Week 5)
+```
+
+---
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| User account storage | Cloudflare D1 (SQLite) | Co-located with Worker; zero extra infra; free at low volume |
+| Password hashing | PBKDF2-SHA256, 100k iterations | bcrypt unavailable in Web Crypto API; PBKDF2 is the standard alternative |
+| JWT implementation | HMAC-SHA256 via Web Crypto API | No external library deps; native in CF Workers |
+| Token storage (WP) | `wp_options` for both tokens | Consistent with existing ProviderSettings pattern |
+| Entitlement caching | 1-hour WP transient | Matches JWT expiry window; balances freshness vs HTTP overhead |
+| Proxy routing | `ProxyProvider` implements `ProviderInterface` | Plugs into existing provider pattern; zero changes to ChatRestController |
+| `nj_resolve_provider()` | Global function loaded eagerly | Same pattern as `wp_ai_mind_is_pro()` was; available to all code |
+| Trial → Free demotion | Happens at token-request time in Worker | No cron needed; transparently enforced on next login |
+| Free user model | Claude Haiku via shared proxy key | Cheapest capable model; qualitative upgrade incentive |
+| Pro routing | Direct to provider (own key), bypasses Worker | Worker pays nothing for Pro usage |
+| LemonSqueezy integration | Webhooks update D1 plan directly | No Freemius dependency; EU VAT handled; clean webhooks |
+| UsageLogger removal | Delete entirely; KV is the source of truth | Logging in plugin can be bypassed; Worker KV is authoritative |
+| `ProGate` replacement | `nj_feature( $key )` helper + `NJ_Entitlement::feature()` | Drop-in replacement at all 13 call sites |
+| Freemius removal trigger | After Phase 4 is in production | Pro users must have migrated before old gate is removed |
+
+---
+
+## Critical Files to Understand Before Modifying
+
+| File | Phase | Why It Matters |
+|------|-------|----------------|
+| `wp-ai-mind.php:25-101` | 5 | Freemius bootstrap + `wam_fs()` — entire block removed in Phase 5 |
+| `includes/Core/ProGate.php` | 5 | 13 call sites; global `wp_ai_mind_is_pro()` — all replaced in Phase 5 |
+| `includes/DB/UsageLogger.php` | 5 | Removed in Phase 5; `maybe_log()` in AbstractProvider removed in Phase 4 |
+| `includes/Providers/AbstractProvider.php` | 4 | `maybe_log()` call removed in Phase 4; do not change `with_retry()` |
+| `includes/Providers/ProviderFactory.php` | 4 | `make_default()` and `make()` both need `nj_resolve_provider()` integration |
+| `includes/Modules/Seo/SeoModule.php:63-90` | 5 | Representative of all 4 gated `permission_callback` lambdas to update |
+| `includes/DB/Schema.php:31-50` | 5 | `wpaim_usage_log` table — removed in Phase 5; add `maybe_migrate()` |
+| `src/admin/index.js` | 6 | Entry point for auth gate wrapping in Phase 6 |
+| `src/admin/settings/ProvidersTab.jsx` | 6 | API key inputs conditionally hidden in Phase 6 |
+| `composer.json` | 5 | Freemius SDK removed in Phase 5 |
+
+---
+
+## Phase Summaries
+
+### Phase 1 — CF Worker: Auth + D1 Foundation
+**Duration estimate:** 1–2 weeks · **Scope:** Greenfield `wp-ai-mind-proxy/` TypeScript project.
+
+Creates the Cloudflare Worker project from scratch. Implements user registration, login, token refresh, and entitlement endpoint. Nothing in the WordPress plugin changes. Phases 2 and 3 are **blocked** until this is deployed to Cloudflare.
+
+**Key deliverables:**
+- `wp-ai-mind-proxy/` project with Wrangler config
+- D1 `users` table migration
+- `POST /v1/auth/register` — creates trial account (7-day `plan_expires`)
+- `POST /v1/auth/token` — verifies password, returns JWT pair, demotes expired trials
+- `POST /v1/auth/refresh` — returns new access token
+- `GET /v1/entitlement` — returns plan, features, token usage
+- All unit tests passing (Vitest)
+
+**Acceptance criteria:** See [phase-1-cf-worker-foundation.md](phases/phase-1-cf-worker-foundation.md)
+
+---
+
+### Phase 2 — PHP: Auth + Entitlement Layer
+**Duration estimate:** 1 week · **Scope:** New PHP classes only; ProGate remains unchanged.
+
+Adds `NJ_Auth` and `NJ_Entitlement` PHP classes and REST endpoints so WordPress can authenticate against the Worker. ProGate and Freemius continue to function — both systems coexist during this phase.
+
+**Key deliverables:**
+- `includes/Auth/NJ_Auth.php` — JWT storage, proactive refresh
+- `includes/Entitlement/NJ_Entitlement.php` — 1h transient cache, null-object fallback
+- `includes/Admin/NJAuthRestController.php` — `/nj/login`, `/nj/register`, `/nj/logout`, `/nj/me`
+- `nj_feature()` global helper in `wp-ai-mind.php`
+- Localized `isAuthenticated` + `entitlement` data on all admin pages
+
+**Acceptance criteria:** See [phase-2-php-auth-entitlement.md](phases/phase-2-php-auth-entitlement.md)
+
+---
+
+### Phase 3 — CF Worker: Chat + LemonSqueezy Webhooks
+**Duration estimate:** 1 week · **Scope:** Worker only; no PHP changes. Runs in parallel with Phase 2.
+
+Replaces the 501 stub `handleChat` and `handleLemonSqueezy` functions from Phase 1 with real implementations. Free/trial users are limited by KV token counters. LemonSqueezy webhook sets `plan='pro'` in D1.
+
+**Key deliverables:**
+- `POST /v1/chat` — enforces KV limits, proxies to Anthropic, updates KV usage
+- `POST /webhooks/lemonsqueezy` — HMAC verification, D1 plan updates
+- Vitest tests for both handlers
+
+**Acceptance criteria:** See [phase-3-cf-worker-chat-webhooks.md](phases/phase-3-cf-worker-chat-webhooks.md)
+
+---
+
+### Phase 4 — PHP: ProxyProvider + ProviderFactory Routing
+**Duration estimate:** 1 week · **Scope:** New PHP classes + targeted modifications to 3 existing files.
+
+Free/trial users transparently route through `ProxyProvider` → Worker. Pro users continue using direct providers unchanged. `nj_resolve_provider()` is the single routing decision point. `AbstractProvider::maybe_log()` removed (KV is the source of truth now).
+
+**Key deliverables:**
+- `includes/Proxy/NJ_Proxy_Client.php` — wraps Worker `/v1/chat` call
+- `includes/Providers/ProxyProvider.php` — implements `ProviderInterface`
+- `nj_resolve_provider()` global function
+- `ProviderFactory::make_default()` delegates to `nj_resolve_provider()`
+- `AbstractProvider` — `maybe_log()` removed
+
+**Acceptance criteria:** See [phase-4-php-proxy-routing.md](phases/phase-4-php-proxy-routing.md)
+
+---
+
+### Phase 5 — PHP: Freemius Removal + Full Cleanup
+**Duration estimate:** 1 week · **Scope:** Delete dead code; replace all 13 ProGate call sites.
+
+⚠️ **Deploy Phase 4 to production before starting this phase.** Existing Pro users must have migrated to NJ accounts before the old gate is removed. Migration notice is shown to unauthenticated users.
+
+**Key deliverables:**
+- `ProGate.php` deleted; `wp_ai_mind_is_pro()` replaced at 13 call sites with `nj_feature()`
+- `UsageLogger.php` deleted
+- Freemius SDK removed from `composer.json` + `vendor/`
+- `wam_fs()` block removed from `wp-ai-mind.php`
+- `Schema::maybe_migrate()` drops `wpaim_usage_log` table
+- All 5 grep-clean checks must pass
+
+**Acceptance criteria:** See [phase-5-php-legacy-removal.md](phases/phase-5-php-legacy-removal.md)
+
+---
+
+### Phase 6 — React: Auth UI + Usage Components
+**Duration estimate:** 1–2 weeks · **Scope:** New React components; modifications to existing React apps.
+
+All React admin apps are wrapped in `AuthProvider`. Unauthenticated users see a login/signup form instead of the AI interface. `UsageMeter` and `UsageWarning` appear on all AI pages. `UpgradeModal` shown on any 429 response. `ProvidersTab` hides API key inputs for non-Pro users.
+
+**Key deliverables:**
+- `src/admin/auth/` — `AuthContext.jsx`, `AuthApp.jsx`, `LoginForm.jsx`, `SignupForm.jsx`
+- `src/admin/shared/` — `UsageMeter.jsx`, `UpgradeModal.jsx`, `UsageWarning.jsx`, `constants.js`
+- `src/admin/index.js` — auth gate wrapping all roots
+- `ProvidersTab.jsx` — conditional API key section
+
+**Acceptance criteria:** See [phase-6-react-auth-ui.md](phases/phase-6-react-auth-ui.md)
+
+---
+
+### Phase 7 — CF Worker: Hardening
+**Duration estimate:** 1–2 weeks · **Scope:** Worker only; can start any time after Phase 3.
+
+Adds brute-force rate limiting on auth endpoints, real SSE streaming via `TransformStream`, multi-provider routing (OpenAI + Gemini), structured JSON error logging, and a staging environment in `wrangler.toml`.
+
+**Key deliverables:**
+- `src/ratelimit.ts` — 10 attempts / 15 min per IP via KV
+- `src/providers/` — `anthropic.ts`, `openai.ts`, `gemini.ts`, `types.ts`
+- `chat.ts` — provider routing + `TransformStream` passthrough for `stream:true`
+- `wrangler.toml` — `[env.staging]` block
+- Vitest tests passing; smoke test confirming rate limit at attempt 11
+
+**Acceptance criteria:** See [phase-7-cf-worker-hardening.md](phases/phase-7-cf-worker-hardening.md)
+
+---
+
+## Testing Strategy Per Phase
+
+| Phase | Unit Tests | Integration / E2E |
+|-------|-----------|-------------------|
+| 1 | `wp-ai-mind-proxy/test/*.test.ts` (Vitest) | curl smoke tests against workers.dev |
+| 2 | `tests/Unit/Auth/`, `tests/Unit/Entitlement/` | Playwright: login flow on localhost:8080 |
+| 3 | `wp-ai-mind-proxy/test/chat.test.ts`, `webhooks.test.ts` | curl: `POST /v1/chat` with test JWT |
+| 4 | `tests/Unit/Proxy/`, `tests/Unit/Providers/ProxyProviderTest.php` | Playwright: chat as free-tier user |
+| 5 | All existing Unit tests must still pass; `ProGateTest.php` deleted | `phpcs` + `phpunit` full suite |
+| 6 | Manual browser verification (no unit tests for React UI) | Visual + flow testing in browser |
+| 7 | `wp-ai-mind-proxy/test/ratelimit.test.ts`, `streaming.test.ts` | curl rate limit + stream smoke tests |
+
+---
+
+## Final Verification Checklist
+
+Run these checks before declaring the overhaul complete.
+
+### Grep clean checks (must return zero matches)
+- [ ] `grep -r "wp_ai_mind_is_pro" .` — no matches
+- [ ] `grep -r "wam_fs" .` — no matches
+- [ ] `grep -r "ProGate" .` — no matches
+- [ ] `grep -r "UsageLogger" .` — no matches
+- [ ] `grep -r "freemius" vendor/` — no matches (directory should not exist)
+
+### Build checks
+- [ ] `./vendor/bin/phpunit tests/Unit/ --colors=always` — all pass
+- [ ] `./vendor/bin/phpcs --standard=phpcs.xml.dist` — no errors
+- [ ] `npm run build` — no errors
+- [ ] `npx vitest run` (in `wp-ai-mind-proxy/`) — all pass
+
+### E2E flow checks
+- [ ] Login → free chat → see UsageMeter → hit 429 → see UpgradeModal
+- [ ] Pro user → chat → routes direct (no Worker involvement, verify via network log)
+- [ ] Logout → auth card shown, not AI interface
+- [ ] D1 `users` table exists with correct schema (check via Cloudflare dashboard or `wrangler d1 execute`)
+- [ ] LemonSqueezy test webhook delivery → D1 plan updates to `pro`
+- [ ] JWT expiry: wait for access token to expire → refresh path exercises silently on next request
+- [ ] Rate limiting: 11 rapid login attempts from same IP → 429 on attempt 11
+
+---
+
+## Worker Endpoint Reference
+
+| Method | Path | Auth | Phase |
+|--------|------|------|-------|
+| POST | `/v1/auth/register` | Public | 1 |
+| POST | `/v1/auth/token` | Public | 1 |
+| POST | `/v1/auth/refresh` | Public | 1 |
+| GET | `/v1/entitlement` | Bearer JWT | 1 |
+| POST | `/v1/chat` | Bearer JWT | 3 |
+| POST | `/webhooks/lemonsqueezy` | HMAC sig | 3 |
+
+## WordPress REST Endpoint Reference
+
+| Method | Path | Auth | Phase |
+|--------|------|------|-------|
+| POST | `/wp-ai-mind/v1/nj/login` | Public | 2 |
+| POST | `/wp-ai-mind/v1/nj/register` | Public | 2 |
+| POST | `/wp-ai-mind/v1/nj/logout` | Public | 2 |
+| GET | `/wp-ai-mind/v1/nj/me` | Public | 2 |
+
+---
+
+## Plan History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-04-17 | Niklas Johansson | Initial plan created |

--- a/docs/superpowers/plans/phases/phase-1-cf-worker-foundation.md
+++ b/docs/superpowers/plans/phases/phase-1-cf-worker-foundation.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** A deployed, independently testable Cloudflare Worker that handles user registration, login, token refresh, and entitlement. Nothing in the WordPress plugin changes during this phase. Phases 2 and 3 are blocked until this is live.
+**Goal:** A deployed, independently testable Cloudflare Worker that handles user registration, login, token refresh, and entitlement across all four tiers (`free`, `trial`, `pro_managed`, `pro`). Nothing in the WordPress plugin changes during this phase. Phases 2 and 3 are blocked until this is live.
 
-**Architecture:** Greenfield `wp-ai-mind-proxy/` TypeScript Worker project. D1 (SQLite) stores user accounts. KV stores monthly token usage. All crypto (JWT, password hashing) uses the Web Crypto API — no external libraries.
+**Architecture:** Greenfield `wp-ai-mind-proxy/` TypeScript Worker project. D1 (SQLite) stores user accounts. KV stores monthly token usage. All crypto (JWT, password hashing) uses the Web Crypto API — no external libraries. A dedicated `src/tier-config.ts` module is the **single source of truth** for per-tier features, token limits, and allowed models — no scattered `if plan === 'free'` checks anywhere else.
 
 **Tech Stack:** Cloudflare Workers (TypeScript), Cloudflare D1, Cloudflare KV, Wrangler CLI, Web Crypto API (HMAC-SHA256, PBKDF2), Vitest
 
@@ -34,9 +34,10 @@ wp-ai-mind-proxy/
   migrations/
     0001_init_users.sql      ← D1 schema
   src/
+    tier-config.ts           ← SINGLE SOURCE OF TRUTH: per-tier features, limits, models
     index.ts                 ← Route dispatch + CORS
     auth.ts                  ← register, token, refresh handlers
-    entitlement.ts           ← GET /v1/entitlement handler
+    entitlement.ts           ← GET /v1/entitlement handler (reads tier-config)
     chat.ts                  ← POST /v1/chat (returns 501 stub in this phase)
     webhooks.ts              ← POST /webhooks/lemonsqueezy (returns 501 stub)
     db.ts                    ← D1 helper wrappers
@@ -50,7 +51,40 @@ wp-ai-mind-proxy/
     password.test.ts
     auth.test.ts
     entitlement.test.ts
+    tier-config.test.ts
 ```
+
+---
+
+## Task 0: Pre-implementation Reuse Audit
+
+> **Mandatory.** Complete this before writing any code. The goal is to understand what already exists and must be reused, extended, or carefully avoided recreating.
+
+- [ ] **Step 0.1: Audit the plugin's existing provider abstractions**
+
+```bash
+# From the plugin root (not wp-ai-mind-proxy/):
+grep -rn "ProviderInterface\|AbstractProvider\|ProviderFactory" includes/ --include="*.php"
+# Review: understand the existing PHP provider contract before designing the Worker's ProviderAdapter (Phase 7).
+# The Worker-side ProviderAdapter (src/providers/types.ts) should mirror the same separation-of-concerns.
+```
+
+- [ ] **Step 0.2: List existing plugin utilities that influence Worker design**
+
+Review these files to understand existing patterns before creating parallel Worker implementations:
+- `includes/Providers/AbstractProvider.php` — retry logic, error handling pattern
+- `includes/Auth/NJ_Auth.php` — token storage pattern (if it exists; skip if not yet created)
+- Any existing helper functions in `wp-ai-mind.php`
+
+Record findings in a short comment at the top of the first commit message (e.g., "No reusable Worker-side code exists yet — greenfield").
+
+- [ ] **Step 0.3: Confirm no Worker project already exists**
+
+```bash
+ls -la wp-ai-mind-proxy/ 2>/dev/null || echo "Confirmed: no existing proxy project"
+```
+
+If a partial project exists, audit it before proceeding — do not overwrite existing work.
 
 ---
 
@@ -201,11 +235,13 @@ Run: `npm test` → Expected: PASS (placeholder assertion)
 
 `migrations/0001_init_users.sql`:
 ```sql
+-- plan column supports all four tiers: 'free', 'trial', 'pro_managed', 'pro'
+-- Add new tiers here; TIER_CONFIG in src/tier-config.ts is the capability definition.
 CREATE TABLE IF NOT EXISTS users (
   id            INTEGER  PRIMARY KEY AUTOINCREMENT,
   email         TEXT     UNIQUE NOT NULL COLLATE NOCASE,
   password_hash TEXT     NOT NULL,
-  plan          TEXT     NOT NULL DEFAULT 'trial',
+  plan          TEXT     NOT NULL DEFAULT 'trial' CHECK(plan IN ('free','trial','pro_managed','pro')),
   plan_expires  DATETIME,
   created_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at    DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -251,11 +287,14 @@ export interface Env {
   ENVIRONMENT?: string;
 }
 
+/** All valid plan values. Must stay in sync with TIER_CONFIG keys in tier-config.ts. */
+export type Plan = 'free' | 'trial' | 'pro_managed' | 'pro';
+
 export interface User {
   id:            number;
   email:         string;
   password_hash: string;
-  plan:          'free' | 'trial' | 'pro';
+  plan:          Plan;
   plan_expires:  string | null;
   created_at:    string;
   updated_at:    string;
@@ -264,7 +303,7 @@ export interface User {
 export interface AuthUser {
   sub:   number;
   email: string;
-  plan:  'free' | 'trial' | 'pro';
+  plan:  Plan;
   iat:   number;
   exp:   number;
   type?: string;
@@ -307,6 +346,193 @@ export function secondsUntilMonthEnd(): number {
 ```bash
 git add src/types.ts src/utils.ts
 git commit -m "feat(proxy): add types and utility helpers"
+```
+
+---
+
+## Task 4b: Tier Configuration Module
+
+**Files:** Create `src/tier-config.ts`, `test/tier-config.test.ts`
+
+> **Critical:** This is the single source of truth for all per-tier configuration. All subsequent modules (`entitlement.ts`, `chat.ts`, etc.) **must** import from this file instead of defining their own plan constants.
+
+- [ ] **Step 4b.1: Write failing tests** (`test/tier-config.test.ts`)
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { getTierConfig, TIER_CONFIG } from '../src/tier-config';
+
+describe('TIER_CONFIG', () => {
+  it('defines all four tiers', () => {
+    expect(Object.keys(TIER_CONFIG)).toEqual(
+      expect.arrayContaining(['free', 'trial', 'pro_managed', 'pro'])
+    );
+  });
+
+  it('free tier has lower limit than trial', () => {
+    const free  = TIER_CONFIG.free;
+    const trial = TIER_CONFIG.trial;
+    expect(free.tokens_per_month).toBeGreaterThan(0);
+    expect(trial.tokens_per_month!).toBeGreaterThan(free.tokens_per_month!);
+  });
+
+  it('pro_managed has higher limit than trial', () => {
+    const trial      = TIER_CONFIG.trial;
+    const proManaged = TIER_CONFIG.pro_managed;
+    expect(proManaged.tokens_per_month!).toBeGreaterThan(trial.tokens_per_month!);
+  });
+
+  it('pro (BYOK) has null token limit', () => {
+    expect(TIER_CONFIG.pro.tokens_per_month).toBeNull();
+  });
+
+  it('free and trial only allow Haiku', () => {
+    expect(TIER_CONFIG.free.allowed_models).toEqual(['claude-haiku-4-5']);
+    expect(TIER_CONFIG.trial.allowed_models).toEqual(['claude-haiku-4-5']);
+  });
+
+  it('pro_managed allows multiple models', () => {
+    expect(TIER_CONFIG.pro_managed.allowed_models.length).toBeGreaterThan(1);
+    expect(TIER_CONFIG.pro_managed.allowed_models).toContain('claude-haiku-4-5');
+  });
+
+  it('pro (BYOK) has empty allowed_models (unrestricted)', () => {
+    expect(TIER_CONFIG.pro.allowed_models).toEqual([]);
+  });
+
+  it('model_selection feature is false for free/trial', () => {
+    expect(TIER_CONFIG.free.features.model_selection).toBe(false);
+    expect(TIER_CONFIG.trial.features.model_selection).toBe(false);
+  });
+
+  it('model_selection feature is true for pro_managed and pro', () => {
+    expect(TIER_CONFIG.pro_managed.features.model_selection).toBe(true);
+    expect(TIER_CONFIG.pro.features.model_selection).toBe(true);
+  });
+
+  it('own_key feature is only true for pro (BYOK)', () => {
+    expect(TIER_CONFIG.free.features.own_key).toBe(false);
+    expect(TIER_CONFIG.trial.features.own_key).toBe(false);
+    expect(TIER_CONFIG.pro_managed.features.own_key).toBe(false);
+    expect(TIER_CONFIG.pro.features.own_key).toBe(true);
+  });
+});
+
+describe('getTierConfig', () => {
+  it('returns free config for unknown plans', () => {
+    const config = getTierConfig('unknown_plan');
+    expect(config).toEqual(TIER_CONFIG.free);
+  });
+
+  it('returns the correct config for each known plan', () => {
+    for (const plan of ['free', 'trial', 'pro_managed', 'pro']) {
+      expect(getTierConfig(plan)).toEqual(TIER_CONFIG[plan]);
+    }
+  });
+});
+```
+
+Run: `npm test` → Expected: FAIL (tier-config module not found)
+
+- [ ] **Step 4b.2: Implement `src/tier-config.ts`**
+
+```typescript
+/**
+ * Tier Configuration — SINGLE SOURCE OF TRUTH for all plan capabilities.
+ *
+ * To add a new tier, add an entry here.
+ * To add a new feature flag, add it to TierFeatures and update each tier entry.
+ * To change a token limit or allowed model, edit this file only.
+ *
+ * No other file should define per-plan constants. Import getTierConfig() instead.
+ */
+
+export interface TierFeatures {
+  chat:            boolean;
+  generator:       boolean;
+  seo:             boolean;
+  images:          boolean;
+  own_key:         boolean;  // Pro BYOK: user supplies their own API key
+  model_selection: boolean;  // User can choose from allowed_models list
+}
+
+export interface TierConfig {
+  /** Monthly token budget. null = unlimited (Pro BYOK user's own cost). */
+  tokens_per_month:       number | null;
+  /**
+   * Models this tier may request. The Worker validates the requested model against this list.
+   * Empty array = unrestricted (Pro BYOK — any model the user's own key supports).
+   */
+  allowed_models:         string[];
+  /** Per-request token cap enforced by the Worker. null = no cap. */
+  max_tokens_per_request: number | null;
+  features:               TierFeatures;
+}
+
+export const TIER_CONFIG: Record<string, TierConfig> = {
+  free: {
+    tokens_per_month:       50_000,
+    allowed_models:         ['claude-haiku-4-5'],
+    max_tokens_per_request: 1_000,
+    features: {
+      chat: true, generator: false, seo: false, images: false,
+      own_key: false, model_selection: false,
+    },
+  },
+
+  trial: {
+    tokens_per_month:       300_000,
+    allowed_models:         ['claude-haiku-4-5'],
+    max_tokens_per_request: 1_000,
+    features: {
+      chat: true, generator: true, seo: true, images: true,
+      own_key: false, model_selection: false,
+    },
+  },
+
+  pro_managed: {
+    tokens_per_month:       2_000_000,
+    allowed_models:         ['claude-haiku-4-5', 'claude-sonnet-4-5', 'claude-opus-4-5'],
+    max_tokens_per_request: 8_000,
+    features: {
+      chat: true, generator: true, seo: true, images: true,
+      own_key: false, model_selection: true,
+    },
+  },
+
+  /** Pro BYOK: user supplies their own provider API key and routes direct. */
+  pro: {
+    tokens_per_month:       null,   // Unlimited — user pays their own API cost.
+    allowed_models:         [],     // Unrestricted — Worker not involved for BYOK routing.
+    max_tokens_per_request: null,
+    features: {
+      chat: true, generator: true, seo: true, images: true,
+      own_key: true, model_selection: true,
+    },
+  },
+};
+
+/**
+ * Returns the TierConfig for a given plan value.
+ * Falls back to `free` for any unknown plan to fail safe.
+ */
+export function getTierConfig(plan: string): TierConfig {
+  return TIER_CONFIG[plan] ?? TIER_CONFIG.free;
+}
+```
+
+- [ ] **Step 4b.3: Run tests to verify they pass**
+
+```bash
+npm test
+# Expected: All tier-config.test.ts tests PASS
+```
+
+- [ ] **Step 4b.4: Commit**
+
+```bash
+git add src/tier-config.ts test/tier-config.test.ts
+git commit -m "feat(proxy): add tier-config module as single source of truth for plan capabilities"
 ```
 
 ---
@@ -750,17 +976,10 @@ function makeEnv(usedTokens: number): Env {
   } as unknown as Env;
 }
 
-const trialUser: AuthUser = {
-  sub: 1, email: 'test@example.com', plan: 'trial', iat: 0, exp: 9999999999
-};
-
-const freeUser: AuthUser = {
-  sub: 2, email: 'free@example.com', plan: 'free', iat: 0, exp: 9999999999
-};
-
-const proUser: AuthUser = {
-  sub: 3, email: 'pro@example.com', plan: 'pro', iat: 0, exp: 9999999999
-};
+const trialUser:      AuthUser = { sub: 1, email: 'test@example.com',  plan: 'trial',       iat: 0, exp: 9999999999 };
+const freeUser:       AuthUser = { sub: 2, email: 'free@example.com',  plan: 'free',        iat: 0, exp: 9999999999 };
+const proManagedUser: AuthUser = { sub: 4, email: 'pm@example.com',    plan: 'pro_managed', iat: 0, exp: 9999999999 };
+const proUser:        AuthUser = { sub: 3, email: 'pro@example.com',   plan: 'pro',         iat: 0, exp: 9999999999 };
 
 describe('handleEntitlement', () => {
   it('returns correct token limit for trial plan', async () => {
@@ -778,11 +997,21 @@ describe('handleEntitlement', () => {
     expect(body.tokens_used).toBe(0);
   });
 
-  it('returns null token_limit for pro plan', async () => {
+  it('returns higher token limit for pro_managed plan', async () => {
+    const res  = await handleEntitlement(new Request('http://x'), makeEnv(100_000), proManagedUser);
+    const body = await res.json() as Record<string, unknown>;
+    expect((body.tokens_limit as number)).toBeGreaterThan(300_000);
+    expect((body.features as Record<string, boolean>).model_selection).toBe(true);
+    expect((body.features as Record<string, boolean>).own_key).toBe(false);
+    expect((body.allowed_models as string[]).length).toBeGreaterThan(1);
+  });
+
+  it('returns null token_limit for pro (BYOK) plan', async () => {
     const res  = await handleEntitlement(new Request('http://x'), makeEnv(0), proUser);
     const body = await res.json() as Record<string, unknown>;
     expect(body.tokens_limit).toBeNull();
     expect((body.features as Record<string, boolean>).own_key).toBe(true);
+    expect((body.allowed_models as string[])).toHaveLength(0); // unrestricted
   });
 
   it('returns correct feature flags for free plan', async () => {
@@ -792,6 +1021,8 @@ describe('handleEntitlement', () => {
     expect(features.chat).toBe(true);
     expect(features.generator).toBe(false);
     expect(features.own_key).toBe(false);
+    expect(features.model_selection).toBe(false);
+    expect((body.allowed_models as string[])).toHaveLength(1); // Haiku only
   });
 
   it('returns correct feature flags for trial plan', async () => {
@@ -801,6 +1032,7 @@ describe('handleEntitlement', () => {
     expect(features.chat).toBe(true);
     expect(features.generator).toBe(true);
     expect(features.own_key).toBe(false);
+    expect(features.model_selection).toBe(false);
   });
 });
 ```
@@ -811,30 +1043,19 @@ Run: `npm test` → Expected: FAIL (entitlement module not found)
 
 ```typescript
 import { yyyyMM, nextMonthStart } from './utils';
+import { getTierConfig } from './tier-config'; // ← single source of truth; no local plan constants
 import type { Env, AuthUser } from './types';
-
-const PLAN_LIMITS: Record<string, number | null> = {
-  free:  50_000,
-  trial: 300_000,
-  pro:   null,
-};
-
-const PLAN_FEATURES: Record<string, Record<string, boolean>> = {
-  free:  { chat: true, generator: false, seo: false, images: false, own_key: false },
-  trial: { chat: true, generator: true,  seo: true,  images: true,  own_key: false },
-  pro:   { chat: true, generator: true,  seo: true,  images: true,  own_key: true  },
-};
 
 export async function handleEntitlement(
   _req: Request,
   env: Env,
   user: AuthUser
 ): Promise<Response> {
+  const config   = getTierConfig(user.plan);
   const monthKey = `usage:${user.sub}:${yyyyMM()}`;
   const usedStr  = await env.USAGE_KV.get(monthKey);
   const used     = usedStr ? parseInt(usedStr, 10) : 0;
-  const limit    = PLAN_LIMITS[user.plan] ?? null;
-  const features = PLAN_FEATURES[user.plan] ?? PLAN_FEATURES.free;
+  const limit    = config.tokens_per_month;
 
   return new Response(JSON.stringify({
     plan:              user.plan,
@@ -842,7 +1063,8 @@ export async function handleEntitlement(
     tokens_limit:      limit,
     tokens_remaining:  limit === null ? null : Math.max(0, limit - used),
     resets_at:         nextMonthStart(),
-    features,
+    features:          config.features,
+    allowed_models:    config.allowed_models,  // PHP uses this to populate model selector
   }), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
@@ -1064,6 +1286,38 @@ git commit -m "chore(proxy): finalize production Cloudflare resource IDs"
 
 ---
 
+## Task 11: Post-implementation Code Reuse Verification
+
+> **Mandatory.** Run these checks before marking Phase 1 complete.
+
+- [ ] **Step 11.1: Confirm no scattered plan constants**
+
+```bash
+# Must return ZERO matches — all plan logic must be in tier-config.ts
+grep -rn "PLAN_LIMITS\|PLAN_FEATURES\|plan === 'free'\|plan === 'trial'\|plan === 'pro'" src/ \
+  --include="*.ts" | grep -v "tier-config.ts" | grep -v "\.test\.ts"
+# Expected: 0 matches (only tier-config.ts and test files are permitted)
+```
+
+- [ ] **Step 11.2: Confirm single-responsibility modules**
+
+Each file should have exactly one responsibility. Verify:
+- `tier-config.ts` — config only (no HTTP logic)
+- `jwt.ts` — JWT signing/verifying only
+- `password.ts` — hashing only
+- `auth.ts` — auth handlers only
+- `entitlement.ts` — entitlement handler only
+- `utils.ts` — pure utility functions only
+
+- [ ] **Step 11.3: Confirm tier-config is imported, not duplicated**
+
+```bash
+grep -rn "50_000\|300_000\|2_000_000\|claude-haiku" src/ --include="*.ts" | grep -v "tier-config.ts"
+# Expected: 0 matches — token limits and model names must not appear outside tier-config.ts
+```
+
+---
+
 ## Phase 1 Acceptance Criteria
 
 - [ ] `POST /v1/auth/register` → 201 with trial plan, 7-day expiry set in D1
@@ -1072,9 +1326,12 @@ git commit -m "chore(proxy): finalize production Cloudflare resource IDs"
 - [ ] `POST /v1/auth/token` expired trial → `plan: 'free'`
 - [ ] `POST /v1/auth/token` wrong password → 401
 - [ ] `POST /v1/auth/refresh` valid refresh token → new `access_token`
-- [ ] `GET /v1/entitlement` with Bearer → full entitlement shape with correct feature flags
+- [ ] `GET /v1/entitlement` with Bearer → full entitlement shape with correct feature flags **and `allowed_models` list**
+- [ ] `GET /v1/entitlement` for `pro_managed` user → `model_selection: true`, multiple `allowed_models`, higher `tokens_limit` than trial
+- [ ] `GET /v1/entitlement` for `pro` (BYOK) user → `tokens_limit: null`, `own_key: true`, `allowed_models: []`
 - [ ] `GET /v1/entitlement` without Bearer → 401
 - [ ] `POST /v1/chat` → 501 stub response (Phase 3 completes this)
+- [ ] `src/tier-config.ts` exports `TIER_CONFIG` with all four tiers; `getTierConfig('unknown')` falls back to `free`
 - [ ] All unit tests pass: `npm test`
 - [ ] Deployed to Cloudflare Workers; production smoke tests pass
 

--- a/docs/superpowers/plans/phases/phase-1-cf-worker-foundation.md
+++ b/docs/superpowers/plans/phases/phase-1-cf-worker-foundation.md
@@ -1,0 +1,1088 @@
+# Phase 1: Cloudflare Worker — Auth + D1 Foundation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A deployed, independently testable Cloudflare Worker that handles user registration, login, token refresh, and entitlement. Nothing in the WordPress plugin changes during this phase. Phases 2 and 3 are blocked until this is live.
+
+**Architecture:** Greenfield `wp-ai-mind-proxy/` TypeScript Worker project. D1 (SQLite) stores user accounts. KV stores monthly token usage. All crypto (JWT, password hashing) uses the Web Crypto API — no external libraries.
+
+**Tech Stack:** Cloudflare Workers (TypeScript), Cloudflare D1, Cloudflare KV, Wrangler CLI, Web Crypto API (HMAC-SHA256, PBKDF2), Vitest
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Password hashing | PBKDF2-SHA256, 100k iterations | bcrypt unavailable in Web Crypto; PBKDF2 is the correct alternative |
+| JWT algorithm | HMAC-SHA256 | No external deps; native Web Crypto; HS256 verified server-side only |
+| Token storage | access (1h) + refresh (30d) JWTs | Standard OAuth2 pattern; short-lived access reduces exposure |
+| Trial demotion | Happens at `POST /v1/auth/token` time | No cron needed; transparently enforced on next login |
+| Entitlement contract | Locked in this phase | PHP NJ_Entitlement (Phase 2) consumes this exact shape |
+
+---
+
+## File Map
+
+**Create new project `wp-ai-mind-proxy/` (sibling to the plugin repo, or in a separate repo):**
+
+```
+wp-ai-mind-proxy/
+  wrangler.toml              ← Cloudflare config (D1 + KV bindings)
+  package.json
+  tsconfig.json
+  migrations/
+    0001_init_users.sql      ← D1 schema
+  src/
+    index.ts                 ← Route dispatch + CORS
+    auth.ts                  ← register, token, refresh handlers
+    entitlement.ts           ← GET /v1/entitlement handler
+    chat.ts                  ← POST /v1/chat (returns 501 stub in this phase)
+    webhooks.ts              ← POST /webhooks/lemonsqueezy (returns 501 stub)
+    db.ts                    ← D1 helper wrappers
+    jwt.ts                   ← signJWT, verifyJWT
+    password.ts              ← hashPassword, verifyPassword
+    middleware.ts            ← requireAuth()
+    types.ts                 ← Env, User, AuthUser interfaces
+    utils.ts                 ← json(), hex(), b64url(), yyyyMM(), nextMonthStart()
+  test/
+    jwt.test.ts
+    password.test.ts
+    auth.test.ts
+    entitlement.test.ts
+```
+
+---
+
+## Task 1: Project Scaffold
+
+**Files:** Create `wp-ai-mind-proxy/` directory with initial config files.
+
+- [ ] **Step 1.1: Create project directory and package.json**
+
+```bash
+mkdir wp-ai-mind-proxy && cd wp-ai-mind-proxy
+npm init -y
+npm install --save-dev wrangler vitest @cloudflare/vitest-pool-workers typescript
+```
+
+- [ ] **Step 1.2: Create tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}
+```
+
+- [ ] **Step 1.3: Create wrangler.toml** (fill in IDs after running `wrangler d1 create` and `wrangler kv:namespace create` in Task 2)
+
+```toml
+name                = "wp-ai-mind-proxy"
+main                = "src/index.ts"
+compatibility_date  = "2025-01-01"
+
+[[d1_databases]]
+binding           = "DB"
+database_name     = "wp-ai-mind"
+database_id       = "REPLACE_AFTER_wrangler_d1_create"
+migrations_dir    = "migrations"
+
+[[kv_namespaces]]
+binding     = "USAGE_KV"
+id          = "REPLACE_AFTER_kv_create"
+preview_id  = "REPLACE_AFTER_kv_create_preview"
+
+[vars]
+ENVIRONMENT = "production"
+
+# Secrets set via CLI — never in this file:
+# wrangler secret put JWT_SECRET
+# wrangler secret put ANTHROPIC_API_KEY
+# wrangler secret put LEMONSQUEEZY_WEBHOOK_SECRET
+```
+
+- [ ] **Step 1.4: Add scripts to package.json**
+
+```json
+"scripts": {
+  "dev":    "wrangler dev",
+  "deploy": "wrangler deploy",
+  "test":   "vitest run",
+  "test:watch": "vitest"
+}
+```
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add .
+git commit -m "chore(proxy): scaffold wp-ai-mind-proxy project"
+```
+
+---
+
+## Task 2: Cloudflare Resources
+
+**Prerequisite:** `wrangler login` completed.
+
+- [ ] **Step 2.1: Create D1 database**
+
+```bash
+wrangler d1 create wp-ai-mind
+# Output example:
+# database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+# Copy this ID into wrangler.toml [[d1_databases]] database_id
+```
+
+- [ ] **Step 2.2: Create KV namespaces**
+
+```bash
+wrangler kv:namespace create USAGE_KV
+# Copy id → wrangler.toml [[kv_namespaces]] id
+
+wrangler kv:namespace create USAGE_KV --preview
+# Copy id → wrangler.toml [[kv_namespaces]] preview_id
+```
+
+- [ ] **Step 2.3: Set secrets**
+
+```bash
+wrangler secret put JWT_SECRET
+# Enter a long random string (e.g. openssl rand -hex 32)
+
+wrangler secret put ANTHROPIC_API_KEY
+# Enter your Anthropic API key (used in Phase 3; stubbed in Phase 1)
+
+wrangler secret put LEMONSQUEEZY_WEBHOOK_SECRET
+# Enter your LemonSqueezy webhook secret (used in Phase 3; stubbed in Phase 1)
+```
+
+- [ ] **Step 2.4: Commit updated wrangler.toml**
+
+```bash
+git add wrangler.toml
+git commit -m "chore(proxy): add Cloudflare resource IDs to wrangler.toml"
+```
+
+---
+
+## Task 3: D1 Migration
+
+**Files:** Create `migrations/0001_init_users.sql`
+
+- [ ] **Step 3.1: Write failing test for schema existence** (`test/auth.test.ts`)
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+describe('D1 schema', () => {
+  it('users table has required columns', async () => {
+    // This test documents the expected schema shape.
+    // Validated by integration test after migration applied.
+    const expectedColumns = ['id', 'email', 'password_hash', 'plan', 'plan_expires', 'created_at', 'updated_at'];
+    // Schema is verified visually / via wrangler d1 execute below.
+    expect(expectedColumns).toHaveLength(7);
+  });
+});
+```
+
+Run: `npm test` → Expected: PASS (placeholder assertion)
+
+- [ ] **Step 3.2: Write migration file**
+
+`migrations/0001_init_users.sql`:
+```sql
+CREATE TABLE IF NOT EXISTS users (
+  id            INTEGER  PRIMARY KEY AUTOINCREMENT,
+  email         TEXT     UNIQUE NOT NULL COLLATE NOCASE,
+  password_hash TEXT     NOT NULL,
+  plan          TEXT     NOT NULL DEFAULT 'trial',
+  plan_expires  DATETIME,
+  created_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+- [ ] **Step 3.3: Apply migration locally**
+
+```bash
+wrangler d1 migrations apply wp-ai-mind --local
+# Expected output: Applied 1 migration(s)
+```
+
+- [ ] **Step 3.4: Verify schema**
+
+```bash
+wrangler d1 execute wp-ai-mind --local --command "PRAGMA table_info(users);"
+# Expected: 7 rows (id, email, password_hash, plan, plan_expires, created_at, updated_at)
+```
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add migrations/
+git commit -m "feat(proxy): add D1 users table migration"
+```
+
+---
+
+## Task 4: Types and Utilities
+
+**Files:** Create `src/types.ts` and `src/utils.ts`
+
+- [ ] **Step 4.1: Write `src/types.ts`**
+
+```typescript
+export interface Env {
+  DB:         D1Database;
+  USAGE_KV:   KVNamespace;
+  JWT_SECRET: string;
+  ANTHROPIC_API_KEY: string;
+  LEMONSQUEEZY_WEBHOOK_SECRET: string;
+  ENVIRONMENT?: string;
+}
+
+export interface User {
+  id:            number;
+  email:         string;
+  password_hash: string;
+  plan:          'free' | 'trial' | 'pro';
+  plan_expires:  string | null;
+  created_at:    string;
+  updated_at:    string;
+}
+
+export interface AuthUser {
+  sub:   number;
+  email: string;
+  plan:  'free' | 'trial' | 'pro';
+  iat:   number;
+  exp:   number;
+  type?: string;
+}
+```
+
+- [ ] **Step 4.2: Write `src/utils.ts`**
+
+```typescript
+export function json(data: unknown, status = 200, headers: HeadersInit = {}): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+export function hex(bytes: Uint8Array): string {
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export function yyyyMM(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+export function nextMonthStart(): string {
+  const d = new Date();
+  return new Date(d.getFullYear(), d.getMonth() + 1, 1).toISOString();
+}
+
+export function secondsUntilMonthEnd(): number {
+  const now  = new Date();
+  const next = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+  return Math.floor((next.getTime() - now.getTime()) / 1000);
+}
+```
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add src/types.ts src/utils.ts
+git commit -m "feat(proxy): add types and utility helpers"
+```
+
+---
+
+## Task 5: JWT Implementation
+
+**Files:** Create `src/jwt.ts`, `test/jwt.test.ts`
+
+- [ ] **Step 5.1: Write failing tests** (`test/jwt.test.ts`)
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { signJWT, verifyJWT } from '../src/jwt';
+
+const SECRET = 'test-secret-32-chars-minimum-length';
+
+describe('signJWT', () => {
+  it('returns a three-part dot-separated string', async () => {
+    const token = await signJWT({ sub: 1 }, SECRET, 3600);
+    expect(token.split('.')).toHaveLength(3);
+  });
+
+  it('encodes the payload correctly', async () => {
+    const token   = await signJWT({ sub: 42, plan: 'trial' }, SECRET, 3600);
+    const [, p]   = token.split('.');
+    const payload = JSON.parse(atob(p.replace(/-/g, '+').replace(/_/g, '/')));
+    expect(payload.sub).toBe(42);
+    expect(payload.plan).toBe('trial');
+    expect(payload.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+});
+
+describe('verifyJWT', () => {
+  it('returns payload for a valid token', async () => {
+    const token   = await signJWT({ sub: 1, email: 'test@example.com' }, SECRET, 3600);
+    const payload = await verifyJWT(token, SECRET);
+    expect(payload).not.toBeNull();
+    expect(payload!.sub).toBe(1);
+    expect(payload!.email).toBe('test@example.com');
+  });
+
+  it('returns null for a tampered token', async () => {
+    const token  = await signJWT({ sub: 1 }, SECRET, 3600);
+    const parts  = token.split('.');
+    parts[1]     = btoa(JSON.stringify({ sub: 999 })).replace(/=/g, '');
+    const result = await verifyJWT(parts.join('.'), SECRET);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a wrong secret', async () => {
+    const token  = await signJWT({ sub: 1 }, SECRET, 3600);
+    const result = await verifyJWT(token, 'wrong-secret');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for an expired token', async () => {
+    const token  = await signJWT({ sub: 1 }, SECRET, -1);
+    const result = await verifyJWT(token, SECRET);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a malformed token', async () => {
+    expect(await verifyJWT('not.a.jwt', SECRET)).toBeNull();
+    expect(await verifyJWT('', SECRET)).toBeNull();
+  });
+});
+```
+
+Run: `npm test` → Expected: FAIL (jwt module not found)
+
+- [ ] **Step 5.2: Implement `src/jwt.ts`**
+
+```typescript
+const ALGO = { name: 'HMAC', hash: 'SHA-256' } as const;
+
+function b64url(input: string | ArrayBuffer): string {
+  const bytes = typeof input === 'string'
+    ? new TextEncoder().encode(input)
+    : new Uint8Array(input);
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function b64urlDecode(str: string): Uint8Array {
+  const padded = str.padEnd(str.length + (4 - (str.length % 4 || 4)), '=');
+  const binary = atob(padded.replace(/-/g, '+').replace(/_/g, '/'));
+  return Uint8Array.from(binary, c => c.charCodeAt(0));
+}
+
+async function importKey(secret: string, usage: KeyUsage[]): Promise<CryptoKey> {
+  return crypto.subtle.importKey('raw', new TextEncoder().encode(secret), ALGO, false, usage);
+}
+
+export async function signJWT(
+  payload: Record<string, unknown>,
+  secret: string,
+  expiresInSeconds: number
+): Promise<string> {
+  const now  = Math.floor(Date.now() / 1000);
+  const full = { ...payload, iat: now, exp: now + expiresInSeconds };
+  const h    = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const p    = b64url(JSON.stringify(full));
+  const key  = await importKey(secret, ['sign']);
+  const sig  = await crypto.subtle.sign(ALGO, key, new TextEncoder().encode(`${h}.${p}`));
+  return `${h}.${p}.${b64url(sig)}`;
+}
+
+export async function verifyJWT(
+  token: string,
+  secret: string
+): Promise<Record<string, unknown> | null> {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const [h, p, s] = parts;
+    const key = await importKey(secret, ['verify']);
+    const valid = await crypto.subtle.verify(
+      ALGO, key, b64urlDecode(s), new TextEncoder().encode(`${h}.${p}`)
+    );
+    if (!valid) return null;
+    const payload = JSON.parse(new TextDecoder().decode(b64urlDecode(p)));
+    if (payload.exp < Math.floor(Date.now() / 1000)) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 5.3: Run tests to verify they pass**
+
+```bash
+npm test
+# Expected: All jwt.test.ts tests PASS
+```
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add src/jwt.ts test/jwt.test.ts
+git commit -m "feat(proxy): implement HMAC-SHA256 JWT sign/verify"
+```
+
+---
+
+## Task 6: Password Hashing
+
+**Files:** Create `src/password.ts`, `test/password.test.ts`
+
+- [ ] **Step 6.1: Write failing tests** (`test/password.test.ts`)
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { hashPassword, verifyPassword } from '../src/password';
+
+describe('hashPassword', () => {
+  it('returns a salt:hash hex string', async () => {
+    const hash = await hashPassword('MyPassword123!');
+    const parts = hash.split(':');
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toHaveLength(32); // 16 bytes hex = 32 chars
+    expect(parts[1]).toHaveLength(64); // 32 bytes hex = 64 chars
+  });
+
+  it('produces different hashes for same password (random salt)', async () => {
+    const h1 = await hashPassword('same');
+    const h2 = await hashPassword('same');
+    expect(h1).not.toBe(h2);
+  });
+});
+
+describe('verifyPassword', () => {
+  it('returns true for correct password', async () => {
+    const hash  = await hashPassword('correct-horse-battery-staple');
+    const valid = await verifyPassword('correct-horse-battery-staple', hash);
+    expect(valid).toBe(true);
+  });
+
+  it('returns false for wrong password', async () => {
+    const hash  = await hashPassword('correct');
+    const valid = await verifyPassword('wrong', hash);
+    expect(valid).toBe(false);
+  });
+
+  it('returns false for malformed stored hash', async () => {
+    expect(await verifyPassword('test', 'not-a-hash')).toBe(false);
+    expect(await verifyPassword('test', '')).toBe(false);
+    expect(await verifyPassword('test', 'aaa:bbb:ccc')).toBe(false);
+  });
+});
+```
+
+Run: `npm test` → Expected: FAIL (password module not found)
+
+- [ ] **Step 6.2: Implement `src/password.ts`**
+
+```typescript
+import { hex } from './utils';
+
+const ITERATIONS = 100_000;
+const KEY_BYTES  = 32;
+
+export async function hashPassword(plain: string): Promise<string> {
+  const salt    = crypto.getRandomValues(new Uint8Array(16));
+  const keyMat  = await derive(plain, salt);
+  return `${hex(salt)}:${hex(new Uint8Array(keyMat))}`;
+}
+
+export async function verifyPassword(plain: string, stored: string): Promise<boolean> {
+  try {
+    const parts = stored.split(':');
+    if (parts.length !== 2) return false;
+    const [saltHex, hashHex] = parts;
+    if (saltHex.length !== 32 || hashHex.length !== 64) return false;
+    const salt   = unhex(saltHex);
+    const keyMat = await derive(plain, salt);
+    return hex(new Uint8Array(keyMat)) === hashHex;
+  } catch {
+    return false;
+  }
+}
+
+async function derive(plain: string, salt: Uint8Array): Promise<ArrayBuffer> {
+  const base = await crypto.subtle.importKey(
+    'raw', new TextEncoder().encode(plain), 'PBKDF2', false, ['deriveBits']
+  );
+  return crypto.subtle.deriveBits(
+    { name: 'PBKDF2', hash: 'SHA-256', salt, iterations: ITERATIONS },
+    base, KEY_BYTES * 8
+  );
+}
+
+function unhex(s: string): Uint8Array {
+  const pairs = s.match(/.{2}/g);
+  if (!pairs) throw new Error('Invalid hex string');
+  return new Uint8Array(pairs.map(b => parseInt(b, 16)));
+}
+```
+
+- [ ] **Step 6.3: Run tests to verify they pass**
+
+```bash
+npm test
+# Expected: All password.test.ts tests PASS
+# Note: 100k PBKDF2 iterations may make tests slow (~1–2s each) — acceptable
+```
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add src/password.ts test/password.test.ts
+git commit -m "feat(proxy): implement PBKDF2 password hash/verify"
+```
+
+---
+
+## Task 7: Auth Handlers
+
+**Files:** Create `src/auth.ts`, `src/middleware.ts`, add tests to `test/auth.test.ts`
+
+- [ ] **Step 7.1: Write failing tests** (add to `test/auth.test.ts`)
+
+```typescript
+// Note: Full integration tests require @cloudflare/vitest-pool-workers with D1 binding.
+// These unit tests validate handler logic with mocked D1.
+
+import { describe, it, expect, vi } from 'vitest';
+import { handleRegister, handleToken, handleRefresh } from '../src/auth';
+
+function makeEnv(dbResult: Record<string, unknown> | null = null) {
+  return {
+    DB: {
+      prepare: vi.fn().mockReturnValue({
+        bind: vi.fn().mockReturnThis(),
+        run:   vi.fn().mockResolvedValue({ success: true }),
+        first: vi.fn().mockResolvedValue(dbResult),
+      }),
+    },
+    JWT_SECRET: 'test-secret-long-enough-for-hmac-sha256',
+  } as unknown as import('../src/types').Env;
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('handleRegister', () => {
+  it('returns 400 if email missing', async () => {
+    const res = await handleRegister(makeRequest({ password: 'pass123' }), makeEnv());
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 201 on success', async () => {
+    const res = await handleRegister(makeRequest({ email: 'a@b.com', password: 'pass1234' }), makeEnv());
+    expect(res.status).toBe(201);
+  });
+});
+
+describe('handleToken', () => {
+  it('returns 401 if user not found', async () => {
+    const res = await handleToken(makeRequest({ email: 'no@user.com', password: 'x' }), makeEnv(null));
+    expect(res.status).toBe(401);
+  });
+});
+```
+
+Run: `npm test` → Expected: FAIL (auth module not found)
+
+- [ ] **Step 7.2: Implement `src/auth.ts`**
+
+```typescript
+import { hashPassword, verifyPassword } from './password';
+import { signJWT, verifyJWT } from './jwt';
+import { json } from './utils';
+import type { Env, User } from './types';
+
+export async function handleRegister(req: Request, env: Env): Promise<Response> {
+  const body = await req.json<{ email?: string; password?: string }>();
+  const email    = body.email?.trim().toLowerCase();
+  const password = body.password;
+
+  if (!email || !password)      return json({ error: 'email and password required' }, 400);
+  if (password.length < 8)      return json({ error: 'password must be at least 8 characters' }, 400);
+  if (!email.includes('@'))     return json({ error: 'invalid email address' }, 400);
+
+  const hash    = await hashPassword(password);
+  const expires = new Date(Date.now() + 7 * 86_400_000).toISOString();
+
+  try {
+    await env.DB.prepare(
+      `INSERT INTO users (email, password_hash, plan, plan_expires) VALUES (?, ?, 'trial', ?)`
+    ).bind(email, hash, expires).run();
+  } catch {
+    return json({ error: 'Email already registered' }, 409);
+  }
+
+  return json({ message: 'Account created. Your 7-day trial starts now.' }, 201);
+}
+
+export async function handleToken(req: Request, env: Env): Promise<Response> {
+  const body  = await req.json<{ email?: string; password?: string }>();
+  const email = body.email?.trim().toLowerCase() ?? '';
+
+  const user = await env.DB.prepare(`SELECT * FROM users WHERE email = ?`)
+    .bind(email).first<User>();
+
+  if (!user || !(await verifyPassword(body.password ?? '', user.password_hash))) {
+    await new Promise(r => setTimeout(r, 200)); // Constant-time delay to prevent timing attacks.
+    return json({ error: 'Invalid credentials' }, 401);
+  }
+
+  let plan = user.plan;
+  if (plan === 'trial' && user.plan_expires && new Date(user.plan_expires) < new Date()) {
+    plan = 'free';
+    await env.DB.prepare(
+      `UPDATE users SET plan = 'free', plan_expires = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?`
+    ).bind(user.id).run();
+  }
+
+  const access  = await signJWT({ sub: user.id, email: user.email, plan }, env.JWT_SECRET, 3600);
+  const refresh = await signJWT({ sub: user.id, type: 'refresh' }, env.JWT_SECRET, 30 * 86_400);
+
+  return json({ access_token: access, refresh_token: refresh, plan });
+}
+
+export async function handleRefresh(req: Request, env: Env): Promise<Response> {
+  const body    = await req.json<{ refresh_token?: string }>();
+  const payload = await verifyJWT(body.refresh_token ?? '', env.JWT_SECRET);
+
+  if (!payload || payload['type'] !== 'refresh') {
+    return json({ error: 'Invalid or expired refresh token' }, 401);
+  }
+
+  const user = await env.DB.prepare(`SELECT * FROM users WHERE id = ?`)
+    .bind(payload['sub']).first<User>();
+  if (!user) return json({ error: 'User not found' }, 404);
+
+  const access = await signJWT({ sub: user.id, email: user.email, plan: user.plan }, env.JWT_SECRET, 3600);
+  return json({ access_token: access });
+}
+```
+
+- [ ] **Step 7.3: Implement `src/middleware.ts`**
+
+```typescript
+import { verifyJWT } from './jwt';
+import { json } from './utils';
+import type { Env, AuthUser } from './types';
+
+export async function requireAuth(
+  req: Request,
+  env: Env
+): Promise<{ user: AuthUser } | Response> {
+  const auth = req.headers.get('Authorization') ?? '';
+  if (!auth.startsWith('Bearer ')) return json({ error: 'Unauthorized' }, 401);
+
+  const payload = await verifyJWT(auth.slice(7), env.JWT_SECRET);
+  if (!payload) return json({ error: 'Invalid or expired token' }, 401);
+
+  return { user: payload as AuthUser };
+}
+```
+
+- [ ] **Step 7.4: Run tests to verify they pass**
+
+```bash
+npm test
+# Expected: All auth.test.ts and middleware unit tests PASS
+```
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add src/auth.ts src/middleware.ts test/auth.test.ts
+git commit -m "feat(proxy): implement register, login, refresh handlers"
+```
+
+---
+
+## Task 8: Entitlement Handler
+
+**Files:** Create `src/entitlement.ts`, `test/entitlement.test.ts`
+
+- [ ] **Step 8.1: Write failing tests** (`test/entitlement.test.ts`)
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { handleEntitlement } from '../src/entitlement';
+import type { Env, AuthUser } from '../src/types';
+
+function makeEnv(usedTokens: number): Env {
+  return {
+    USAGE_KV: {
+      get: vi.fn().mockResolvedValue(usedTokens > 0 ? String(usedTokens) : null),
+    },
+  } as unknown as Env;
+}
+
+const trialUser: AuthUser = {
+  sub: 1, email: 'test@example.com', plan: 'trial', iat: 0, exp: 9999999999
+};
+
+const freeUser: AuthUser = {
+  sub: 2, email: 'free@example.com', plan: 'free', iat: 0, exp: 9999999999
+};
+
+const proUser: AuthUser = {
+  sub: 3, email: 'pro@example.com', plan: 'pro', iat: 0, exp: 9999999999
+};
+
+describe('handleEntitlement', () => {
+  it('returns correct token limit for trial plan', async () => {
+    const res  = await handleEntitlement(new Request('http://x'), makeEnv(5000), trialUser);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.tokens_limit).toBe(300_000);
+    expect(body.tokens_used).toBe(5000);
+    expect(body.plan).toBe('trial');
+  });
+
+  it('returns correct token limit for free plan', async () => {
+    const res  = await handleEntitlement(new Request('http://x'), makeEnv(0), freeUser);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.tokens_limit).toBe(50_000);
+    expect(body.tokens_used).toBe(0);
+  });
+
+  it('returns null token_limit for pro plan', async () => {
+    const res  = await handleEntitlement(new Request('http://x'), makeEnv(0), proUser);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.tokens_limit).toBeNull();
+    expect((body.features as Record<string, boolean>).own_key).toBe(true);
+  });
+
+  it('returns correct feature flags for free plan', async () => {
+    const res      = await handleEntitlement(new Request('http://x'), makeEnv(0), freeUser);
+    const body     = await res.json() as Record<string, unknown>;
+    const features = body.features as Record<string, boolean>;
+    expect(features.chat).toBe(true);
+    expect(features.generator).toBe(false);
+    expect(features.own_key).toBe(false);
+  });
+
+  it('returns correct feature flags for trial plan', async () => {
+    const res      = await handleEntitlement(new Request('http://x'), makeEnv(0), trialUser);
+    const body     = await res.json() as Record<string, unknown>;
+    const features = body.features as Record<string, boolean>;
+    expect(features.chat).toBe(true);
+    expect(features.generator).toBe(true);
+    expect(features.own_key).toBe(false);
+  });
+});
+```
+
+Run: `npm test` → Expected: FAIL (entitlement module not found)
+
+- [ ] **Step 8.2: Implement `src/entitlement.ts`**
+
+```typescript
+import { yyyyMM, nextMonthStart } from './utils';
+import type { Env, AuthUser } from './types';
+
+const PLAN_LIMITS: Record<string, number | null> = {
+  free:  50_000,
+  trial: 300_000,
+  pro:   null,
+};
+
+const PLAN_FEATURES: Record<string, Record<string, boolean>> = {
+  free:  { chat: true, generator: false, seo: false, images: false, own_key: false },
+  trial: { chat: true, generator: true,  seo: true,  images: true,  own_key: false },
+  pro:   { chat: true, generator: true,  seo: true,  images: true,  own_key: true  },
+};
+
+export async function handleEntitlement(
+  _req: Request,
+  env: Env,
+  user: AuthUser
+): Promise<Response> {
+  const monthKey = `usage:${user.sub}:${yyyyMM()}`;
+  const usedStr  = await env.USAGE_KV.get(monthKey);
+  const used     = usedStr ? parseInt(usedStr, 10) : 0;
+  const limit    = PLAN_LIMITS[user.plan] ?? null;
+  const features = PLAN_FEATURES[user.plan] ?? PLAN_FEATURES.free;
+
+  return new Response(JSON.stringify({
+    plan:              user.plan,
+    tokens_used:       used,
+    tokens_limit:      limit,
+    tokens_remaining:  limit === null ? null : Math.max(0, limit - used),
+    resets_at:         nextMonthStart(),
+    features,
+  }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+```
+
+- [ ] **Step 8.3: Run tests to verify they pass**
+
+```bash
+npm test
+# Expected: All entitlement.test.ts tests PASS
+```
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git add src/entitlement.ts test/entitlement.test.ts
+git commit -m "feat(proxy): implement GET /v1/entitlement handler"
+```
+
+---
+
+## Task 9: Stubs + Route Dispatch
+
+**Files:** Create `src/chat.ts`, `src/webhooks.ts`, `src/db.ts`, `src/index.ts`
+
+- [ ] **Step 9.1: Create `src/chat.ts` (stub)**
+
+```typescript
+import { json } from './utils';
+import type { Env, AuthUser } from './types';
+
+export async function handleChat(
+  _req: Request,
+  _env: Env,
+  _user: AuthUser
+): Promise<Response> {
+  return json({ error: 'Chat proxy not yet implemented. Coming in Phase 3.' }, 501);
+}
+```
+
+- [ ] **Step 9.2: Create `src/webhooks.ts` (stub)**
+
+```typescript
+import { json } from './utils';
+import type { Env } from './types';
+
+export async function handleLemonSqueezy(
+  _req: Request,
+  _env: Env
+): Promise<Response> {
+  return json({ error: 'Webhook handler not yet implemented. Coming in Phase 3.' }, 501);
+}
+```
+
+- [ ] **Step 9.3: Create `src/db.ts`**
+
+```typescript
+import type { Env, User } from './types';
+
+export async function getUserByEmail(email: string, env: Env): Promise<User | null> {
+  return env.DB.prepare(`SELECT * FROM users WHERE email = ?`)
+    .bind(email.toLowerCase().trim()).first<User>();
+}
+
+export async function getUserById(id: number, env: Env): Promise<User | null> {
+  return env.DB.prepare(`SELECT * FROM users WHERE id = ?`).bind(id).first<User>();
+}
+
+export async function updateUserPlan(
+  email: string,
+  plan: 'free' | 'trial' | 'pro',
+  planExpires: string | null,
+  env: Env
+): Promise<void> {
+  await env.DB.prepare(
+    `UPDATE users SET plan = ?, plan_expires = ?, updated_at = CURRENT_TIMESTAMP WHERE email = ?`
+  ).bind(plan, planExpires, email.toLowerCase().trim()).run();
+}
+```
+
+- [ ] **Step 9.4: Create `src/index.ts`**
+
+```typescript
+import { handleRegister, handleToken, handleRefresh } from './auth';
+import { handleEntitlement } from './entitlement';
+import { handleChat } from './chat';
+import { handleLemonSqueezy } from './webhooks';
+import { requireAuth } from './middleware';
+import { json } from './utils';
+import type { Env } from './types';
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url    = new URL(request.url);
+    const method = request.method;
+    const path   = url.pathname;
+
+    // CORS preflight
+    if (method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders(request) });
+    }
+
+    // Public routes
+    if (method === 'POST' && path === '/v1/auth/register')      return handleRegister(request, env);
+    if (method === 'POST' && path === '/v1/auth/token')         return handleToken(request, env);
+    if (method === 'POST' && path === '/v1/auth/refresh')       return handleRefresh(request, env);
+    if (method === 'POST' && path === '/webhooks/lemonsqueezy') return handleLemonSqueezy(request, env);
+
+    // Authenticated routes
+    const authResult = await requireAuth(request, env);
+    if (authResult instanceof Response) return authResult;
+    const { user } = authResult;
+
+    if (method === 'GET'  && path === '/v1/entitlement') return handleEntitlement(request, env, user);
+    if (method === 'POST' && path === '/v1/chat')        return handleChat(request, env, user);
+
+    return json({ error: 'Not found' }, 404);
+  },
+};
+
+function corsHeaders(req: Request): HeadersInit {
+  return {
+    'Access-Control-Allow-Origin':  req.headers.get('Origin') ?? '*',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+    'Access-Control-Max-Age':       '86400',
+  };
+}
+```
+
+- [ ] **Step 9.5: Run full test suite**
+
+```bash
+npm test
+# Expected: All tests PASS (jwt, password, auth, entitlement)
+```
+
+- [ ] **Step 9.6: Commit**
+
+```bash
+git add src/
+git commit -m "feat(proxy): add route dispatch, stubs, and db helpers"
+```
+
+---
+
+## Task 10: Deploy and Smoke Test
+
+- [ ] **Step 10.1: Local smoke test**
+
+```bash
+wrangler dev
+# In a new terminal:
+
+# Register
+curl -X POST http://localhost:8787/v1/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"test@example.com","password":"testpass123"}' | jq .
+# Expected: {"message":"Account created. Your 7-day trial starts now."}
+
+# Login
+curl -X POST http://localhost:8787/v1/auth/token \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"test@example.com","password":"testpass123"}' | jq .
+# Expected: {"access_token":"eyJ...","refresh_token":"eyJ...","plan":"trial"}
+# Save the access_token as TOKEN
+
+# Entitlement
+curl http://localhost:8787/v1/entitlement \
+  -H "Authorization: Bearer $TOKEN" | jq .
+# Expected: {"plan":"trial","tokens_used":0,"tokens_limit":300000,...}
+
+# Unauthenticated access
+curl http://localhost:8787/v1/entitlement | jq .
+# Expected: {"error":"Unauthorized"}
+```
+
+- [ ] **Step 10.2: Deploy to Cloudflare**
+
+```bash
+wrangler deploy
+# Note the deployed URL, e.g. https://wp-ai-mind-proxy.YOUR.workers.dev
+# Update NJ_Auth::PROXY_BASE in includes/Auth/NJ_Auth.php (Phase 2) with this URL
+```
+
+- [ ] **Step 10.3: Apply migration to production**
+
+```bash
+wrangler d1 migrations apply wp-ai-mind --remote
+# Expected: Applied 1 migration(s)
+```
+
+- [ ] **Step 10.4: Production smoke test (repeat Step 10.1 against live URL)**
+
+```bash
+BASE="https://wp-ai-mind-proxy.YOUR.workers.dev"
+
+curl -X POST $BASE/v1/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"smoke@example.com","password":"smoketest123"}' | jq .
+# Expected: 201 with message
+
+TOKEN=$(curl -s -X POST $BASE/v1/auth/token \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"smoke@example.com","password":"smoketest123"}' | jq -r .access_token)
+
+curl $BASE/v1/entitlement -H "Authorization: Bearer $TOKEN" | jq .
+# Expected: full entitlement doc with plan='trial'
+```
+
+- [ ] **Step 10.5: Commit final wrangler.toml with production resource IDs**
+
+```bash
+git add wrangler.toml
+git commit -m "chore(proxy): finalize production Cloudflare resource IDs"
+```
+
+---
+
+## Phase 1 Acceptance Criteria
+
+- [ ] `POST /v1/auth/register` → 201 with trial plan, 7-day expiry set in D1
+- [ ] `POST /v1/auth/register` duplicate email → 409
+- [ ] `POST /v1/auth/token` correct credentials → `access_token`, `refresh_token`, `plan`
+- [ ] `POST /v1/auth/token` expired trial → `plan: 'free'`
+- [ ] `POST /v1/auth/token` wrong password → 401
+- [ ] `POST /v1/auth/refresh` valid refresh token → new `access_token`
+- [ ] `GET /v1/entitlement` with Bearer → full entitlement shape with correct feature flags
+- [ ] `GET /v1/entitlement` without Bearer → 401
+- [ ] `POST /v1/chat` → 501 stub response (Phase 3 completes this)
+- [ ] All unit tests pass: `npm test`
+- [ ] Deployed to Cloudflare Workers; production smoke tests pass
+
+---
+
+## Phase 1 Risk Notes
+
+- **PBKDF2 at 100k iterations is ~150ms per login.** Acceptable (login is not a hot path). Reduce to 60k if Cloudflare CPU limit warnings appear.
+- **D1 is eventually consistent across regions.** Logins may appear delayed ~1s at edge. Acceptable.
+- **Trial expiry race:** A user's cached JWT (up to 1h old) may show `plan: 'trial'` after expiry. The 1-hour JWT TTL keeps the window short — acceptable.
+- **Constant-time delay on auth failure:** 200ms delay in `handleToken` prevents timing-based email enumeration.

--- a/docs/superpowers/plans/phases/phase-2-php-auth-entitlement.md
+++ b/docs/superpowers/plans/phases/phase-2-php-auth-entitlement.md
@@ -12,6 +12,41 @@
 
 ---
 
+## Task 0: Pre-implementation Reuse Audit
+
+> **Mandatory.** Complete before writing any new PHP classes.
+
+- [ ] **Step 0.1: Audit existing Auth-related PHP files**
+
+```bash
+find includes/ -name "*.php" | xargs grep -l "token\|auth\|jwt\|session" -i 2>/dev/null
+# Review each match. Do not create a new class for logic that already exists.
+```
+
+- [ ] **Step 0.2: Audit existing REST controller pattern**
+
+```bash
+ls includes/Admin/*RestController.php includes/Modules/**/*RestController.php 2>/dev/null
+# Follow the same structure/conventions as existing REST controllers.
+```
+
+- [ ] **Step 0.3: Audit `wp_options` usage pattern in the plugin**
+
+```bash
+grep -rn "get_option\|update_option" includes/ --include="*.php" | head -20
+# Understand naming conventions (prefix `wpaim_`) before choosing option keys.
+```
+
+- [ ] **Step 0.4: Confirm NJ_Auth and NJ_Entitlement do not already exist**
+
+```bash
+ls includes/Auth/NJ_Auth.php includes/Entitlement/NJ_Entitlement.php 2>/dev/null \
+  || echo "Confirmed: classes not yet created"
+# If either exists, read it fully before proceeding — do not overwrite in-progress work.
+```
+
+---
+
 ## Design Decisions
 
 | Decision | Choice | Reason |
@@ -379,12 +414,14 @@ class NJ_Entitlement {
             'tokens_remaining' => 0,
             'resets_at'        => null,
             'features'         => [
-                'chat'      => false,
-                'generator' => false,
-                'seo'       => false,
-                'images'    => false,
-                'own_key'   => false,
+                'chat'            => false,
+                'generator'       => false,
+                'seo'             => false,
+                'images'          => false,
+                'own_key'         => false,
+                'model_selection' => false,
             ],
+            'allowed_models'   => [],  // Populated from Worker entitlement response for pro_managed
         ];
     }
 
@@ -671,6 +708,41 @@ git commit -m "feat(auth): wire NJ_Auth and NJ_Entitlement into plugin bootstrap
 
 ---
 
+## Task 5: Post-implementation Code Reuse Verification
+
+> **Mandatory.** Run before marking Phase 2 complete.
+
+- [ ] **Step 5.1: No duplicate WP option keys**
+
+```bash
+grep -rn "wpaim_nj_access_token\|wpaim_nj_refresh_token\|wpaim_entitlement" includes/ --include="*.php"
+# Expected: only NJ_Auth.php and NJ_Entitlement.php reference these keys
+```
+
+- [ ] **Step 5.2: No plan-name checks in PHP (use nj_feature() instead)**
+
+```bash
+grep -rn "plan.*===\|=== .*plan\|pro_managed\|'free'\|'trial'" includes/ --include="*.php" \
+  | grep -v "NJ_Entitlement\|NJ_Auth\|Test"
+# Expected: no plan-name string comparisons outside the entitlement class
+```
+
+- [ ] **Step 5.3: Confirm `nj_feature('model_selection')` is available**
+
+```bash
+grep -n "model_selection" includes/Entitlement/NJ_Entitlement.php
+# Expected: appears in empty_doc() features array
+```
+
+- [ ] **Step 5.4: Full test suite still passes**
+
+```bash
+./vendor/bin/phpunit tests/Unit/ --colors=always
+# Expected: all tests pass
+```
+
+---
+
 ## Phase 2 Acceptance Criteria
 
 - [ ] `POST /wp-ai-mind/v1/nj/login` with correct credentials → stores tokens in wp_options, returns entitlement doc
@@ -679,7 +751,10 @@ git commit -m "feat(auth): wire NJ_Auth and NJ_Entitlement into plugin bootstrap
 - [ ] `GET /wp-ai-mind/v1/nj/me` → returns fresh entitlement (busts cache first)
 - [ ] `POST /wp-ai-mind/v1/nj/logout` → clears tokens and transient
 - [ ] `nj_feature('chat')` returns `false` when not authenticated
-- [ ] `nj_feature('chat')` returns `true` after login with trial/free/pro plan
+- [ ] `nj_feature('chat')` returns `true` after login with trial/free/pro_managed/pro plan
+- [ ] `nj_feature('model_selection')` returns `true` for `pro_managed` and `pro` plans; `false` for `free`/`trial`
+- [ ] Entitlement doc includes `allowed_models` array (populated from Worker response)
+- [ ] `wpAiMindData` includes `allowed_models` for use in React model selector (Phase 6)
 - [ ] Entitlement transient is set after first fetch; second call does not make HTTP request
 - [ ] Refresh token is stored encrypted in `wp_options`; raw JWT value is never written to the database
 - [ ] `NJ_Auth::encrypt_refresh()` / `decrypt_refresh()` round-trip returns original value

--- a/docs/superpowers/plans/phases/phase-2-php-auth-entitlement.md
+++ b/docs/superpowers/plans/phases/phase-2-php-auth-entitlement.md
@@ -16,7 +16,7 @@
 
 | Decision | Choice | Reason |
 |----------|--------|--------|
-| Token storage | `wp_options` (not encrypted for access token) | Short-lived JWT is an opaque Bearer credential; same risk as storing any API key. Refresh token should be encrypted with AES-256-CBC using AUTH_KEY |
+| Token storage | `wp_options` (access token plain; refresh token AES-256-CBC encrypted) | Access token is short-lived (1 h) — same risk as any API key. Refresh token has a 30-day lifetime and is encrypted with `openssl_encrypt( $refresh, 'aes-256-cbc', AUTH_KEY, 0, AUTH_SALT )` before writing to `wp_options`, and decrypted on read. |
 | Entitlement cache | 1-hour WP transient | Matches JWT expiry window; balances freshness vs HTTP overhead |
 | Null-object pattern | `empty_doc()` returns a fully-shaped array | Callers never need to null-check; feature flags default to `false` |
 | Proactive refresh | Refresh when token has < 5 minutes remaining | Prevents mid-request token expiry without adding a second HTTP round-trip |
@@ -102,6 +102,38 @@ class NJAuthTest extends TestCase {
         $this->assertNull( $method->invoke( null, 'not.a.jwt' ) );
         $this->assertNull( $method->invoke( null, '' ) );
     }
+
+    public function test_stored_refresh_token_is_encrypted(): void {
+        if ( ! defined( 'AUTH_KEY' ) ) {
+            define( 'AUTH_KEY', 'test-auth-key-32-bytes-long-value' );
+        }
+        if ( ! defined( 'AUTH_SALT' ) ) {
+            define( 'AUTH_SALT', 'test-auth-salt-16b' );
+        }
+
+        $raw_refresh = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMSJ9.sig';
+        $stored_value = null;
+
+        Functions\when( 'update_option' )->alias(
+            function ( string $key, string $value ) use ( &$stored_value, $raw_refresh ) {
+                if ( 'wpaim_nj_refresh_token' === $key ) {
+                    $stored_value = $value;
+                }
+                return true;
+            }
+        );
+
+        $encrypt_method = new \ReflectionMethod( \WP_AI_Mind\Auth\NJ_Auth::class, 'encrypt_refresh' );
+        $encrypt_method->setAccessible( true );
+        $encrypted = $encrypt_method->invoke( null, $raw_refresh );
+
+        $this->assertNotSame( $raw_refresh, $encrypted, 'Stored refresh token must not be the raw JWT.' );
+        $this->assertNotEmpty( $encrypted );
+
+        $decrypt_method = new \ReflectionMethod( \WP_AI_Mind\Auth\NJ_Auth::class, 'decrypt_refresh' );
+        $decrypt_method->setAccessible( true );
+        $this->assertSame( $raw_refresh, $decrypt_method->invoke( null, $encrypted ) );
+    }
 }
 ```
 
@@ -128,8 +160,8 @@ class NJ_Auth {
     public const PROXY_BASE = 'https://wp-ai-mind-proxy.YOUR_SUBDOMAIN.workers.dev';
 
     public static function store( string $access, string $refresh ): void {
-        update_option( self::ACCESS_KEY,  $access,  false );
-        update_option( self::REFRESH_KEY, $refresh, false );
+        update_option( self::ACCESS_KEY,  $access,                          false );
+        update_option( self::REFRESH_KEY, self::encrypt_refresh( $refresh ), false );
         delete_transient( 'wpaim_entitlement' );
     }
 
@@ -167,7 +199,8 @@ class NJ_Auth {
     }
 
     private static function do_refresh(): string {
-        $refresh = (string) get_option( self::REFRESH_KEY, '' );
+        $stored  = (string) get_option( self::REFRESH_KEY, '' );
+        $refresh = '' !== $stored ? self::decrypt_refresh( $stored ) : '';
         if ( '' === $refresh ) return '';
 
         $response = wp_remote_post( self::PROXY_BASE . '/v1/auth/refresh', [
@@ -187,6 +220,28 @@ class NJ_Auth {
         update_option( self::ACCESS_KEY, $body['access_token'], false );
         delete_transient( 'wpaim_entitlement' );
         return $body['access_token'];
+    }
+
+    /**
+     * Encrypts the refresh token with AES-256-CBC before writing to wp_options.
+     * Uses AUTH_KEY as the key and AUTH_SALT (truncated/padded to 16 bytes) as the IV.
+     */
+    private static function encrypt_refresh( string $refresh ): string {
+        if ( '' === $refresh ) return '';
+        $iv        = substr( hash( 'sha256', AUTH_SALT ), 0, 16 );
+        $encrypted = openssl_encrypt( $refresh, 'aes-256-cbc', AUTH_KEY, 0, $iv );
+        return false !== $encrypted ? $encrypted : '';
+    }
+
+    /**
+     * Decrypts a refresh token previously encrypted by encrypt_refresh().
+     * Returns '' on failure so the caller can treat it as "not authenticated".
+     */
+    private static function decrypt_refresh( string $stored ): string {
+        if ( '' === $stored ) return '';
+        $iv        = substr( hash( 'sha256', AUTH_SALT ), 0, 16 );
+        $decrypted = openssl_decrypt( $stored, 'aes-256-cbc', AUTH_KEY, 0, $iv );
+        return false !== $decrypted ? $decrypted : '';
     }
 
     private static function decode_payload( string $token ): ?array {
@@ -625,6 +680,9 @@ git commit -m "feat(auth): wire NJ_Auth and NJ_Entitlement into plugin bootstrap
 - [ ] `nj_feature('chat')` returns `false` when not authenticated
 - [ ] `nj_feature('chat')` returns `true` after login with trial/free/pro plan
 - [ ] Entitlement transient is set after first fetch; second call does not make HTTP request
+- [ ] Refresh token is stored encrypted in `wp_options`; raw JWT value is never written to the database
+- [ ] `NJ_Auth::encrypt_refresh()` / `decrypt_refresh()` round-trip returns original value
+- [ ] PHPUnit test confirms stored value differs from the raw JWT string
 - [ ] All PHPUnit tests pass: `./vendor/bin/phpunit tests/Unit/ --colors=always`
 - [ ] `wpAiMindData` JavaScript object includes `isAuthenticated` and `entitlement` keys on all pages
 
@@ -632,6 +690,6 @@ git commit -m "feat(auth): wire NJ_Auth and NJ_Entitlement into plugin bootstrap
 
 ## Phase 2 Risk Notes
 
-- **`wp_options` for tokens is readable by any code with database access.** The access JWT is short-lived (1h) — this is the same risk as any plugin storing an API key. The refresh token is longer-lived; consider encrypting it with `AUTH_KEY` via `openssl_encrypt()` as a future hardening step.
+- **`wp_options` for tokens is readable by any code with database access.** The access JWT is short-lived (1 h) — same risk as any plugin storing an API key. The refresh token (30-day lifetime) is encrypted with AES-256-CBC using `AUTH_KEY`/`AUTH_SALT` before storage, so a raw database read cannot be used to silently obtain new access tokens. If `AUTH_KEY` is not defined (non-standard WP setup), encryption will produce an empty string and the token will not be stored — treat this as a startup-time misconfiguration.
 - **First page load after transient expiry adds ~100–300ms latency** (one HTTP call to the Worker). This is a cold-cache penalty once per hour per WordPress request — acceptable.
 - **`__return_true` on auth endpoints** means any WordPress visitor can attempt login/register. This is intentional — the rate limiting is enforced by the Worker (Phase 7). The WordPress REST endpoint is just a proxy.

--- a/docs/superpowers/plans/phases/phase-2-php-auth-entitlement.md
+++ b/docs/superpowers/plans/phases/phase-2-php-auth-entitlement.md
@@ -21,6 +21,7 @@
 | Null-object pattern | `empty_doc()` returns a fully-shaped array | Callers never need to null-check; feature flags default to `false` |
 | Proactive refresh | Refresh when token has < 5 minutes remaining | Prevents mid-request token expiry without adding a second HTTP round-trip |
 | Login/register REST endpoints | `permission_callback => __return_true` | Auth endpoints exist before WP session; nonce not available on first load |
+| **Multi-user model** | **One NJ account per WordPress site (site-wide `wp_options`)** | **Design constraint:** All WordPress users on a site share a single NJ account and entitlement tier. A WP Editor using the plugin authenticates as the same NJ account as the WP Admin. `POST /nj/logout` invalidates the token for every WP user simultaneously. This is intentional for single-owner installs (the primary use-case) and avoids the complexity of per-WP-user NJ account mapping. Sites with multiple WP users who each need independent NJ accounts are out of scope for this phase — see Risk Notes for migration path. |
 
 ---
 
@@ -693,3 +694,9 @@ git commit -m "feat(auth): wire NJ_Auth and NJ_Entitlement into plugin bootstrap
 - **`wp_options` for tokens is readable by any code with database access.** The access JWT is short-lived (1 h) — same risk as any plugin storing an API key. The refresh token (30-day lifetime) is encrypted with AES-256-CBC using `AUTH_KEY`/`AUTH_SALT` before storage, so a raw database read cannot be used to silently obtain new access tokens. If `AUTH_KEY` is not defined (non-standard WP setup), encryption will produce an empty string and the token will not be stored — treat this as a startup-time misconfiguration.
 - **First page load after transient expiry adds ~100–300ms latency** (one HTTP call to the Worker). This is a cold-cache penalty once per hour per WordPress request — acceptable.
 - **`__return_true` on auth endpoints** means any WordPress visitor can attempt login/register. This is intentional — the rate limiting is enforced by the Worker (Phase 7). The WordPress REST endpoint is just a proxy.
+- **Single NJ account per WordPress site (multi-user UX implications).** Because tokens are stored in `wp_options`, the plugin operates under a single shared NJ identity for the entire WordPress site. Concrete consequences:
+  - Any WP user with plugin access (Admin, Editor, Author) uses the same NJ account and entitlement tier.
+  - `POST /nj/logout` clears the shared token, ending the session for *all* WP users on the site at once — not just the user who triggered the logout.
+  - If a lower-privileged WP user changes the NJ password or rotates credentials, it affects every other WP user immediately.
+  - This model is safe and correct for the intended single-owner install. It becomes confusing on sites where multiple WP users independently expect their own NJ sessions.
+  - **If per-WP-user isolation is needed in the future**, the migration path is to replace the `wp_options` keys with `user_meta` keyed by `get_current_user_id()` and scope the `wpaim_entitlement` transient to `wpaim_entitlement_{user_id}`. The `NJ_Auth` and `NJ_Entitlement` class interfaces would not need to change — only the storage keys. This migration is deferred until there is a concrete multi-user use-case.

--- a/docs/superpowers/plans/phases/phase-2-php-auth-entitlement.md
+++ b/docs/superpowers/plans/phases/phase-2-php-auth-entitlement.md
@@ -1,0 +1,637 @@
+# Phase 2: PHP — Auth + Entitlement Layer
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The WordPress plugin can authenticate against the Cloudflare Worker, store JWTs, fetch entitlement data, and expose it to all PHP callers via `nj_feature()`. This replaces ProGate as the source of truth. ProGate is NOT removed yet — both coexist during this phase.
+
+**Architecture:** Three new PHP classes (`NJ_Auth`, `NJ_Entitlement`, `NJAuthRestController`) plus a global helper function `nj_feature()`. Auth tokens stored in `wp_options`. Entitlement cached as a 1-hour WP transient. New WP REST endpoints proxy credentials to the Worker.
+
+**Tech Stack:** PHP 8.1+, WordPress wp_options, WP transients, WP REST API, wp_remote_post/get, PHPUnit + Brain Monkey
+
+**Depends on:** Phase 1 deployed (Worker endpoints live at `https://wp-ai-mind-proxy.YOUR.workers.dev`)
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Token storage | `wp_options` (not encrypted for access token) | Short-lived JWT is an opaque Bearer credential; same risk as storing any API key. Refresh token should be encrypted with AES-256-CBC using AUTH_KEY |
+| Entitlement cache | 1-hour WP transient | Matches JWT expiry window; balances freshness vs HTTP overhead |
+| Null-object pattern | `empty_doc()` returns a fully-shaped array | Callers never need to null-check; feature flags default to `false` |
+| Proactive refresh | Refresh when token has < 5 minutes remaining | Prevents mid-request token expiry without adding a second HTTP round-trip |
+| Login/register REST endpoints | `permission_callback => __return_true` | Auth endpoints exist before WP session; nonce not available on first load |
+
+---
+
+## File Map
+
+**New files:**
+- `includes/Auth/NJ_Auth.php`
+- `includes/Entitlement/NJ_Entitlement.php`
+- `includes/Admin/NJAuthRestController.php`
+- `tests/Unit/Auth/NJAuthTest.php`
+- `tests/Unit/Entitlement/NJEntitlementTest.php`
+
+**Modified files:**
+- `wp-ai-mind.php` — add eager-loads for NJ_Auth, NJ_Entitlement, `nj_feature()` helper
+- `includes/Core/Plugin.php` — register NJAuthRestController REST routes
+- `includes/Admin/SettingsPage.php` — add `isAuthenticated` + `entitlement` to localized data
+- `includes/Admin/ChatPage.php` — same
+- `includes/Admin/DashboardPage.php` — same
+- `includes/Admin/GeneratorPage.php` — same
+- `includes/Modules/Editor/EditorModule.php` — same
+- `includes/Modules/Frontend/FrontendWidgetModule.php` — same
+- `includes/Modules/Generator/GeneratorModule.php` — same
+- `includes/Modules/Images/ImagesModule.php` — same
+- `includes/Modules/Seo/SeoModule.php` — same
+- `includes/Modules/Usage/UsageModule.php` — same
+
+---
+
+## Task 1: NJ_Auth Class
+
+**Files:** Create `includes/Auth/NJ_Auth.php`, `tests/Unit/Auth/NJAuthTest.php`
+
+- [ ] **Step 1.1: Write failing tests** (`tests/Unit/Auth/NJAuthTest.php`)
+
+```php
+<?php
+namespace WP_AI_Mind\Tests\Unit\Auth;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class NJAuthTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+        // Mock all WP functions used by NJ_Auth.
+        Functions\when( 'get_option' )->justReturn( '' );
+        Functions\when( 'update_option' )->justReturn( true );
+        Functions\when( 'delete_option' )->justReturn( true );
+        Functions\when( 'delete_transient' )->justReturn( true );
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_is_authenticated_returns_false_when_no_token(): void {
+        Functions\when( 'get_option' )->justReturn( '' );
+        $this->assertFalse( \WP_AI_Mind\Auth\NJ_Auth::is_authenticated() );
+    }
+
+    public function test_is_authenticated_returns_true_when_token_present(): void {
+        Functions\when( 'get_option' )->justReturn( 'some-jwt-token' );
+        $this->assertTrue( \WP_AI_Mind\Auth\NJ_Auth::is_authenticated() );
+    }
+
+    public function test_logout_clears_tokens(): void {
+        Functions\expect( 'delete_option' )->twice();
+        Functions\expect( 'delete_transient' )->once();
+        \WP_AI_Mind\Auth\NJ_Auth::logout();
+    }
+
+    public function test_decode_payload_returns_null_for_invalid_jwt(): void {
+        $method = new \ReflectionMethod( \WP_AI_Mind\Auth\NJ_Auth::class, 'decode_payload' );
+        $method->setAccessible( true );
+        $this->assertNull( $method->invoke( null, 'not.a.jwt' ) );
+        $this->assertNull( $method->invoke( null, '' ) );
+    }
+}
+```
+
+Run: `./vendor/bin/phpunit tests/Unit/Auth/NJAuthTest.php --colors=always`
+Expected: FAIL (class not found)
+
+- [ ] **Step 1.2: Implement `includes/Auth/NJ_Auth.php`**
+
+```php
+<?php
+namespace WP_AI_Mind\Auth;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class NJ_Auth {
+
+    private const ACCESS_KEY  = 'wpaim_nj_access_token';
+    private const REFRESH_KEY = 'wpaim_nj_refresh_token';
+
+    /**
+     * Base URL of the Cloudflare Worker proxy.
+     * Update this after wrangler deploy outputs the workers.dev URL.
+     */
+    public const PROXY_BASE = 'https://wp-ai-mind-proxy.YOUR_SUBDOMAIN.workers.dev';
+
+    public static function store( string $access, string $refresh ): void {
+        update_option( self::ACCESS_KEY,  $access,  false );
+        update_option( self::REFRESH_KEY, $refresh, false );
+        delete_transient( 'wpaim_entitlement' );
+    }
+
+    public static function get_access_token(): string {
+        return (string) get_option( self::ACCESS_KEY, '' );
+    }
+
+    /**
+     * Returns a valid (non-expired) access token, refreshing silently if needed.
+     * Returns '' if not authenticated or refresh fails.
+     */
+    public static function get_valid_access_token(): string {
+        $token = self::get_access_token();
+        if ( '' === $token ) return '';
+
+        $payload = self::decode_payload( $token );
+        if ( ! $payload ) return self::do_refresh();
+
+        // Refresh proactively when less than 5 minutes remain.
+        if ( ( (int) ( $payload['exp'] ?? 0 ) ) - time() < 300 ) {
+            return self::do_refresh();
+        }
+
+        return $token;
+    }
+
+    public static function logout(): void {
+        delete_option( self::ACCESS_KEY );
+        delete_option( self::REFRESH_KEY );
+        delete_transient( 'wpaim_entitlement' );
+    }
+
+    public static function is_authenticated(): bool {
+        return '' !== self::get_access_token();
+    }
+
+    private static function do_refresh(): string {
+        $refresh = (string) get_option( self::REFRESH_KEY, '' );
+        if ( '' === $refresh ) return '';
+
+        $response = wp_remote_post( self::PROXY_BASE . '/v1/auth/refresh', [
+            'headers' => [ 'Content-Type' => 'application/json' ],
+            'body'    => wp_json_encode( [ 'refresh_token' => $refresh ] ),
+            'timeout' => 10,
+        ] );
+
+        if ( is_wp_error( $response ) ) return '';
+
+        $body = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( empty( $body['access_token'] ) ) {
+            self::logout(); // Refresh invalid — force re-login.
+            return '';
+        }
+
+        update_option( self::ACCESS_KEY, $body['access_token'], false );
+        delete_transient( 'wpaim_entitlement' );
+        return $body['access_token'];
+    }
+
+    private static function decode_payload( string $token ): ?array {
+        $parts = explode( '.', $token );
+        if ( 3 !== count( $parts ) ) return null;
+
+        $decoded = base64_decode( strtr( $parts[1], '-_', '+/' ) );
+        if ( false === $decoded ) return null;
+
+        $payload = json_decode( $decoded, true );
+        return is_array( $payload ) ? $payload : null;
+    }
+}
+```
+
+- [ ] **Step 1.3: Run tests to verify they pass**
+
+```bash
+./vendor/bin/phpunit tests/Unit/Auth/NJAuthTest.php --colors=always
+# Expected: 4 tests PASS
+```
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git add includes/Auth/NJ_Auth.php tests/Unit/Auth/NJAuthTest.php
+git commit -m "feat(auth): add NJ_Auth class for JWT token storage and refresh"
+```
+
+---
+
+## Task 2: NJ_Entitlement Class
+
+**Files:** Create `includes/Entitlement/NJ_Entitlement.php`, `tests/Unit/Entitlement/NJEntitlementTest.php`
+
+- [ ] **Step 2.1: Write failing tests** (`tests/Unit/Entitlement/NJEntitlementTest.php`)
+
+```php
+<?php
+namespace WP_AI_Mind\Tests\Unit\Entitlement;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class NJEntitlementTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+        Functions\when( 'get_option' )->justReturn( '' );
+        Functions\when( 'get_transient' )->justReturn( false );
+        Functions\when( 'set_transient' )->justReturn( true );
+        Functions\when( 'delete_transient' )->justReturn( true );
+        Functions\when( 'is_wp_error' )->justReturn( false );
+        Functions\when( 'wp_remote_get' )->justReturn( [] );
+        Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+        Functions\when( 'wp_remote_retrieve_body' )->justReturn( '' );
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_get_returns_empty_doc_when_not_authenticated(): void {
+        Functions\when( 'get_option' )->justReturn( '' ); // No token stored.
+        $doc = \WP_AI_Mind\Entitlement\NJ_Entitlement::get();
+        $this->assertSame( 'none', $doc['plan'] );
+        $this->assertFalse( $doc['features']['chat'] );
+        $this->assertFalse( $doc['features']['own_key'] );
+    }
+
+    public function test_get_returns_cached_transient_when_available(): void {
+        Functions\when( 'get_option' )->justReturn( 'some-token' );
+        $cached = [
+            'plan'     => 'trial',
+            'features' => [ 'chat' => true, 'generator' => true, 'seo' => true, 'images' => true, 'own_key' => false ],
+            'tokens_used' => 5000, 'tokens_limit' => 300000, 'tokens_remaining' => 295000, 'resets_at' => null,
+        ];
+        Functions\when( 'get_transient' )->justReturn( $cached );
+
+        // wp_remote_get should NOT be called (cache hit).
+        Functions\expect( 'wp_remote_get' )->never();
+
+        $doc = \WP_AI_Mind\Entitlement\NJ_Entitlement::get();
+        $this->assertSame( 'trial', $doc['plan'] );
+    }
+
+    public function test_feature_returns_false_when_not_authenticated(): void {
+        Functions\when( 'get_option' )->justReturn( '' );
+        $this->assertFalse( \WP_AI_Mind\Entitlement\NJ_Entitlement::feature( 'chat' ) );
+    }
+
+    public function test_bust_deletes_transient(): void {
+        Functions\expect( 'delete_transient' )->once()->with( 'wpaim_entitlement' );
+        \WP_AI_Mind\Entitlement\NJ_Entitlement::bust();
+    }
+
+    public function test_get_returns_empty_doc_on_http_error(): void {
+        Functions\when( 'get_option' )->justReturn( 'some-token' );
+        Functions\when( 'is_wp_error' )->justReturn( true );
+
+        $doc = \WP_AI_Mind\Entitlement\NJ_Entitlement::get();
+        $this->assertSame( 'none', $doc['plan'] );
+    }
+}
+```
+
+Run: `./vendor/bin/phpunit tests/Unit/Entitlement/NJEntitlementTest.php --colors=always`
+Expected: FAIL (class not found)
+
+- [ ] **Step 2.2: Implement `includes/Entitlement/NJ_Entitlement.php`**
+
+```php
+<?php
+namespace WP_AI_Mind\Entitlement;
+
+use WP_AI_Mind\Auth\NJ_Auth;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class NJ_Entitlement {
+
+    private const TRANSIENT_KEY = 'wpaim_entitlement';
+    private const TTL           = HOUR_IN_SECONDS;
+
+    /** Null-object shape returned when unauthenticated or fetch fails. */
+    private static function empty_doc(): array {
+        return [
+            'plan'             => 'none',
+            'tokens_used'      => 0,
+            'tokens_limit'     => 0,
+            'tokens_remaining' => 0,
+            'resets_at'        => null,
+            'features'         => [
+                'chat'      => false,
+                'generator' => false,
+                'seo'       => false,
+                'images'    => false,
+                'own_key'   => false,
+            ],
+        ];
+    }
+
+    public static function get(): array {
+        if ( ! NJ_Auth::is_authenticated() ) {
+            return self::empty_doc();
+        }
+
+        $cached = get_transient( self::TRANSIENT_KEY );
+        if ( is_array( $cached ) ) {
+            return $cached;
+        }
+
+        return self::fetch_and_cache();
+    }
+
+    public static function feature( string $key ): bool {
+        return (bool) ( self::get()['features'][ $key ] ?? false );
+    }
+
+    public static function plan(): string {
+        return (string) ( self::get()['plan'] ?? 'none' );
+    }
+
+    public static function bust(): void {
+        delete_transient( self::TRANSIENT_KEY );
+    }
+
+    private static function fetch_and_cache(): array {
+        $token = NJ_Auth::get_valid_access_token();
+        if ( '' === $token ) return self::empty_doc();
+
+        $response = wp_remote_get( NJ_Auth::PROXY_BASE . '/v1/entitlement', [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+                'Content-Type'  => 'application/json',
+            ],
+            'timeout' => 10,
+        ] );
+
+        if ( is_wp_error( $response ) ) return self::empty_doc();
+        if ( 200 !== wp_remote_retrieve_response_code( $response ) ) return self::empty_doc();
+
+        $doc = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( ! is_array( $doc ) || empty( $doc['plan'] ) ) return self::empty_doc();
+
+        set_transient( self::TRANSIENT_KEY, $doc, self::TTL );
+        return $doc;
+    }
+}
+```
+
+- [ ] **Step 2.3: Run tests to verify they pass**
+
+```bash
+./vendor/bin/phpunit tests/Unit/Entitlement/NJEntitlementTest.php --colors=always
+# Expected: 5 tests PASS
+```
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add includes/Entitlement/NJ_Entitlement.php tests/Unit/Entitlement/NJEntitlementTest.php
+git commit -m "feat(entitlement): add NJ_Entitlement class with transient caching"
+```
+
+---
+
+## Task 3: NJAuthRestController
+
+**Files:** Create `includes/Admin/NJAuthRestController.php`
+
+- [ ] **Step 3.1: Implement `includes/Admin/NJAuthRestController.php`**
+
+```php
+<?php
+namespace WP_AI_Mind\Admin;
+
+use WP_AI_Mind\Auth\NJ_Auth;
+use WP_AI_Mind\Entitlement\NJ_Entitlement;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class NJAuthRestController {
+
+    public function register_routes(): void {
+        $ns = 'wp-ai-mind/v1';
+
+        register_rest_route( $ns, '/nj/login', [
+            'methods'             => \WP_REST_Server::CREATABLE,
+            'callback'            => [ $this, 'login' ],
+            'permission_callback' => '__return_true',
+            'args'                => [
+                'email'    => [ 'type' => 'string', 'required' => true, 'sanitize_callback' => 'sanitize_email' ],
+                'password' => [ 'type' => 'string', 'required' => true ],
+            ],
+        ] );
+
+        register_rest_route( $ns, '/nj/register', [
+            'methods'             => \WP_REST_Server::CREATABLE,
+            'callback'            => [ $this, 'register' ],
+            'permission_callback' => '__return_true',
+            'args'                => [
+                'email'    => [ 'type' => 'string', 'required' => true, 'sanitize_callback' => 'sanitize_email' ],
+                'password' => [ 'type' => 'string', 'required' => true ],
+            ],
+        ] );
+
+        register_rest_route( $ns, '/nj/logout', [
+            'methods'             => \WP_REST_Server::CREATABLE,
+            'callback'            => [ $this, 'logout' ],
+            'permission_callback' => '__return_true',
+        ] );
+
+        register_rest_route( $ns, '/nj/me', [
+            'methods'             => \WP_REST_Server::READABLE,
+            'callback'            => [ $this, 'me' ],
+            'permission_callback' => '__return_true',
+        ] );
+    }
+
+    public function login( \WP_REST_Request $request ): \WP_REST_Response {
+        $email    = sanitize_email( (string) $request->get_param( 'email' ) );
+        $password = (string) $request->get_param( 'password' );
+
+        if ( empty( $email ) || empty( $password ) ) {
+            return new \WP_REST_Response( [ 'error' => __( 'Email and password are required.', 'wp-ai-mind' ) ], 400 );
+        }
+
+        $response = wp_remote_post( NJ_Auth::PROXY_BASE . '/v1/auth/token', [
+            'headers' => [ 'Content-Type' => 'application/json' ],
+            'body'    => wp_json_encode( compact( 'email', 'password' ) ),
+            'timeout' => 15,
+        ] );
+
+        if ( is_wp_error( $response ) ) {
+            return new \WP_REST_Response( [ 'error' => __( 'Could not reach the authentication server.', 'wp-ai-mind' ) ], 503 );
+        }
+
+        $status = wp_remote_retrieve_response_code( $response );
+        $body   = json_decode( wp_remote_retrieve_body( $response ), true );
+
+        if ( 200 !== $status ) {
+            return new \WP_REST_Response(
+                [ 'error' => $body['error'] ?? __( 'Authentication failed.', 'wp-ai-mind' ) ],
+                $status
+            );
+        }
+
+        NJ_Auth::store( $body['access_token'], $body['refresh_token'] );
+        NJ_Entitlement::bust();
+
+        return new \WP_REST_Response( [
+            'success'     => true,
+            'plan'        => $body['plan'],
+            'entitlement' => NJ_Entitlement::get(),
+        ] );
+    }
+
+    public function register( \WP_REST_Request $request ): \WP_REST_Response {
+        $email    = sanitize_email( (string) $request->get_param( 'email' ) );
+        $password = (string) $request->get_param( 'password' );
+
+        $response = wp_remote_post( NJ_Auth::PROXY_BASE . '/v1/auth/register', [
+            'headers' => [ 'Content-Type' => 'application/json' ],
+            'body'    => wp_json_encode( compact( 'email', 'password' ) ),
+            'timeout' => 20,
+        ] );
+
+        if ( is_wp_error( $response ) ) {
+            return new \WP_REST_Response( [ 'error' => __( 'Could not reach the authentication server.', 'wp-ai-mind' ) ], 503 );
+        }
+
+        $status = wp_remote_retrieve_response_code( $response );
+        $body   = json_decode( wp_remote_retrieve_body( $response ), true );
+
+        if ( 201 !== $status ) {
+            return new \WP_REST_Response(
+                [ 'error' => $body['error'] ?? __( 'Registration failed.', 'wp-ai-mind' ) ],
+                $status
+            );
+        }
+
+        // Auto-login after successful registration.
+        return $this->login( $request );
+    }
+
+    public function logout( \WP_REST_Request $request ): \WP_REST_Response {
+        NJ_Auth::logout();
+        return new \WP_REST_Response( [ 'success' => true ] );
+    }
+
+    public function me( \WP_REST_Request $request ): \WP_REST_Response {
+        NJ_Entitlement::bust();
+        return new \WP_REST_Response( NJ_Entitlement::get() );
+    }
+}
+```
+
+- [ ] **Step 3.2: Commit**
+
+```bash
+git add includes/Admin/NJAuthRestController.php
+git commit -m "feat(auth): add NJAuthRestController REST endpoints"
+```
+
+---
+
+## Task 4: Wire into Plugin
+
+**Files:** Modify `wp-ai-mind.php`, `includes/Core/Plugin.php`, all Admin page classes
+
+- [ ] **Step 4.1: Add eager-loads to `wp-ai-mind.php`**
+
+After the existing `require_once WP_AI_MIND_DIR . 'includes/Core/ProGate.php';` line, add:
+
+```php
+// NJ Auth + Entitlement — loaded eagerly for global availability.
+require_once WP_AI_MIND_DIR . 'includes/Auth/NJ_Auth.php';
+require_once WP_AI_MIND_DIR . 'includes/Entitlement/NJ_Entitlement.php';
+
+if ( ! function_exists( 'nj_feature' ) ) {
+    /**
+     * Returns whether the current authenticated user's plan includes a feature.
+     * Returns false when not authenticated.
+     *
+     * @param string $key Feature key: 'chat', 'generator', 'seo', 'images', 'own_key'
+     */
+    function nj_feature( string $key ): bool {
+        return \WP_AI_Mind\Entitlement\NJ_Entitlement::feature( $key );
+    }
+}
+```
+
+- [ ] **Step 4.2: Register routes in `includes/Core/Plugin.php`**
+
+In the `register_rest_routes()` method, add:
+
+```php
+public function register_rest_routes(): void {
+    do_action( 'wp_ai_mind_register_rest_routes' );
+
+    // NJ Auth routes (registered directly, not via module action).
+    $auth_controller = new \WP_AI_Mind\Admin\NJAuthRestController();
+    $auth_controller->register_routes();
+}
+```
+
+- [ ] **Step 4.3: Update `includes/Admin/SettingsPage.php` localized data**
+
+In the `enqueue_assets()` method, find the `wp_localize_script()` call and add:
+
+```php
+'isAuthenticated' => \WP_AI_Mind\Auth\NJ_Auth::is_authenticated(),
+'entitlement'     => \WP_AI_Mind\Entitlement\NJ_Entitlement::get(),
+// Keep isPro as a derived alias for backward compatibility with any third-party code.
+'isPro'           => \nj_feature( 'own_key' ),
+```
+
+Repeat this pattern for all other Admin pages and module files that call `wp_localize_script()`:
+- `includes/Admin/ChatPage.php`
+- `includes/Admin/DashboardPage.php`
+- `includes/Admin/GeneratorPage.php`
+- `includes/Modules/Editor/EditorModule.php`
+- `includes/Modules/Frontend/FrontendWidgetModule.php`
+- `includes/Modules/Generator/GeneratorModule.php`
+- `includes/Modules/Images/ImagesModule.php`
+- `includes/Modules/Seo/SeoModule.php`
+- `includes/Modules/Usage/UsageModule.php`
+
+- [ ] **Step 4.4: Run full test suite**
+
+```bash
+./vendor/bin/phpunit tests/Unit/ --colors=always
+# Expected: All existing tests PASS + new NJAuth + NJEntitlement tests PASS
+```
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add wp-ai-mind.php includes/Core/Plugin.php includes/Admin/ includes/Modules/
+git commit -m "feat(auth): wire NJ_Auth and NJ_Entitlement into plugin bootstrap and localized data"
+```
+
+---
+
+## Phase 2 Acceptance Criteria
+
+- [ ] `POST /wp-ai-mind/v1/nj/login` with correct credentials → stores tokens in wp_options, returns entitlement doc
+- [ ] `POST /wp-ai-mind/v1/nj/login` with wrong credentials → 401 error
+- [ ] `POST /wp-ai-mind/v1/nj/register` → creates account, auto-logs in, returns entitlement
+- [ ] `GET /wp-ai-mind/v1/nj/me` → returns fresh entitlement (busts cache first)
+- [ ] `POST /wp-ai-mind/v1/nj/logout` → clears tokens and transient
+- [ ] `nj_feature('chat')` returns `false` when not authenticated
+- [ ] `nj_feature('chat')` returns `true` after login with trial/free/pro plan
+- [ ] Entitlement transient is set after first fetch; second call does not make HTTP request
+- [ ] All PHPUnit tests pass: `./vendor/bin/phpunit tests/Unit/ --colors=always`
+- [ ] `wpAiMindData` JavaScript object includes `isAuthenticated` and `entitlement` keys on all pages
+
+---
+
+## Phase 2 Risk Notes
+
+- **`wp_options` for tokens is readable by any code with database access.** The access JWT is short-lived (1h) — this is the same risk as any plugin storing an API key. The refresh token is longer-lived; consider encrypting it with `AUTH_KEY` via `openssl_encrypt()` as a future hardening step.
+- **First page load after transient expiry adds ~100–300ms latency** (one HTTP call to the Worker). This is a cold-cache penalty once per hour per WordPress request — acceptable.
+- **`__return_true` on auth endpoints** means any WordPress visitor can attempt login/register. This is intentional — the rate limiting is enforced by the Worker (Phase 7). The WordPress REST endpoint is just a proxy.

--- a/docs/superpowers/plans/phases/phase-3-cf-worker-chat-webhooks.md
+++ b/docs/superpowers/plans/phases/phase-3-cf-worker-chat-webhooks.md
@@ -8,8 +8,36 @@
 
 **Tech Stack:** Cloudflare Workers (TypeScript), Cloudflare KV (usage tracking), Cloudflare D1 (plan updates), Web Crypto (HMAC-SHA256 webhook signature verification), Anthropic API
 
-**Depends on:** Phase 1 complete (auth endpoints live, D1 schema exists)
+**Depends on:** Phase 1 complete (auth endpoints live, D1 schema exists, `src/tier-config.ts` in place)
 **Runs in parallel with:** Phase 2 (PHP auth layer)
+
+---
+
+## Task 0: Pre-implementation Reuse Audit
+
+> **Mandatory.** Complete before modifying any source files.
+
+- [ ] **Step 0.1: Read existing `src/tier-config.ts`** (created in Phase 1)
+
+```bash
+cat wp-ai-mind-proxy/src/tier-config.ts
+# Understand getTierConfig() — use it directly; do NOT redefine PLAN_LIMITS here.
+```
+
+- [ ] **Step 0.2: Read existing `src/utils.ts`**
+
+```bash
+cat wp-ai-mind-proxy/src/utils.ts
+# Confirm yyyyMM(), nextMonthStart(), secondsUntilMonthEnd() are available.
+# Import from utils.ts instead of re-implementing.
+```
+
+- [ ] **Step 0.3: Read existing `src/db.ts`**
+
+```bash
+cat wp-ai-mind-proxy/src/db.ts
+# Confirm updateUserPlan() exists — use it in the LemonSqueezy handler.
+```
 
 ---
 
@@ -46,9 +74,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleChat } from '../src/chat';
 import type { Env, AuthUser } from '../src/types';
 
-const trialUser: AuthUser = { sub: 1, email: 'a@b.com', plan: 'trial', iat: 0, exp: 9999999999 };
-const freeUser:  AuthUser = { sub: 2, email: 'b@c.com', plan: 'free',  iat: 0, exp: 9999999999 };
-const proUser:   AuthUser = { sub: 3, email: 'c@d.com', plan: 'pro',   iat: 0, exp: 9999999999 };
+const trialUser:      AuthUser = { sub: 1, email: 'a@b.com', plan: 'trial',       iat: 0, exp: 9999999999 };
+const freeUser:       AuthUser = { sub: 2, email: 'b@c.com', plan: 'free',        iat: 0, exp: 9999999999 };
+const proManagedUser: AuthUser = { sub: 4, email: 'd@e.com', plan: 'pro_managed', iat: 0, exp: 9999999999 };
+const proUser:        AuthUser = { sub: 3, email: 'c@d.com', plan: 'pro',         iat: 0, exp: 9999999999 };
 
 function makeEnv(usedTokens: number, fetchResponse: Response): Env {
   return {
@@ -83,7 +112,6 @@ describe('handleChat — token limit enforcement', () => {
     const body = await res.json() as Record<string, unknown>;
     expect(body.error).toBe('token_limit_exceeded');
     expect(body.limit).toBe(50_000);
-    // fetch should NOT be called when limit is exceeded
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
@@ -100,7 +128,22 @@ describe('handleChat — token limit enforcement', () => {
     expect(res.status).toBe(429);
   });
 
-  it('does not enforce limit for pro users', async () => {
+  it('allows pro_managed user below their higher limit', async () => {
+    const anthropicBody = JSON.stringify({
+      content: [{ type: 'text', text: 'hello' }],
+      usage: { input_tokens: 100, output_tokens: 50 }
+    });
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(anthropicBody, { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    // 300_001 would exceed trial (300k) but is well below pro_managed limit
+    const env = makeEnv(300_001, new Response('{}'));
+
+    await handleChat(makeRequest({ model: 'claude-sonnet-4-5', messages: [] }), env, proManagedUser);
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+  });
+
+  it('does not enforce limit for pro (BYOK) users', async () => {
     const anthropicBody = JSON.stringify({
       content: [{ type: 'text', text: 'hello' }],
       usage: { input_tokens: 100, output_tokens: 50 }
@@ -110,13 +153,42 @@ describe('handleChat — token limit enforcement', () => {
     );
     const env = makeEnv(999_999, new Response('{}'));
 
+    await handleChat(makeRequest({ model: 'claude-opus-4-5', messages: [] }), env, proUser);
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+  });
+});
+
+describe('handleChat — model allowlist enforcement', () => {
+  it('returns 403 when free user requests a non-Haiku model', async () => {
+    globalThis.fetch = vi.fn();
+    const env = makeEnv(0, new Response('{}'));
+
     const res = await handleChat(
-      makeRequest({ model: 'claude-opus-4-7', messages: [] }),
+      makeRequest({ model: 'claude-sonnet-4-5', messages: [] }),
       env,
-      proUser
+      freeUser
     );
 
-    // fetch should be called (no limit check for pro)
+    expect(res.status).toBe(403);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe('model_not_allowed');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('allows pro_managed user to request Sonnet', async () => {
+    const anthropicBody = JSON.stringify({ content: [], usage: { input_tokens: 50, output_tokens: 50 } });
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(anthropicBody, { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    const env = makeEnv(0, new Response('{}'));
+
+    const res = await handleChat(
+      makeRequest({ model: 'claude-sonnet-4-5', messages: [] }),
+      env,
+      proManagedUser
+    );
+
+    expect(res.status).toBe(200);
     expect(globalThis.fetch).toHaveBeenCalledOnce();
   });
 });
@@ -128,18 +200,16 @@ Run: `npm test` → Expected: FAIL (chat module returns 501)
 
 ```typescript
 import { yyyyMM, nextMonthStart, secondsUntilMonthEnd, json } from './utils';
+import { getTierConfig } from './tier-config'; // ← single source of truth; no local PLAN_LIMITS
 import type { Env, AuthUser } from './types';
 
-const PLAN_LIMITS: Record<string, number | null> = {
-  free:  50_000,
-  trial: 300_000,
-  pro:   null,
-};
+const DEFAULT_MODEL = 'claude-haiku-4-5'; // fallback when no model specified
 
 export async function handleChat(req: Request, env: Env, user: AuthUser): Promise<Response> {
-  const limit = PLAN_LIMITS[user.plan] ?? null;
+  const config = getTierConfig(user.plan);
+  const limit  = config.tokens_per_month;
 
-  // Step 1: Enforce token limits for free/trial plans.
+  // Step 1: Enforce token limits for non-BYOK tiers.
   if (limit !== null) {
     const monthKey = `usage:${user.sub}:${yyyyMM()}`;
     const usedStr  = await env.USAGE_KV.get(monthKey);
@@ -155,9 +225,32 @@ export async function handleChat(req: Request, env: Env, user: AuthUser): Promis
     }
   }
 
-  // Step 2: Forward request to Anthropic.
-  const body = await req.json<Record<string, unknown>>();
+  const body             = await req.json<Record<string, unknown>>();
+  const requestedModel   = (body.model as string | undefined) ?? DEFAULT_MODEL;
+  const allowedModels    = config.allowed_models;
 
+  // Step 2: Validate model against tier allowlist.
+  // Pro BYOK (allowed_models = []) is unrestricted — Worker is not in the loop for BYOK.
+  // For managed tiers, enforce the allowlist.
+  if (allowedModels.length > 0 && !allowedModels.includes(requestedModel)) {
+    return json({
+      error:          'model_not_allowed',
+      requested_model: requestedModel,
+      allowed_models:  allowedModels,
+    }, 403);
+  }
+
+  // Step 3: Apply per-request max_tokens cap (prevents runaway single requests).
+  const maxTokensCap = config.max_tokens_per_request;
+  const requestBody: Record<string, unknown> = {
+    ...body,
+    model:      requestedModel,
+    max_tokens: maxTokensCap !== null
+      ? Math.min((body.max_tokens as number | undefined) ?? maxTokensCap, maxTokensCap)
+      : body.max_tokens,
+  };
+
+  // Step 4: Forward request to Anthropic.
   const anthropicResp = await fetch('https://api.anthropic.com/v1/messages', {
     method:  'POST',
     headers: {
@@ -165,10 +258,10 @@ export async function handleChat(req: Request, env: Env, user: AuthUser): Promis
       'anthropic-version': '2023-06-01',
       'content-type':      'application/json',
     },
-    body: JSON.stringify(body),
+    body: JSON.stringify(requestBody),
   });
 
-  // Step 3: Update KV usage asynchronously after successful response.
+  // Step 5: Update KV usage after successful response (non-BYOK tiers only).
   if (anthropicResp.ok && limit !== null) {
     const cloned  = anthropicResp.clone();
     const data    = await cloned.json<{ usage?: { input_tokens?: number; output_tokens?: number } }>();
@@ -183,7 +276,7 @@ export async function handleChat(req: Request, env: Env, user: AuthUser): Promis
     }
   }
 
-  // Step 4: Return Anthropic response verbatim (body passthrough).
+  // Step 6: Return Anthropic response verbatim (body passthrough).
   return new Response(anthropicResp.body, {
     status:  anthropicResp.status,
     headers: {
@@ -343,9 +436,19 @@ export async function handleLemonSqueezy(req: Request, env: Env): Promise<Respon
 
   if (email) {
     if (UPGRADE_EVENTS.includes(eventName)) {
+      // Determine the target plan from the webhook payload.
+      // LemonSqueezy can carry a custom 'plan_type' field in the order metadata:
+      //   'pro'         → Pro BYOK (user brings their own API key)
+      //   'pro_managed' → Pro Managed (platform API, higher limits + model selection)
+      // Defaults to 'pro_managed' for backward-compat if not specified.
+      const meta      = event?.data?.attributes?.first_order_item?.product_name as string | undefined;
+      const targetPlan = (meta?.toLowerCase().includes('byok') || meta?.toLowerCase().includes('own-key'))
+        ? 'pro'
+        : 'pro_managed';
+
       await env.DB.prepare(
-        `UPDATE users SET plan = 'pro', plan_expires = NULL, updated_at = CURRENT_TIMESTAMP WHERE email = ?`
-      ).bind(email).run();
+        `UPDATE users SET plan = ?, plan_expires = NULL, updated_at = CURRENT_TIMESTAMP WHERE email = ?`
+      ).bind(targetPlan, email).run();
     } else if (DOWNGRADE_EVENTS.includes(eventName)) {
       await env.DB.prepare(
         `UPDATE users SET plan = 'free', plan_expires = NULL, updated_at = CURRENT_TIMESTAMP WHERE email = ?`
@@ -449,13 +552,43 @@ git commit -m "chore(proxy): Phase 3 complete — chat proxy and webhooks deploy
 
 ---
 
+## Task 4: Post-implementation Code Reuse Verification
+
+> **Mandatory.** Run before marking Phase 3 complete.
+
+- [ ] **Step 4.1: Confirm tier-config is the sole limit source**
+
+```bash
+grep -rn "50_000\|300_000\|2_000_000\|claude-haiku" src/ --include="*.ts" | grep -v "tier-config.ts"
+# Expected: 0 matches
+```
+
+- [ ] **Step 4.2: Confirm utilities are reused from utils.ts**
+
+```bash
+grep -rn "yyyyMM\|secondsUntilMonthEnd\|nextMonthStart" src/ --include="*.ts" | grep -v "utils.ts"
+# Expected: only import statements referencing utils.ts; no re-implementations
+```
+
+- [ ] **Step 4.3: Full Vitest suite passes**
+
+```bash
+cd wp-ai-mind-proxy && npm test
+# Expected: all tests pass
+```
+
+---
+
 ## Phase 3 Acceptance Criteria
 
 - [ ] `POST /v1/chat` with valid JWT + within limits → Anthropic response returned
 - [ ] `POST /v1/chat` at token limit → 429 with `error: 'token_limit_exceeded'`
+- [ ] `POST /v1/chat` by `pro_managed` user requesting Sonnet → allowed; by `free` user requesting Sonnet → 403 `model_not_allowed`
+- [ ] `POST /v1/chat` by `pro_managed` user at trial-level usage (300k) but below pro_managed limit (2M) → allowed
+- [ ] `POST /v1/chat` — per-request `max_tokens` capped at `config.max_tokens_per_request` for managed tiers
 - [ ] KV key `usage:{id}:{YYYY-MM}` increments after each successful chat
 - [ ] KV key TTL expires at end of month (not a fixed duration from now)
-- [ ] `POST /webhooks/lemonsqueezy` with correct HMAC → D1 plan updated to `pro`
+- [ ] `POST /webhooks/lemonsqueezy` with correct HMAC → D1 plan updated to `pro_managed` (default) or `pro` (BYOK products)
 - [ ] `POST /webhooks/lemonsqueezy` with incorrect HMAC → 401
 - [ ] `subscription_cancelled` event → D1 plan updated to `free`
 - [ ] All unit tests pass: `npm test`

--- a/docs/superpowers/plans/phases/phase-3-cf-worker-chat-webhooks.md
+++ b/docs/superpowers/plans/phases/phase-3-cf-worker-chat-webhooks.md
@@ -1,0 +1,470 @@
+# Phase 3: Cloudflare Worker — Chat Proxy + LemonSqueezy Webhooks
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The Worker can receive authenticated chat requests, enforce plan token limits via KV, forward to Anthropic, and handle LemonSqueezy subscription webhooks to update D1 plan state. No WordPress plugin changes in this phase.
+
+**Architecture:** Implements `POST /v1/chat` (real Anthropic proxy) and `POST /webhooks/lemonsqueezy` (HMAC-verified plan update) in the existing `wp-ai-mind-proxy/` project. Replaces the Phase 1 501 stubs.
+
+**Tech Stack:** Cloudflare Workers (TypeScript), Cloudflare KV (usage tracking), Cloudflare D1 (plan updates), Web Crypto (HMAC-SHA256 webhook signature verification), Anthropic API
+
+**Depends on:** Phase 1 complete (auth endpoints live, D1 schema exists)
+**Runs in parallel with:** Phase 2 (PHP auth layer)
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Token counting | Read KV before request, write after response | TOCTOU race is acceptable — soft-cap approach; a few over-limit requests are harmless |
+| KV key TTL | Set to seconds until end of current month | KV handles cleanup automatically; no cron job needed |
+| Response passthrough | Return Anthropic response body verbatim | Wire format is identical — PHP `NJ_Proxy_Client` (Phase 4) needs zero adaptation |
+| Webhook verification | Constant-time HMAC comparison | Prevents timing attacks on signature validation |
+| Pro users | Skip KV limit check entirely | Pro users route direct (Phase 4); Worker still accepts their tokens if they call directly |
+
+---
+
+## File Map
+
+**Modified files (in `wp-ai-mind-proxy/`):**
+- `src/chat.ts` — replace 501 stub with real Anthropic proxy + KV usage tracking
+- `src/webhooks.ts` — replace 501 stub with HMAC-verified LemonSqueezy handler
+- `test/chat.test.ts` — new test file
+- `test/webhooks.test.ts` — new test file
+
+---
+
+## Task 1: Chat Proxy
+
+**Files:** Replace `src/chat.ts` stub, create `test/chat.test.ts`
+
+- [ ] **Step 1.1: Write failing tests** (`test/chat.test.ts`)
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleChat } from '../src/chat';
+import type { Env, AuthUser } from '../src/types';
+
+const trialUser: AuthUser = { sub: 1, email: 'a@b.com', plan: 'trial', iat: 0, exp: 9999999999 };
+const freeUser:  AuthUser = { sub: 2, email: 'b@c.com', plan: 'free',  iat: 0, exp: 9999999999 };
+const proUser:   AuthUser = { sub: 3, email: 'c@d.com', plan: 'pro',   iat: 0, exp: 9999999999 };
+
+function makeEnv(usedTokens: number, fetchResponse: Response): Env {
+  return {
+    USAGE_KV: {
+      get: vi.fn().mockResolvedValue(usedTokens > 0 ? String(usedTokens) : null),
+      put: vi.fn().mockResolvedValue(undefined),
+    },
+    ANTHROPIC_API_KEY: 'test-key',
+  } as unknown as Env;
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/v1/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('handleChat — token limit enforcement', () => {
+  it('returns 429 when free user is at token limit', async () => {
+    const env = makeEnv(50_000, new Response('{}', { status: 200 }));
+    globalThis.fetch = vi.fn();
+
+    const res = await handleChat(
+      makeRequest({ model: 'claude-haiku-4-5', messages: [] }),
+      env,
+      freeUser
+    );
+
+    expect(res.status).toBe(429);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe('token_limit_exceeded');
+    expect(body.limit).toBe(50_000);
+    // fetch should NOT be called when limit is exceeded
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 when trial user is at token limit', async () => {
+    const env = makeEnv(300_000, new Response('{}', { status: 200 }));
+    globalThis.fetch = vi.fn();
+
+    const res = await handleChat(
+      makeRequest({ model: 'claude-haiku-4-5', messages: [] }),
+      env,
+      trialUser
+    );
+
+    expect(res.status).toBe(429);
+  });
+
+  it('does not enforce limit for pro users', async () => {
+    const anthropicBody = JSON.stringify({
+      content: [{ type: 'text', text: 'hello' }],
+      usage: { input_tokens: 100, output_tokens: 50 }
+    });
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(anthropicBody, { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    const env = makeEnv(999_999, new Response('{}'));
+
+    const res = await handleChat(
+      makeRequest({ model: 'claude-opus-4-7', messages: [] }),
+      env,
+      proUser
+    );
+
+    // fetch should be called (no limit check for pro)
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+  });
+});
+```
+
+Run: `npm test` → Expected: FAIL (chat module returns 501)
+
+- [ ] **Step 1.2: Implement `src/chat.ts`**
+
+```typescript
+import { yyyyMM, nextMonthStart, secondsUntilMonthEnd, json } from './utils';
+import type { Env, AuthUser } from './types';
+
+const PLAN_LIMITS: Record<string, number | null> = {
+  free:  50_000,
+  trial: 300_000,
+  pro:   null,
+};
+
+export async function handleChat(req: Request, env: Env, user: AuthUser): Promise<Response> {
+  const limit = PLAN_LIMITS[user.plan] ?? null;
+
+  // Step 1: Enforce token limits for free/trial plans.
+  if (limit !== null) {
+    const monthKey = `usage:${user.sub}:${yyyyMM()}`;
+    const usedStr  = await env.USAGE_KV.get(monthKey);
+    const used     = usedStr ? parseInt(usedStr, 10) : 0;
+
+    if (used >= limit) {
+      return json({
+        error:     'token_limit_exceeded',
+        used,
+        limit,
+        resets_at: nextMonthStart(),
+      }, 429);
+    }
+  }
+
+  // Step 2: Forward request to Anthropic.
+  const body = await req.json<Record<string, unknown>>();
+
+  const anthropicResp = await fetch('https://api.anthropic.com/v1/messages', {
+    method:  'POST',
+    headers: {
+      'x-api-key':         env.ANTHROPIC_API_KEY,
+      'anthropic-version': '2023-06-01',
+      'content-type':      'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  // Step 3: Update KV usage asynchronously after successful response.
+  if (anthropicResp.ok && limit !== null) {
+    const cloned  = anthropicResp.clone();
+    const data    = await cloned.json<{ usage?: { input_tokens?: number; output_tokens?: number } }>();
+    const tokens  = (data.usage?.input_tokens ?? 0) + (data.usage?.output_tokens ?? 0);
+
+    if (tokens > 0) {
+      const monthKey = `usage:${user.sub}:${yyyyMM()}`;
+      const current  = parseInt((await env.USAGE_KV.get(monthKey)) ?? '0', 10);
+      await env.USAGE_KV.put(monthKey, String(current + tokens), {
+        expirationTtl: secondsUntilMonthEnd(),
+      });
+    }
+  }
+
+  // Step 4: Return Anthropic response verbatim (body passthrough).
+  return new Response(anthropicResp.body, {
+    status:  anthropicResp.status,
+    headers: {
+      'Content-Type': anthropicResp.headers.get('Content-Type') ?? 'application/json',
+    },
+  });
+}
+```
+
+- [ ] **Step 1.3: Run tests to verify they pass**
+
+```bash
+npm test
+# Expected: All chat.test.ts tests PASS
+```
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git add src/chat.ts test/chat.test.ts
+git commit -m "feat(proxy): implement POST /v1/chat with Anthropic proxy and KV usage tracking"
+```
+
+---
+
+## Task 2: LemonSqueezy Webhook Handler
+
+**Files:** Replace `src/webhooks.ts` stub, create `test/webhooks.test.ts`
+
+- [ ] **Step 2.1: Write failing tests** (`test/webhooks.test.ts`)
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { handleLemonSqueezy } from '../src/webhooks';
+import type { Env } from '../src/types';
+
+async function makeSignedRequest(body: unknown, secret: string): Promise<Request> {
+  const bodyStr = JSON.stringify(body);
+  const key     = await crypto.subtle.importKey(
+    'raw', new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
+  );
+  const sigBytes = new Uint8Array(await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(bodyStr)));
+  const sig      = Array.from(sigBytes).map(b => b.toString(16).padStart(2, '0')).join('');
+
+  return new Request('http://localhost/webhooks/lemonsqueezy', {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Signature': sig },
+    body:    bodyStr,
+  });
+}
+
+const WEBHOOK_SECRET = 'test-webhook-secret-value';
+
+function makeEnv(): Env {
+  return {
+    DB: {
+      prepare: vi.fn().mockReturnValue({
+        bind: vi.fn().mockReturnThis(),
+        run:  vi.fn().mockResolvedValue({ success: true }),
+      }),
+    },
+    LEMONSQUEEZY_WEBHOOK_SECRET: WEBHOOK_SECRET,
+  } as unknown as Env;
+}
+
+describe('handleLemonSqueezy', () => {
+  it('returns 401 for invalid signature', async () => {
+    const req = new Request('http://localhost/webhooks/lemonsqueezy', {
+      method:  'POST',
+      headers: { 'X-Signature': 'badhash' },
+      body:    JSON.stringify({ meta: { event_name: 'order_created' } }),
+    });
+    const res = await handleLemonSqueezy(req, makeEnv());
+    expect(res.status).toBe(401);
+  });
+
+  it('upgrades user to pro on subscription_created', async () => {
+    const env  = makeEnv();
+    const body = {
+      meta: { event_name: 'subscription_created' },
+      data: { attributes: { user_email: 'user@example.com' } },
+    };
+    const req = await makeSignedRequest(body, WEBHOOK_SECRET);
+    const res = await handleLemonSqueezy(req, env);
+
+    expect(res.status).toBe(200);
+    expect(env.DB.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("plan = 'pro'")
+    );
+  });
+
+  it('downgrades user to free on subscription_cancelled', async () => {
+    const env  = makeEnv();
+    const body = {
+      meta: { event_name: 'subscription_cancelled' },
+      data: { attributes: { user_email: 'user@example.com' } },
+    };
+    const req = await makeSignedRequest(body, WEBHOOK_SECRET);
+    const res = await handleLemonSqueezy(req, env);
+
+    expect(res.status).toBe(200);
+    expect(env.DB.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("plan = 'free'")
+    );
+  });
+
+  it('returns 200 for unknown event types (graceful)', async () => {
+    const env  = makeEnv();
+    const body = { meta: { event_name: 'some_other_event' }, data: {} };
+    const req  = await makeSignedRequest(body, WEBHOOK_SECRET);
+    const res  = await handleLemonSqueezy(req, env);
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+Run: `npm test` → Expected: FAIL (webhooks module returns 501)
+
+- [ ] **Step 2.2: Implement `src/webhooks.ts`**
+
+```typescript
+import { hex, json } from './utils';
+import type { Env } from './types';
+
+const UPGRADE_EVENTS   = ['order_created', 'subscription_created', 'subscription_resumed'];
+const DOWNGRADE_EVENTS = ['subscription_cancelled', 'subscription_expired'];
+
+export async function handleLemonSqueezy(req: Request, env: Env): Promise<Response> {
+  const sig  = req.headers.get('X-Signature') ?? '';
+  const body = await req.text();
+
+  // Verify HMAC-SHA256 signature.
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(env.LEMONSQUEEZY_WEBHOOK_SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const computed = hex(new Uint8Array(
+    await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(body))
+  ));
+
+  // Constant-time comparison to prevent timing attacks.
+  if (!constantTimeEqual(computed, sig)) {
+    return json({ error: 'Invalid signature' }, 401);
+  }
+
+  const event = JSON.parse(body) as {
+    meta?: { event_name?: string };
+    data?: { attributes?: { user_email?: string } };
+  };
+
+  const eventName = event?.meta?.event_name ?? '';
+  const email     = event?.data?.attributes?.user_email?.toLowerCase().trim();
+
+  if (email) {
+    if (UPGRADE_EVENTS.includes(eventName)) {
+      await env.DB.prepare(
+        `UPDATE users SET plan = 'pro', plan_expires = NULL, updated_at = CURRENT_TIMESTAMP WHERE email = ?`
+      ).bind(email).run();
+    } else if (DOWNGRADE_EVENTS.includes(eventName)) {
+      await env.DB.prepare(
+        `UPDATE users SET plan = 'free', plan_expires = NULL, updated_at = CURRENT_TIMESTAMP WHERE email = ?`
+      ).bind(email).run();
+    }
+    // Unknown events are silently accepted — LemonSqueezy expects 200 for all events.
+  }
+
+  return json({ received: true });
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+```
+
+- [ ] **Step 2.3: Run full test suite**
+
+```bash
+npm test
+# Expected: All tests PASS (jwt, password, auth, entitlement, chat, webhooks)
+```
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add src/webhooks.ts test/webhooks.test.ts
+git commit -m "feat(proxy): implement LemonSqueezy webhook handler with HMAC verification"
+```
+
+---
+
+## Task 3: Deploy and Smoke Test
+
+- [ ] **Step 3.1: Deploy updated Worker**
+
+```bash
+wrangler deploy
+# Expected: ✓ Deployed to https://wp-ai-mind-proxy.YOUR.workers.dev
+```
+
+- [ ] **Step 3.2: Smoke test chat endpoint with a real API key**
+
+```bash
+BASE="https://wp-ai-mind-proxy.YOUR.workers.dev"
+
+# Get an access token first
+TOKEN=$(curl -s -X POST $BASE/v1/auth/token \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"smoke@example.com","password":"smoketest123"}' | jq -r .access_token)
+
+# Send a minimal chat request
+curl -X POST $BASE/v1/chat \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "claude-haiku-4-5",
+    "max_tokens": 50,
+    "messages": [{"role": "user", "content": "Say hello in one word."}]
+  }' | jq .
+# Expected: Anthropic response with content array
+```
+
+- [ ] **Step 3.3: Smoke test limit enforcement**
+
+```bash
+# Insert a user at their limit directly in D1 (for testing only)
+wrangler d1 execute wp-ai-mind --remote --command \
+  "UPDATE users SET plan = 'free' WHERE email = 'smoke@example.com';"
+
+# Set KV usage to limit
+wrangler kv:key put --binding=USAGE_KV "usage:USER_ID:$(date +%Y-%m)" "50000"
+
+# Attempt chat — should be 429
+curl -X POST $BASE/v1/chat \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"claude-haiku-4-5","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}' | jq .
+# Expected: {"error":"token_limit_exceeded","used":50000,"limit":50000,...}
+```
+
+- [ ] **Step 3.4: Test LemonSqueezy webhook with test delivery**
+
+In LemonSqueezy dashboard → Webhooks → Send test event for `subscription_created`.
+Verify D1 user plan is updated to `pro`:
+```bash
+wrangler d1 execute wp-ai-mind --remote --command "SELECT plan FROM users WHERE email = 'your@email.com';"
+# Expected: plan = 'pro'
+```
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git commit -m "chore(proxy): Phase 3 complete — chat proxy and webhooks deployed"
+```
+
+---
+
+## Phase 3 Acceptance Criteria
+
+- [ ] `POST /v1/chat` with valid JWT + within limits → Anthropic response returned
+- [ ] `POST /v1/chat` at token limit → 429 with `error: 'token_limit_exceeded'`
+- [ ] KV key `usage:{id}:{YYYY-MM}` increments after each successful chat
+- [ ] KV key TTL expires at end of month (not a fixed duration from now)
+- [ ] `POST /webhooks/lemonsqueezy` with correct HMAC → D1 plan updated to `pro`
+- [ ] `POST /webhooks/lemonsqueezy` with incorrect HMAC → 401
+- [ ] `subscription_cancelled` event → D1 plan updated to `free`
+- [ ] All unit tests pass: `npm test`
+
+---
+
+## Phase 3 Risk Notes
+
+- **KV TOCTOU race:** Two simultaneous requests from the same user could both pass the limit check before either writes usage. This results in slightly over-limit requests — acceptable for a soft cap.
+- **Streaming response buffering:** The current implementation buffers the full Anthropic response before returning it to the plugin. This means the PHP side won't see incremental output until Phase 7 (real SSE streaming). For the initial release this is acceptable.
+- **Worker Paid plan required for production streaming.** The Cloudflare Workers Free plan has a 10ms CPU time limit per request. Proxying an Anthropic response that takes 10–30 seconds requires the Paid plan (no CPU time limit on I/O-bound work). Ensure the Cloudflare account is on a Paid plan before going live.
+- **KV `put` with `expirationTtl`** sets a TTL from the moment of write. Since `secondsUntilMonthEnd()` is computed fresh on each write, this correctly aligns with calendar month end regardless of when in the month the write occurs.

--- a/docs/superpowers/plans/phases/phase-4-php-proxy-routing.md
+++ b/docs/superpowers/plans/phases/phase-4-php-proxy-routing.md
@@ -12,15 +12,55 @@
 
 ---
 
+## Task 0: Pre-implementation Reuse Audit
+
+> **Mandatory.** Complete before writing any new PHP classes.
+
+- [ ] **Step 0.1: Read `ProviderInterface` and `AbstractProvider`**
+
+```bash
+cat includes/Providers/ProviderInterface.php
+cat includes/Providers/AbstractProvider.php
+# ProxyProvider MUST extend AbstractProvider and implement ProviderInterface.
+# Do not create a parallel hierarchy.
+```
+
+- [ ] **Step 0.2: Read existing Provider implementations**
+
+```bash
+ls includes/Providers/
+# Review ClaudeProvider.php (or similar) to understand the pattern ProxyProvider must follow.
+# ProxyProvider.php should follow the same structure — no bespoke patterns.
+```
+
+- [ ] **Step 0.3: Read `NJ_Entitlement::feature()` and `NJ_Entitlement::get()`**
+
+```bash
+grep -n "feature\|get\|allowed_models" includes/Entitlement/NJ_Entitlement.php
+# Understand what data is available (including allowed_models from Phase 2) before
+# implementing ProxyProvider's model-selection logic.
+```
+
+- [ ] **Step 0.4: Confirm `nj_resolve_provider()` does not already exist**
+
+```bash
+grep -rn "nj_resolve_provider" . --include="*.php"
+# If it exists, read it before modifying — do not duplicate.
+```
+
+---
+
 ## Design Decisions
 
 | Decision | Choice | Reason |
 |----------|--------|--------|
 | ProxyProvider slug | `'proxy'` | Distinguishable from real provider slugs; logged in any debug output |
-| Free tier model | `claude-haiku-4-5` | Cheapest capable model; qualitative incentive to upgrade to Pro for model choice |
-| Max output tokens (free) | 1,000 | Hard cap enforced in Worker too; prevents runaway single responses |
+| Free/trial model | `claude-haiku-4-5` (forced) | Cheapest capable model; qualitative incentive to upgrade |
+| `pro_managed` model | Requested model forwarded to Worker | Worker validates against allowlist from `tier-config.ts`; plugin UI uses `allowed_models` from entitlement |
+| Max output tokens (free/trial) | 1,000 (from Worker tier-config) | Hard cap enforced by Worker; plugin honours it locally too |
+| Max output tokens (pro_managed) | 8,000 (from Worker tier-config) | Worker enforces final cap |
 | Simulated streaming | Word-by-word token split | Real SSE passthrough is Phase 7; this gives users the streaming UX immediately |
-| Tool calling | `supports_tools() = false` on ProxyProvider | Tool calls require own API key (Pro plan); prevents misconfigured requests |
+| Tool calling | `supports_tools() = false` on ProxyProvider | Tool calls require own API key (`pro` BYOK); prevents misconfigured requests |
 | UsageLogger removal | Remove `maybe_log()` call from AbstractProvider | Worker KV is the authoritative logger; plugin-side logging is redundant |
 
 ---
@@ -299,19 +339,37 @@ class ProxyProvider extends AbstractProvider {
     public function supports_tools(): bool       { return false; } // Tool calls require Pro plan.
 
     public function get_models(): array {
-        return [
-            'claude-haiku-4-5' => [
-                'name'           => __( 'Claude Haiku (Free tier)', 'wp-ai-mind' ),
-                'input_per_mtok' => 0,
+        // Return available models from the entitlement payload (populated by Worker tier-config).
+        // For free/trial this is just Haiku. For pro_managed it includes Sonnet, Opus, etc.
+        $entitlement    = \WP_AI_Mind\Entitlement\NJ_Entitlement::get();
+        $allowed_models = (array) ( $entitlement['allowed_models'] ?? [ 'claude-haiku-4-5' ] );
+
+        $models = [];
+        foreach ( $allowed_models as $model_id ) {
+            $models[ $model_id ] = [
+                'name'            => $model_id,
+                'input_per_mtok'  => 0, // Cost absorbed by platform.
                 'output_per_mtok' => 0,
-            ],
-        ];
+            ];
+        }
+        return $models;
     }
 
     protected function do_complete( CompletionRequest $request ): CompletionResponse {
+        $entitlement    = \WP_AI_Mind\Entitlement\NJ_Entitlement::get();
+        $can_select     = (bool) ( $entitlement['features']['model_selection'] ?? false );
+        $allowed_models = (array) ( $entitlement['allowed_models'] ?? [] );
+
+        // Respect model selection for pro_managed; force Haiku for free/trial.
+        if ( $can_select && ! empty( $request->model ) && in_array( $request->model, $allowed_models, true ) ) {
+            $model = $request->model;
+        } else {
+            $model = $this->get_default_model(); // 'claude-haiku-4-5' for free/trial
+        }
+
         $body = [
-            'model'      => 'claude-haiku-4-5',
-            'max_tokens' => min( (int) $request->max_tokens, 1000 ),
+            'model'      => $model,
+            'max_tokens' => (int) $request->max_tokens, // Worker enforces the per-tier cap
             'messages'   => $request->messages,
         ];
 
@@ -395,15 +453,17 @@ if ( ! function_exists( 'nj_resolve_provider' ) ) {
      * Returns the correct ProviderInterface for the current authenticated user.
      *
      * Routing rules:
-     * - Pro plan + own_key feature: returns the named direct provider (user's own API key)
-     * - Free / trial authenticated: returns ProxyProvider (routes via Worker)
-     * - Not authenticated: returns ProxyProvider (is_available() = false; caller checks this)
+     * - own_key feature (Pro BYOK): returns a direct provider using the user's own API key.
+     *   Worker is bypassed — no platform cost for BYOK requests.
+     * - pro_managed / trial / free (authenticated): returns ProxyProvider.
+     *   ProxyProvider routes via the Worker, which enforces per-tier limits and model allowlists.
+     * - Not authenticated: returns ProxyProvider (is_available() = false; caller must check this).
      *
-     * @param string $provider_slug Optional provider slug for Pro users ('claude', 'openai', etc.)
+     * @param string $provider_slug Optional provider slug for Pro BYOK users ('claude', 'openai', etc.)
      */
     function nj_resolve_provider( string $provider_slug = '' ): \WP_AI_Mind\Providers\ProviderInterface {
         if ( \nj_feature( 'own_key' ) ) {
-            // Pro path: use the user's own API key with a direct provider.
+            // Pro BYOK path: direct provider with user's own API key; Worker not involved.
             $factory = new \WP_AI_Mind\Providers\ProviderFactory(
                 new \WP_AI_Mind\Settings\ProviderSettings()
             );
@@ -412,7 +472,8 @@ if ( ! function_exists( 'nj_resolve_provider' ) ) {
                 : $factory->make_default();
         }
 
-        // Free / trial path: always route via Worker (slug ignored — Worker only speaks Claude).
+        // Pro Managed / trial / free path: always route via Worker.
+        // ProxyProvider respects model_selection feature flag internally.
         return new \WP_AI_Mind\Providers\ProxyProvider();
     }
 }
@@ -491,10 +552,46 @@ git commit -m "refactor(providers): remove maybe_log from AbstractProvider (logg
 
 ---
 
+## Task 5: Post-implementation Code Reuse Verification
+
+> **Mandatory.** Run before marking Phase 4 complete.
+
+- [ ] **Step 5.1: No hardcoded plan names in ProxyProvider**
+
+```bash
+grep -n "pro_managed\|free\|trial\|plan ===" includes/Providers/ProxyProvider.php
+# Expected: 0 matches — ProxyProvider uses nj_feature() and entitlement data, not plan name strings
+```
+
+- [ ] **Step 5.2: No hardcoded model names in ProxyProvider**
+
+```bash
+grep -n "claude-haiku\|claude-sonnet\|claude-opus" includes/Providers/ProxyProvider.php
+# Expected: only in get_default_model() return value; model lists come from entitlement payload
+```
+
+- [ ] **Step 5.3: AbstractProvider contract still honoured**
+
+```bash
+grep -n "do_complete\|do_stream\|get_slug\|is_available\|get_models" includes/Providers/ProxyProvider.php
+# Expected: all required ProviderInterface methods are implemented
+```
+
+- [ ] **Step 5.4: Full test suite passes**
+
+```bash
+./vendor/bin/phpunit tests/Unit/ --colors=always
+# Expected: all tests pass including new ProxyProvider tests
+```
+
+---
+
 ## Phase 4 Acceptance Criteria
 
-- [ ] Free/trial user chat request routes via `ProxyProvider` → Worker → Anthropic (verify via network/debug log)
-- [ ] Pro user chat request routes via direct `ClaudeProvider` (Worker not involved)
+- [ ] Free/trial user chat request routes via `ProxyProvider` → Worker → Anthropic (verify via network/debug log), model forced to Haiku
+- [ ] `pro_managed` user chat request routes via `ProxyProvider` → Worker, requested model forwarded; Worker validates against allowlist
+- [ ] Pro BYOK user chat request routes via direct `ClaudeProvider` (Worker not involved)
+- [ ] `ProxyProvider::get_models()` returns Haiku only for free/trial; returns full allowed_models list for pro_managed
 - [ ] `ProxyProvider::is_available()` returns `false` when not authenticated
 - [ ] `ProxyProvider::generate_image()` throws 403 `ProviderException`
 - [ ] `ProxyProvider::supports_tools()` returns `false`

--- a/docs/superpowers/plans/phases/phase-4-php-proxy-routing.md
+++ b/docs/superpowers/plans/phases/phase-4-php-proxy-routing.md
@@ -1,0 +1,510 @@
+# Phase 4: PHP — ProxyProvider + ProviderFactory Routing
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Free/trial users transparently route through a new `ProxyProvider` class (which calls `NJ_Proxy_Client` → Cloudflare Worker). Pro users continue using their own API keys through existing providers. `nj_resolve_provider()` is the single routing decision point. UsageLogger is disabled (logging has moved to Worker KV).
+
+**Architecture:** `ProxyProvider` implements the existing `ProviderInterface` so `ChatRestController` requires zero changes. `nj_resolve_provider()` is a global function (same pattern as `wp_ai_mind_is_pro()`) that inspects `NJ_Entitlement` to select the correct provider.
+
+**Tech Stack:** PHP 8.1+, WordPress plugin, PHPUnit + Brain Monkey
+
+**Depends on:** Phase 2 (NJ_Auth + NJ_Entitlement available) + Phase 3 (Worker `/v1/chat` endpoint live)
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| ProxyProvider slug | `'proxy'` | Distinguishable from real provider slugs; logged in any debug output |
+| Free tier model | `claude-haiku-4-5` | Cheapest capable model; qualitative incentive to upgrade to Pro for model choice |
+| Max output tokens (free) | 1,000 | Hard cap enforced in Worker too; prevents runaway single responses |
+| Simulated streaming | Word-by-word token split | Real SSE passthrough is Phase 7; this gives users the streaming UX immediately |
+| Tool calling | `supports_tools() = false` on ProxyProvider | Tool calls require own API key (Pro plan); prevents misconfigured requests |
+| UsageLogger removal | Remove `maybe_log()` call from AbstractProvider | Worker KV is the authoritative logger; plugin-side logging is redundant |
+
+---
+
+## File Map
+
+**New files:**
+- `includes/Proxy/NJ_Proxy_Client.php`
+- `includes/Providers/ProxyProvider.php`
+- `tests/Unit/Proxy/NJProxyClientTest.php`
+- `tests/Unit/Providers/ProxyProviderTest.php`
+
+**Modified files:**
+- `wp-ai-mind.php` — add eager-load of `nj_resolve_provider()` global helper
+- `includes/Providers/ProviderFactory.php` — `make_default()` delegates to `nj_resolve_provider()`
+- `includes/Modules/Chat/ChatRestController.php` — use `nj_resolve_provider()` for provider selection
+- `includes/Providers/AbstractProvider.php` — remove `maybe_log()` call and `UsageLogger` import
+
+---
+
+## Task 1: NJ_Proxy_Client
+
+**Files:** Create `includes/Proxy/NJ_Proxy_Client.php`, `tests/Unit/Proxy/NJProxyClientTest.php`
+
+- [ ] **Step 1.1: Write failing tests** (`tests/Unit/Proxy/NJProxyClientTest.php`)
+
+```php
+<?php
+namespace WP_AI_Mind\Tests\Unit\Proxy;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_AI_Mind\Proxy\NJ_Proxy_Client;
+use WP_AI_Mind\Providers\ProviderException;
+
+class NJProxyClientTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+        Functions\when( 'get_option' )->justReturn( 'valid-jwt-token' );
+        Functions\when( 'is_wp_error' )->justReturn( false );
+        Functions\when( 'wp_json_encode' )->returnArg();
+        Functions\when( 'wp_remote_post' )->justReturn( [] );
+        Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+        Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"content":[{"type":"text","text":"hello"}],"usage":{"input_tokens":10,"output_tokens":5}}' );
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_chat_returns_raw_body_on_success(): void {
+        $client = new NJ_Proxy_Client();
+        $result = $client->chat( [ 'model' => 'claude-haiku-4-5', 'messages' => [] ] );
+        $this->assertIsString( $result );
+        $decoded = json_decode( $result, true );
+        $this->assertArrayHasKey( 'content', $decoded );
+    }
+
+    public function test_chat_throws_provider_exception_on_429(): void {
+        Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 429 );
+        Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"error":"token_limit_exceeded"}' );
+
+        $this->expectException( ProviderException::class );
+
+        $client = new NJ_Proxy_Client();
+        $client->chat( [ 'model' => 'claude-haiku-4-5', 'messages' => [] ] );
+    }
+
+    public function test_chat_throws_provider_exception_on_server_error(): void {
+        Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 500 );
+        Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"error":"internal error"}' );
+
+        $this->expectException( ProviderException::class );
+
+        $client = new NJ_Proxy_Client();
+        $client->chat( [ 'model' => 'claude-haiku-4-5', 'messages' => [] ] );
+    }
+}
+```
+
+Run: `./vendor/bin/phpunit tests/Unit/Proxy/NJProxyClientTest.php --colors=always`
+Expected: FAIL (class not found)
+
+- [ ] **Step 1.2: Implement `includes/Proxy/NJ_Proxy_Client.php`**
+
+```php
+<?php
+namespace WP_AI_Mind\Proxy;
+
+use WP_AI_Mind\Auth\NJ_Auth;
+use WP_AI_Mind\Providers\ProviderException;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * HTTP client for the Cloudflare Worker proxy.
+ * Used by ProxyProvider for free/trial user chat requests.
+ */
+class NJ_Proxy_Client {
+
+    /**
+     * Sends a chat completion request to the Worker.
+     * $body must be a valid Anthropic messages API payload (model, max_tokens, messages).
+     *
+     * @throws ProviderException on 429 (limit exceeded) or non-2xx responses.
+     * @return string Raw JSON response body from the Worker.
+     */
+    public function chat( array $body ): string {
+        $token = NJ_Auth::get_valid_access_token();
+        if ( '' === $token ) {
+            throw new ProviderException(
+                __( 'Not authenticated. Please log in to use AI features.', 'wp-ai-mind' ),
+                'proxy', 401, false
+            );
+        }
+
+        $response = wp_remote_post( NJ_Auth::PROXY_BASE . '/v1/chat', [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+                'Content-Type'  => 'application/json',
+            ],
+            'body'    => wp_json_encode( $body ),
+            'timeout' => WP_AI_MIND_HTTP_TIMEOUT,
+        ] );
+
+        if ( is_wp_error( $response ) ) {
+            throw new ProviderException(
+                $response->get_error_message(),
+                'proxy', 502, true
+            );
+        }
+
+        $status = wp_remote_retrieve_response_code( $response );
+        $raw    = wp_remote_retrieve_body( $response );
+
+        if ( 429 === $status ) {
+            throw new ProviderException(
+                __( 'Monthly AI credit limit reached. Upgrade to Pro for unlimited access.', 'wp-ai-mind' ),
+                'proxy', 429, false
+            );
+        }
+
+        if ( $status < 200 || $status >= 300 ) {
+            $data = json_decode( $raw, true );
+            throw new ProviderException(
+                is_array( $data ) && ! empty( $data['error'] )
+                    ? (string) $data['error']
+                    : __( 'Proxy error. Please try again.', 'wp-ai-mind' ),
+                'proxy',
+                (int) $status,
+                in_array( (int) $status, [ 500, 502, 503 ], true )
+            );
+        }
+
+        return $raw;
+    }
+}
+```
+
+- [ ] **Step 1.3: Run tests to verify they pass**
+
+```bash
+./vendor/bin/phpunit tests/Unit/Proxy/NJProxyClientTest.php --colors=always
+# Expected: 3 tests PASS
+```
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git add includes/Proxy/NJ_Proxy_Client.php tests/Unit/Proxy/NJProxyClientTest.php
+git commit -m "feat(proxy): add NJ_Proxy_Client HTTP client for Worker chat endpoint"
+```
+
+---
+
+## Task 2: ProxyProvider
+
+**Files:** Create `includes/Providers/ProxyProvider.php`, `tests/Unit/Providers/ProxyProviderTest.php`
+
+- [ ] **Step 2.1: Write failing tests** (`tests/Unit/Providers/ProxyProviderTest.php`)
+
+```php
+<?php
+namespace WP_AI_Mind\Tests\Unit\Providers;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_AI_Mind\Providers\ProxyProvider;
+use WP_AI_Mind\Providers\ProviderException;
+use WP_AI_Mind\Providers\CompletionRequest;
+
+class ProxyProviderTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_get_slug_returns_proxy(): void {
+        $provider = new ProxyProvider();
+        $this->assertSame( 'proxy', $provider->get_slug() );
+    }
+
+    public function test_supports_tools_returns_false(): void {
+        $provider = new ProxyProvider();
+        $this->assertFalse( $provider->supports_tools() );
+    }
+
+    public function test_is_available_returns_false_when_not_authenticated(): void {
+        Functions\when( 'get_option' )->justReturn( '' );
+        $provider = new ProxyProvider();
+        $this->assertFalse( $provider->is_available() );
+    }
+
+    public function test_is_available_returns_true_when_authenticated(): void {
+        Functions\when( 'get_option' )->justReturn( 'some-token' );
+        $provider = new ProxyProvider();
+        $this->assertTrue( $provider->is_available() );
+    }
+
+    public function test_generate_image_throws_403_exception(): void {
+        $this->expectException( ProviderException::class );
+        $provider = new ProxyProvider();
+        $provider->generate_image( 'a sunset' );
+    }
+
+    public function test_get_default_model_returns_haiku(): void {
+        $provider = new ProxyProvider();
+        $this->assertSame( 'claude-haiku-4-5', $provider->get_default_model() );
+    }
+}
+```
+
+Run: `./vendor/bin/phpunit tests/Unit/Providers/ProxyProviderTest.php --colors=always`
+Expected: FAIL (class not found)
+
+- [ ] **Step 2.2: Implement `includes/Providers/ProxyProvider.php`**
+
+```php
+<?php
+namespace WP_AI_Mind\Providers;
+
+use WP_AI_Mind\Auth\NJ_Auth;
+use WP_AI_Mind\Proxy\NJ_Proxy_Client;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Routes free/trial user chat requests through the NJ Cloudflare Worker proxy.
+ * The Worker uses the platform's Anthropic API key — the plugin never sees it.
+ *
+ * This provider implements ProviderInterface identically to ClaudeProvider,
+ * so ChatRestController requires no changes to support it.
+ */
+class ProxyProvider extends AbstractProvider {
+
+    private NJ_Proxy_Client $client;
+
+    public function __construct() {
+        $this->client = new NJ_Proxy_Client();
+    }
+
+    public function get_slug(): string          { return 'proxy'; }
+    public function get_default_model(): string  { return 'claude-haiku-4-5'; }
+    public function is_available(): bool         { return NJ_Auth::is_authenticated(); }
+    public function supports_tools(): bool       { return false; } // Tool calls require Pro plan.
+
+    public function get_models(): array {
+        return [
+            'claude-haiku-4-5' => [
+                'name'           => __( 'Claude Haiku (Free tier)', 'wp-ai-mind' ),
+                'input_per_mtok' => 0,
+                'output_per_mtok' => 0,
+            ],
+        ];
+    }
+
+    protected function do_complete( CompletionRequest $request ): CompletionResponse {
+        $body = [
+            'model'      => 'claude-haiku-4-5',
+            'max_tokens' => min( (int) $request->max_tokens, 1000 ),
+            'messages'   => $request->messages,
+        ];
+
+        if ( '' !== $request->system ) {
+            $body['system'] = $request->system;
+        }
+
+        $raw  = $this->client->chat( $body );
+        $data = json_decode( $raw, true );
+
+        return $this->parse_claude_response( $data ?? [] );
+    }
+
+    protected function do_stream( CompletionRequest $request, callable $on_chunk ): CompletionResponse {
+        // Phase 4: simulate streaming from buffered response.
+        // Real SSE passthrough is implemented in Phase 7.
+        $response = $this->do_complete( $request );
+        $words    = explode( ' ', $response->content );
+
+        foreach ( $words as $i => $word ) {
+            $on_chunk( ( $i > 0 ? ' ' : '' ) . $word );
+        }
+
+        return $response;
+    }
+
+    public function generate_image( string $prompt, array $options = [] ): int {
+        throw new ProviderException(
+            __( 'Image generation requires a Pro plan with your own API key.', 'wp-ai-mind' ),
+            'proxy', 403, false
+        );
+    }
+
+    private function parse_claude_response( array $data ): CompletionResponse {
+        $content = '';
+        foreach ( $data['content'] ?? [] as $block ) {
+            if ( 'text' === ( $block['type'] ?? '' ) ) {
+                $content .= $block['text'] ?? '';
+            }
+        }
+
+        return new CompletionResponse(
+            content:           $content,
+            model:             $data['model']                       ?? 'claude-haiku-4-5',
+            prompt_tokens:     (int) ( $data['usage']['input_tokens']  ?? 0 ),
+            completion_tokens: (int) ( $data['usage']['output_tokens'] ?? 0 ),
+            cost_usd:          0.0, // Cost absorbed by the platform.
+            raw:               $data,
+        );
+    }
+}
+```
+
+- [ ] **Step 2.3: Run tests to verify they pass**
+
+```bash
+./vendor/bin/phpunit tests/Unit/Providers/ProxyProviderTest.php --colors=always
+# Expected: 6 tests PASS
+```
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add includes/Providers/ProxyProvider.php tests/Unit/Providers/ProxyProviderTest.php
+git commit -m "feat(providers): add ProxyProvider routing free/trial requests through Worker"
+```
+
+---
+
+## Task 3: nj_resolve_provider() + ProviderFactory Wiring
+
+**Files:** Modify `wp-ai-mind.php`, `includes/Providers/ProviderFactory.php`, `includes/Modules/Chat/ChatRestController.php`
+
+- [ ] **Step 3.1: Add `nj_resolve_provider()` to `wp-ai-mind.php` eager block**
+
+After the `nj_feature()` function definition (added in Phase 2), add:
+
+```php
+if ( ! function_exists( 'nj_resolve_provider' ) ) {
+    /**
+     * Returns the correct ProviderInterface for the current authenticated user.
+     *
+     * Routing rules:
+     * - Pro plan + own_key feature: returns the named direct provider (user's own API key)
+     * - Free / trial authenticated: returns ProxyProvider (routes via Worker)
+     * - Not authenticated: returns ProxyProvider (is_available() = false; caller checks this)
+     *
+     * @param string $provider_slug Optional provider slug for Pro users ('claude', 'openai', etc.)
+     */
+    function nj_resolve_provider( string $provider_slug = '' ): \WP_AI_Mind\Providers\ProviderInterface {
+        if ( \nj_feature( 'own_key' ) ) {
+            // Pro path: use the user's own API key with a direct provider.
+            $factory = new \WP_AI_Mind\Providers\ProviderFactory(
+                new \WP_AI_Mind\Settings\ProviderSettings()
+            );
+            return '' !== $provider_slug
+                ? $factory->make( $provider_slug )
+                : $factory->make_default();
+        }
+
+        // Free / trial path: always route via Worker (slug ignored — Worker only speaks Claude).
+        return new \WP_AI_Mind\Providers\ProxyProvider();
+    }
+}
+```
+
+- [ ] **Step 3.2: Update `includes/Providers/ProviderFactory.php::make_default()`**
+
+```php
+public function make_default(): ProviderInterface {
+    // When NJ routing is active, delegate to entitlement-aware resolver.
+    if ( function_exists( 'nj_resolve_provider' ) ) {
+        return \nj_resolve_provider();
+    }
+
+    // Legacy fallback (removed in Phase 5 when Freemius is stripped).
+    $slug = get_option( 'wp_ai_mind_default_provider', 'claude' );
+    return $this->make( ! empty( $slug ) ? $slug : 'claude' );
+}
+```
+
+- [ ] **Step 3.3: Update `includes/Modules/Chat/ChatRestController.php::send_message()`**
+
+Find the line that calls `$factory->make( $provider_slug )` and replace with:
+
+```php
+// Use entitlement-aware routing when available; fall back to direct factory for Pro users.
+$provider = function_exists( 'nj_resolve_provider' )
+    ? \nj_resolve_provider( $provider_slug )
+    : $factory->make( $provider_slug );
+```
+
+- [ ] **Step 3.4: Run full test suite**
+
+```bash
+./vendor/bin/phpunit tests/Unit/ --colors=always
+# Expected: All tests PASS
+```
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add wp-ai-mind.php includes/Providers/ProviderFactory.php includes/Modules/Chat/ChatRestController.php
+git commit -m "feat(routing): add nj_resolve_provider() and wire into ProviderFactory and ChatRestController"
+```
+
+---
+
+## Task 4: Remove UsageLogger from AbstractProvider
+
+**Files:** Modify `includes/Providers/AbstractProvider.php`
+
+- [ ] **Step 4.1: Remove `maybe_log()` from `AbstractProvider`**
+
+In `includes/Providers/AbstractProvider.php`:
+
+1. Remove the `use WP_AI_Mind\DB\UsageLogger;` import at the top
+2. Remove the call to `$this->maybe_log( $request, $response )` in the `complete()` method
+3. Remove the call to `$this->maybe_log( $request, $response )` in the `stream()` method
+4. Remove the entire `private function maybe_log(...)` method
+
+The logging has moved to the Worker's KV store. The `UsageLogger` class itself is deleted in Phase 5.
+
+- [ ] **Step 4.2: Run full test suite**
+
+```bash
+./vendor/bin/phpunit tests/Unit/ --colors=always
+# Expected: All tests PASS (AbstractProviderTest must not reference maybe_log)
+```
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add includes/Providers/AbstractProvider.php
+git commit -m "refactor(providers): remove maybe_log from AbstractProvider (logging moved to Worker KV)"
+```
+
+---
+
+## Phase 4 Acceptance Criteria
+
+- [ ] Free/trial user chat request routes via `ProxyProvider` → Worker → Anthropic (verify via network/debug log)
+- [ ] Pro user chat request routes via direct `ClaudeProvider` (Worker not involved)
+- [ ] `ProxyProvider::is_available()` returns `false` when not authenticated
+- [ ] `ProxyProvider::generate_image()` throws 403 `ProviderException`
+- [ ] `ProxyProvider::supports_tools()` returns `false`
+- [ ] Token usage is no longer written to `wpaim_usage_log` table
+- [ ] All PHPUnit tests pass: `./vendor/bin/phpunit tests/Unit/ --colors=always`
+
+---
+
+## Phase 4 Risk Notes
+
+- **`nj_resolve_provider()` calls `NJ_Entitlement::get()`** which may trigger one HTTP call per hour on transient expiry. First-request-after-expiry latency: up to 300ms. Mitigated by the 1-hour cache.
+- **ProxyProvider silently ignores `$provider_slug` for free users.** If a free user selected Gemini as their default, they will receive Claude Haiku responses. This is intentional — document it in the UI (Phase 6): "Free and trial plans use Claude Haiku via shared infrastructure."
+- **`wp_remote_post()` has a configurable timeout.** The `WP_AI_MIND_HTTP_TIMEOUT` constant (60s) is used. Anthropic Haiku responses at 1,000 tokens are typically <10s — this timeout is safe.

--- a/docs/superpowers/plans/phases/phase-5-php-legacy-removal.md
+++ b/docs/superpowers/plans/phases/phase-5-php-legacy-removal.md
@@ -10,6 +10,38 @@
 
 **Depends on:** Phase 4 in production. Migration notice shown to existing users.
 
+---
+
+## Task 0: Pre-implementation Reuse Audit
+
+> **Mandatory.** This phase removes code — read everything before deleting anything.
+
+- [ ] **Step 0.1: Audit all 13 ProGate call sites**
+
+```bash
+grep -rn "wp_ai_mind_is_pro\|ProGate" includes/ --include="*.php"
+# List every call site. For each, determine the correct nj_feature() replacement key
+# using the feature flag table in the master spec before making any changes.
+```
+
+- [ ] **Step 0.2: Confirm nj_feature() covers all gated features**
+
+```bash
+grep -rn "nj_feature" includes/Entitlement/NJ_Entitlement.php wp-ai-mind.php
+# Verify the feature keys used at each ProGate call site exist in NJ_Entitlement::empty_doc().
+```
+
+- [ ] **Step 0.3: Confirm Phase 4 is live in production**
+
+Do not start this phase until `ProxyProvider` is serving real traffic and existing Pro users have had adequate migration notice (minimum 2 weeks).
+
+- [ ] **Step 0.4: Audit UsageLogger dependencies**
+
+```bash
+grep -rn "UsageLogger\|maybe_log\|wpaim_usage_log" includes/ --include="*.php"
+# Ensure every reference is accounted for before deleting the class.
+```
+
 **Critical Warning:** Existing Pro users who purchased via Freemius will lose their Pro status until they create an NJ account and upgrade via LemonSqueezy. Plan a migration period and show the admin notice from Task 1 for at least 2 weeks before removing Freemius.
 
 ---

--- a/docs/superpowers/plans/phases/phase-5-php-legacy-removal.md
+++ b/docs/superpowers/plans/phases/phase-5-php-legacy-removal.md
@@ -1,0 +1,353 @@
+# Phase 5: PHP — Freemius + ProGate + UsageLogger Removal
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Freemius SDK, ProGate class, and UsageLogger class are completely removed. All 13 `wp_ai_mind_is_pro()` call sites are replaced with `nj_feature()`. The `wpaim_usage_log` DB table is dropped. The plugin bootstrap is simplified from ~110 lines to ~30.
+
+**Architecture:** Pure cleanup phase. No new functionality added. All feature gating now flows through `NJ_Entitlement::feature()` and `nj_feature()`. This phase must run AFTER Phase 4 is deployed to production and all existing Pro users have migrated to NJ accounts.
+
+**Tech Stack:** PHP 8.1+, Composer, PHPUnit
+
+**Depends on:** Phase 4 in production. Migration notice shown to existing users.
+
+**Critical Warning:** Existing Pro users who purchased via Freemius will lose their Pro status until they create an NJ account and upgrade via LemonSqueezy. Plan a migration period and show the admin notice from Task 1 for at least 2 weeks before removing Freemius.
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Freemius removal | Delete `vendor/freemius/` + `composer.json` entry | Cannot keep SDK that phones home; clean break |
+| ProGate removal | Delete file + replace all call sites | No backward compat needed — `nj_feature('own_key')` is the direct replacement |
+| `isPro` localized key | Keep as derived alias: `nj_feature('own_key')` | Third-party code or themes may read `wpAiMindData.isPro`; keep the shape |
+| UsageLogger DB table | Drop with `maybe_migrate()` on update | Cannot leave orphan tables; migration tracks version with `wpaim_db_version` option |
+| UsagePage | Redirect to Worker usage data via `GET /v1/usage` | Preserves the admin UI; data source changes from local DB to Worker KV |
+
+---
+
+## File Map
+
+**Files deleted:**
+- `includes/Core/ProGate.php`
+- `includes/DB/UsageLogger.php`
+- `tests/Unit/Core/ProGateTest.php`
+
+**Files modified:**
+- `wp-ai-mind.php` — remove entire Freemius bootstrap block (~53–101), ProGate eager-load
+- `composer.json` — remove `freemius/wordpress-sdk` dependency
+- `includes/DB/Schema.php` — remove `wpaim_usage_log` table creation, add `maybe_migrate()`
+- `includes/Core/Plugin.php` — call `Schema::maybe_migrate()` from `activate()`
+- `includes/Admin/SettingsPage.php` + 8 other admin/module files — final `isPro` localize update (already done in Phase 2, but ensure ProGate import is removed)
+- `includes/Modules/Generator/GeneratorModule.php` — replace ProGate permission callback
+- `includes/Modules/Images/ImagesModule.php` — replace ProGate permission callback
+- `includes/Modules/Seo/SeoModule.php` — replace 2× ProGate permission callbacks
+
+---
+
+## Task 1: Migration Notice
+
+**Files:** Modify `includes/Admin/ActivationNotice.php` (or create if it doesn't exist with that hook)
+
+- [ ] **Step 1.1: Add migration notice to the admin**
+
+In `includes/Core/Plugin.php` or `includes/Admin/ActivationNotice.php`, add:
+
+```php
+add_action( 'admin_notices', function() {
+    // Show notice only on WP AI Mind admin pages.
+    $screen = get_current_screen();
+    if ( ! $screen || strpos( $screen->id, 'wp-ai-mind' ) === false ) return;
+
+    if ( ! \WP_AI_Mind\Auth\NJ_Auth::is_authenticated() ) {
+        ?>
+        <div class="notice notice-warning is-dismissible">
+            <p>
+                <strong><?php esc_html_e( 'WP AI Mind — Account Required', 'wp-ai-mind' ); ?></strong>
+            </p>
+            <p>
+                <?php esc_html_e( 'WP AI Mind now uses account-based authentication. Please log in or create a free account to continue using AI features.', 'wp-ai-mind' ); ?>
+                <a href="<?php echo esc_url( admin_url( 'admin.php?page=wp-ai-mind' ) ); ?>">
+                    <?php esc_html_e( 'Set up your account →', 'wp-ai-mind' ); ?>
+                </a>
+            </p>
+        </div>
+        <?php
+    }
+} );
+```
+
+- [ ] **Step 1.2: Commit**
+
+```bash
+git add includes/Core/Plugin.php
+git commit -m "feat(admin): add migration notice prompting users to create NJ account"
+```
+
+---
+
+## Task 2: Remove Freemius SDK
+
+**Files:** Modify `composer.json`, `wp-ai-mind.php`
+
+- [ ] **Step 2.1: Remove Freemius from `composer.json`**
+
+Open `composer.json`. Remove the entry `"freemius/wordpress-sdk": "^2.13"` (or similar) from `require`.
+
+Then run:
+```bash
+composer update
+# The vendor/freemius/ directory is now gone.
+# Expected: Generating autoload files — no Freemius mention
+```
+
+Verify: `ls vendor/freemius 2>/dev/null || echo "freemius removed"`
+
+- [ ] **Step 2.2: Remove the `wam_fs()` function block from `wp-ai-mind.php`**
+
+Delete the entire block from approximately line 25 to line 101 that includes:
+- The `if ( ! function_exists( 'wam_fs' ) ) { ... }` block containing `fs_dynamic_init()`
+- The `wam_fs()` function definition
+- The `do_action( 'wam_fs_loaded' )` call
+- The `wam_fs()->set_basename(...)` call
+
+The file should reduce to: constants, autoloader, eager requires, activation/deactivation hooks, and `add_action('plugins_loaded', ...)`.
+
+- [ ] **Step 2.3: Verify plugin still loads**
+
+```bash
+# On local Docker environment
+docker restart blognjohanssoneu-wordpress-1
+# Then check the WP admin — plugin should activate without errors
+# Check PHP error log: docker exec blognjohanssoneu-wordpress-1 tail -50 /var/log/apache2/error.log
+```
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add composer.json wp-ai-mind.php composer.lock
+git commit -m "feat(cleanup): remove Freemius SDK from composer and plugin bootstrap"
+```
+
+---
+
+## Task 3: Delete ProGate + Replace All Call Sites
+
+**Files:** Delete `includes/Core/ProGate.php`, modify 9 files
+
+- [ ] **Step 3.1: Replace ProGate call sites**
+
+Replace every occurrence of `\wp_ai_mind_is_pro()` or `wp_ai_mind_is_pro()` with the appropriate `nj_feature()` call. There are 13 call sites across these files:
+
+**`includes/Admin/SettingsPage.php`, `ChatPage.php`, `DashboardPage.php`, `GeneratorPage.php`**
+and
+**`includes/Modules/Editor/EditorModule.php`, `FrontendWidgetModule.php`, `GeneratorModule.php`, `ImagesModule.php`, `SeoModule.php`, `UsageModule.php`**
+
+For localized script data (all pages):
+```php
+// Before:
+'isPro' => \wp_ai_mind_is_pro(),
+
+// After (already done in Phase 2 — confirm it's in place):
+'isPro'       => \nj_feature( 'own_key' ),
+'entitlement' => \WP_AI_Mind\Entitlement\NJ_Entitlement::get(),
+```
+
+For permission callbacks in REST route registrations:
+
+**`includes/Modules/Generator/GeneratorModule.php:55`:**
+```php
+// Before:
+'permission_callback' => fn() => \wp_ai_mind_is_pro() && \current_user_can( 'edit_posts' ),
+
+// After:
+'permission_callback' => fn() => \nj_feature( 'generator' ) && \current_user_can( 'edit_posts' ),
+```
+
+**`includes/Modules/Images/ImagesModule.php:65`:**
+```php
+// Before:
+'permission_callback' => fn() => \wp_ai_mind_is_pro() && \current_user_can( 'edit_posts' ),
+
+// After:
+'permission_callback' => fn() => \nj_feature( 'images' ) && \current_user_can( 'edit_posts' ),
+```
+
+**`includes/Modules/Seo/SeoModule.php:69` and `:86`:**
+```php
+// Before:
+'permission_callback' => fn() => \wp_ai_mind_is_pro() && \current_user_can( 'edit_posts' ),
+
+// After:
+'permission_callback' => fn() => \nj_feature( 'seo' ) && \current_user_can( 'edit_posts' ),
+```
+
+- [ ] **Step 3.2: Remove ProGate eager-load from `wp-ai-mind.php`**
+
+Delete this line:
+```php
+require_once WP_AI_MIND_DIR . 'includes/Core/ProGate.php';
+```
+
+- [ ] **Step 3.3: Delete `includes/Core/ProGate.php`**
+
+```bash
+rm includes/Core/ProGate.php
+```
+
+- [ ] **Step 3.4: Delete `tests/Unit/Core/ProGateTest.php`**
+
+```bash
+rm tests/Unit/Core/ProGateTest.php
+```
+
+- [ ] **Step 3.5: Verify no remaining references**
+
+```bash
+grep -r "wp_ai_mind_is_pro\|ProGate\|wam_fs\|freemius" . \
+  --include="*.php" --exclude-dir=vendor --exclude-dir=.worktrees
+# Expected: NO output (zero matches)
+```
+
+- [ ] **Step 3.6: Run full test suite**
+
+```bash
+./vendor/bin/phpunit tests/Unit/ --colors=always
+# Expected: All tests PASS (ProGateTest is deleted, remaining 130+ tests pass)
+```
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(cleanup): remove ProGate class and replace all call sites with nj_feature()"
+```
+
+---
+
+## Task 4: Remove UsageLogger + Drop DB Table
+
+**Files:** Delete `includes/DB/UsageLogger.php`, modify `includes/DB/Schema.php`, `includes/Core/Plugin.php`
+
+- [ ] **Step 4.1: Delete `includes/DB/UsageLogger.php`**
+
+```bash
+rm includes/DB/UsageLogger.php
+```
+
+- [ ] **Step 4.2: Update `includes/DB/Schema.php` — remove table creation, add migration**
+
+Remove the entire `$usage_log` dbDelta block from the `create_tables()` method. Then add:
+
+```php
+/**
+ * Runs on plugin update. Drops legacy tables that have been superseded.
+ * Uses a version flag in wp_options to run each migration only once.
+ */
+public static function maybe_migrate(): void {
+    $current = (int) get_option( 'wpaim_db_version', 1 );
+
+    if ( $current < 2 ) {
+        global $wpdb;
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange
+        $wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'wpaim_usage_log' );
+        update_option( 'wpaim_db_version', 2 );
+    }
+}
+```
+
+- [ ] **Step 4.3: Call `maybe_migrate()` from `includes/Core/Plugin.php`**
+
+In `Plugin::activate()`, add:
+```php
+\WP_AI_Mind\DB\Schema::maybe_migrate();
+```
+
+Also add a `plugins_loaded` hook in the Plugin constructor for running on updates:
+```php
+add_action( 'plugins_loaded', [ 'WP_AI_Mind\DB\Schema', 'maybe_migrate' ] );
+```
+
+- [ ] **Step 4.4: Run full test suite**
+
+```bash
+./vendor/bin/phpunit tests/Unit/ --colors=always
+# Expected: All remaining tests PASS
+```
+
+- [ ] **Step 4.5: Run phpcs**
+
+```bash
+./vendor/bin/phpcs --standard=phpcs.xml.dist
+# Expected: 0 errors, 0 warnings (or only known pre-existing warnings)
+```
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add includes/DB/UsageLogger.php includes/DB/Schema.php includes/Core/Plugin.php
+git commit -m "feat(cleanup): remove UsageLogger, drop wpaim_usage_log table via migration"
+```
+
+---
+
+## Task 5: Final Verification
+
+- [ ] **Step 5.1: Verify complete cleanup**
+
+```bash
+# All of these must return ZERO matches:
+grep -r "wp_ai_mind_is_pro" . --include="*.php" --exclude-dir=vendor --exclude-dir=.worktrees
+grep -r "ProGate" .           --include="*.php" --exclude-dir=vendor --exclude-dir=.worktrees
+grep -r "UsageLogger" .       --include="*.php" --exclude-dir=vendor --exclude-dir=.worktrees
+grep -r "wam_fs" .            --include="*.php" --exclude-dir=vendor --exclude-dir=.worktrees
+grep -r "freemius" .          --include="*.php" --exclude-dir=vendor --exclude-dir=.worktrees
+
+# All expected to output: (no results)
+```
+
+- [ ] **Step 5.2: Verify DB migration works on local**
+
+```bash
+# Connect to local DB and verify table does not exist after migration:
+docker exec blognjohanssoneu-db-1 mysql -uwp_user -pwp_pass wordpress \
+  -e "SHOW TABLES LIKE 'wpaim_usage_log';"
+# Expected: Empty result set
+```
+
+- [ ] **Step 5.3: Run npm build to verify JS still compiles**
+
+```bash
+npm run build
+# Expected: No errors; assets/ directory updated
+```
+
+- [ ] **Step 5.4: Commit final state**
+
+```bash
+git add -A
+git commit -m "chore(cleanup): Phase 5 complete — Freemius, ProGate, UsageLogger fully removed"
+```
+
+---
+
+## Phase 5 Acceptance Criteria
+
+- [ ] `vendor/freemius/` directory does not exist
+- [ ] `includes/Core/ProGate.php` does not exist
+- [ ] `includes/DB/UsageLogger.php` does not exist
+- [ ] `grep -r "wp_ai_mind_is_pro" . --include="*.php" --exclude-dir=vendor` → zero matches
+- [ ] `grep -r "wam_fs" . --include="*.php" --exclude-dir=vendor` → zero matches
+- [ ] `wpaim_usage_log` table absent on fresh install and dropped via `maybe_migrate()` on update
+- [ ] All REST permission callbacks use `nj_feature()` checks
+- [ ] `./vendor/bin/phpunit tests/Unit/ --colors=always` → all pass
+- [ ] `./vendor/bin/phpcs --standard=phpcs.xml.dist` → no errors
+- [ ] `npm run build` → no errors
+
+---
+
+## Phase 5 Risk Notes
+
+- **Existing Pro users lose access immediately on deploy.** Plan a migration period (minimum 2 weeks with the admin notice from Task 1 visible). Consider sending an email to all Freemius customers with a link to create an NJ account.
+- **`composer update` after removing Freemius may change other transitive dependencies.** Run `composer install --no-dev` in CI to catch unexpected changes before merging.
+- **`phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange`** is required on the DROP TABLE statement. This is intentional and safe — the comment is the documented exception.

--- a/docs/superpowers/plans/phases/phase-6-react-auth-ui.md
+++ b/docs/superpowers/plans/phases/phase-6-react-auth-ui.md
@@ -12,6 +12,35 @@
 
 ---
 
+## Task 0: Pre-implementation Reuse Audit
+
+> **Mandatory.** Complete before writing any new React components.
+
+- [ ] **Step 0.1: Audit existing React components**
+
+```bash
+find src/admin/ -name "*.jsx" -o -name "*.js" | sort
+# Review existing components before creating new ones.
+# Reuse existing UI patterns (modals, buttons, forms) rather than creating bespoke versions.
+```
+
+- [ ] **Step 0.2: Audit existing `@wordpress/components` usage**
+
+```bash
+grep -rn "@wordpress/components\|@wordpress/element" src/ --include="*.jsx" --include="*.js" | head -20
+# Use the same WP component imports already used in the project. Do not introduce new UI libraries.
+```
+
+- [ ] **Step 0.3: Understand localized data shape**
+
+Review what `window.wpAiMindData` contains after Phase 2/5 (especially `entitlement.features` and `entitlement.allowed_models`). All UI decisions must read from this object — never hardcode plan names or feature checks in JSX.
+
+- [ ] **Step 0.4: Plan component responsibilities (SRP)**
+
+Before writing code, write a one-line responsibility statement for each new component. If a component has more than one responsibility, split it.
+
+---
+
 ## Design Decisions
 
 | Decision | Choice | Reason |
@@ -30,20 +59,23 @@
 ## File Map
 
 **New files:**
-- `src/admin/auth/AuthContext.jsx`
-- `src/admin/auth/AuthApp.jsx`
-- `src/admin/auth/LoginForm.jsx`
-- `src/admin/auth/SignupForm.jsx`
-- `src/admin/shared/UsageMeter.jsx`
-- `src/admin/shared/UpgradeModal.jsx`
-- `src/admin/shared/UsageWarning.jsx`
-- `src/admin/shared/constants.js`
+- `src/admin/auth/AuthContext.jsx` — auth state + entitlement context (SRP: state management only)
+- `src/admin/auth/AuthApp.jsx` — auth gate (SRP: renders auth forms OR children)
+- `src/admin/auth/LoginForm.jsx` — login form (SRP: login flow only)
+- `src/admin/auth/SignupForm.jsx` — signup form (SRP: signup flow only)
+- `src/admin/shared/UsageMeter.jsx` — token usage bar (hidden for `plan === 'pro'` or `plan === 'none'`)
+- `src/admin/shared/UpgradeModal.jsx` — upgrade CTA modal (SRP: shown on 429 only)
+- `src/admin/shared/UsageWarning.jsx` — inline warning near limit
+- `src/admin/shared/ModelSelector.jsx` — model dropdown (shown when `entitlement.features.model_selection === true`)
+- `src/admin/shared/constants.js` — URLs only (no logic)
 
 **Modified files:**
 - `src/admin/index.js` — wrap all React roots in `AuthProvider`; show `AuthApp` when unauthenticated
-- `src/admin/settings/ProvidersTab.jsx` — conditional API key section (Pro only; non-Pro sees upgrade CTA)
-- `src/admin/components/Chat/ChatApp.jsx` — 429 error → show `UpgradeModal`
+- `src/admin/settings/ProvidersTab.jsx` — conditional API key section (Pro BYOK only, gated by `entitlement.features.own_key`)
+- `src/admin/components/Chat/ChatApp.jsx` — 429 error → show `UpgradeModal`; show `ModelSelector` when `model_selection` feature enabled
 - `src/admin/dashboard/DashboardApp.jsx` — show `UsageMeter` + `UsageWarning`
+
+**IMPORTANT:** All feature decisions in JSX must read from `entitlement.features.*` or `entitlement.allowed_models`. Never write `plan === 'pro_managed'` or `plan === 'pro'` in component code — use the feature flag instead. This makes tier changes a config-only update.
 
 ---
 
@@ -1268,6 +1300,135 @@ git commit -m "feat(dashboard): add UsageMeter and UsageWarning to dashboard"
 
 ---
 
+## Task 9b: ModelSelector Component
+
+**Files:** Create `src/admin/shared/ModelSelector.jsx`, modify `src/admin/components/Chat/ChatApp.jsx`
+
+**Responsibility (SRP):** `ModelSelector` renders a model dropdown from the `entitlement.allowed_models` list and calls `onChange` with the selected value. It has no knowledge of chat requests or API calls.
+
+- [ ] **Step 9b.1: Create `src/admin/shared/ModelSelector.jsx`**
+
+```jsx
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * ModelSelector — renders a model dropdown for tiers with model_selection enabled.
+ * Hidden automatically when the feature is not available; callers do not need to guard.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.entitlement - Full entitlement object from AuthContext
+ * @param {string}   props.selected    - Currently selected model ID
+ * @param {Function} props.onChange    - Called with the new model ID string
+ */
+export function ModelSelector( { entitlement, selected, onChange } ) {
+    const canSelect    = entitlement?.features?.model_selection === true;
+    const allowedModels = entitlement?.allowed_models ?? [];
+
+    if ( ! canSelect || allowedModels.length <= 1 ) {
+        return null; // Nothing to select — hide component entirely
+    }
+
+    const options = allowedModels.map( ( modelId ) => ( {
+        label: modelId,  // Replace with human-readable names in a future iteration
+        value: modelId,
+    } ) );
+
+    return (
+        <SelectControl
+            label={ __( 'Model', 'wp-ai-mind' ) }
+            value={ selected || allowedModels[ 0 ] }
+            options={ options }
+            onChange={ onChange }
+            __nextHasNoMarginBottom
+        />
+    );
+}
+```
+
+- [ ] **Step 9b.2: Wire `ModelSelector` into `ChatApp.jsx`**
+
+In `src/admin/components/Chat/ChatApp.jsx`:
+
+1. Import `ModelSelector`: `import { ModelSelector } from '../shared/ModelSelector';`
+2. Import `useAuth`: `import { useAuth } from '../auth/AuthContext';`
+3. Add state: `const [ selectedModel, setSelectedModel ] = useState( '' );`
+4. Add `useAuth`: `const { entitlement } = useAuth();`
+5. Render `ModelSelector` in the chat header/toolbar area:
+
+```jsx
+<ModelSelector
+    entitlement={ entitlement }
+    selected={ selectedModel }
+    onChange={ setSelectedModel }
+/>
+```
+
+6. Pass `selectedModel` (when non-empty) to the chat request body via `apiFetch`:
+
+```js
+const body = {
+    message: content,
+    ...(selectedModel ? { model: selectedModel } : {}),
+};
+```
+
+- [ ] **Step 9b.3: Build and verify**
+
+```bash
+npm run build
+# Expected: no build errors
+```
+
+Manual verification:
+1. Log in as `pro_managed` account → `ModelSelector` appears in chat header with multiple options
+2. Log in as `free` or `trial` account → `ModelSelector` is absent (hidden, not just disabled)
+3. Log in as `pro` (BYOK) account → `ModelSelector` is absent (BYOK user selects model via API key settings, not here)
+4. Select Sonnet as `pro_managed`, send message → network request includes `"model":"claude-sonnet-4-5"`
+
+- [ ] **Step 9b.4: Commit**
+
+```bash
+git add src/admin/shared/ModelSelector.jsx src/admin/components/Chat/ChatApp.jsx
+git commit -m "feat(ui): add ModelSelector component for pro_managed tier"
+```
+
+---
+
+## Task 9c: Post-implementation Code Reuse Verification
+
+> **Mandatory.** Run before marking Phase 6 complete.
+
+- [ ] **Step 9c.1: No hardcoded plan names in JSX**
+
+```bash
+grep -rn "pro_managed\|plan === 'pro'\|plan === 'free'\|plan === 'trial'" src/admin/ --include="*.jsx" --include="*.js"
+# Expected: 0 matches — all feature decisions must use entitlement.features.* flags
+```
+
+- [ ] **Step 9c.2: No duplicate WP component imports**
+
+```bash
+grep -rn "import.*@wordpress/components" src/admin/ --include="*.jsx" --include="*.js" | sort | uniq -d
+# Expected: each component is imported from one place only
+```
+
+- [ ] **Step 9c.3: ModelSelector does not contain chat request logic**
+
+```bash
+grep -n "apiFetch\|wp_remote\|fetch\|POST" src/admin/shared/ModelSelector.jsx
+# Expected: 0 matches — ModelSelector is UI-only (SRP)
+```
+
+- [ ] **Step 9c.4: Build passes**
+
+```bash
+npm run build
+# Expected: exits 0, no errors
+```
+
+---
+
 ## Task 10: Manual integration verification
 
 No unit tests are written for React components in this plugin. Verify the full flow manually in the browser after `npm run build`.
@@ -1298,13 +1459,22 @@ docker restart blognjohanssoneu-wordpress-1
 2. Expected: on successful POST to `/wp-ai-mind/v1/nj/login`, the auth card disappears and the full UI renders.
 3. Reload the page — expected: stays authenticated (PHP still serves `isAuthenticated: true` in localised data).
 
-- [ ] **Step 10.5: ProvidersTab — free-tier vs Pro**
+- [ ] **Step 10.5: ProvidersTab — free-tier vs Pro BYOK vs Pro Managed**
 
-1. Log in as a **free-tier** account.
-2. Navigate to Settings → Providers tab.
-3. Expected: "API Keys" section shows the upgrade CTA paragraph and "Upgrade to Pro" link — no TextControl inputs visible.
-4. Log in as a **Pro** account.
-5. Expected: "API Keys" section shows the three TextControl fields for Claude, OpenAI, Gemini.
+1. Log in as a **free-tier** account. Navigate to Settings → Providers tab.
+   Expected: "API Keys" section shows the upgrade CTA — no TextControl inputs visible.
+2. Log in as a **pro_managed** account. Navigate to Settings → Providers tab.
+   Expected: "API Keys" section shows the upgrade CTA for BYOK — no TextControl inputs visible.
+3. Log in as a **Pro BYOK** account. Navigate to Settings → Providers tab.
+   Expected: "API Keys" section shows the three TextControl fields for Claude, OpenAI, Gemini.
+
+- [ ] **Step 10.5b: ModelSelector — pro_managed vs free/trial**
+
+1. Log in as a **pro_managed** account. Navigate to Chat.
+   Expected: `ModelSelector` dropdown visible with multiple model options.
+2. Select Sonnet, send a message — inspect network request body: must include `"model":"claude-sonnet-4-5"`.
+3. Log in as **free** or **trial**. Navigate to Chat.
+   Expected: No model selector visible; Haiku used by default.
 
 - [ ] **Step 10.6: UpgradeModal — simulate 429**
 

--- a/docs/superpowers/plans/phases/phase-6-react-auth-ui.md
+++ b/docs/superpowers/plans/phases/phase-6-react-auth-ui.md
@@ -1,0 +1,1354 @@
+# Phase 6: React — Auth UI + Usage Components
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add login/signup screen when unauthenticated; add UsageMeter to all pages; show UpgradeModal on 429; conditionally hide API key inputs for non-Pro users.
+
+**Architecture:** WordPress plugin's React admin apps are wrapped in an AuthProvider. On load, `window.wpAiMindData.isAuthenticated` determines whether to show the AI interface or the auth forms. Entitlement data flows via React context to all components.
+
+**Tech Stack:** React (@wordpress/element), @wordpress/api-fetch, @wordpress/i18n, existing JSX component structure.
+
+**Depends on:** Phase 2 (REST auth endpoints live) + Phase 5 (entitlement in localized scripts).
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Auth gate location | `src/admin/index.js` wrapping each root | Single mount point — no duplication across apps |
+| `GatedApp` placement | Inside `AuthProvider` | Must call `useAuth()` which requires context to be present |
+| `AuthProvider` initial state | Read from `window.wpAiMindData` at mount | Avoids an extra REST round-trip on page load; PHP already localises auth state in Phase 5 |
+| `refreshEntitlement()` | GET `/wp-ai-mind/v1/nj/me` | Allows React to re-hydrate entitlement after a login or upgrade without a full page reload |
+| Shared constants | `src/admin/shared/constants.js` | One place to update URLs before launch; prevents magic strings scattered across components |
+| UsageMeter visibility | Hidden when `plan === 'pro'` or `plan === 'none'` | Pro users have no limit; unregistered users have no account to show meters for |
+| UpgradeModal trigger | `err?.status === 429 \|\| err?.data?.code === 'token_limit_exceeded'` | Worker returns 429 with that code; catch it uniformly in all AI feature components |
+| Pro API key section | Gated by `entitlement?.features?.own_key` | Feature flag from Phase 2/5 entitlement payload; consistent with PHP gating |
+
+---
+
+## File Map
+
+**New files:**
+- `src/admin/auth/AuthContext.jsx`
+- `src/admin/auth/AuthApp.jsx`
+- `src/admin/auth/LoginForm.jsx`
+- `src/admin/auth/SignupForm.jsx`
+- `src/admin/shared/UsageMeter.jsx`
+- `src/admin/shared/UpgradeModal.jsx`
+- `src/admin/shared/UsageWarning.jsx`
+- `src/admin/shared/constants.js`
+
+**Modified files:**
+- `src/admin/index.js` — wrap all React roots in `AuthProvider`; show `AuthApp` when unauthenticated
+- `src/admin/settings/ProvidersTab.jsx` — conditional API key section (Pro only; non-Pro sees upgrade CTA)
+- `src/admin/components/Chat/ChatApp.jsx` — 429 error → show `UpgradeModal`
+- `src/admin/dashboard/DashboardApp.jsx` — show `UsageMeter` + `UsageWarning`
+
+---
+
+## Task 1: constants.js + AuthContext scaffold
+
+**Files:** `src/admin/shared/constants.js`, `src/admin/auth/AuthContext.jsx`
+
+- [ ] **Step 1.1: Create `src/admin/shared/constants.js`**
+
+```js
+// TODO: Replace placeholder URLs with real values before launch.
+
+/**
+ * LemonSqueezy checkout URL for WP AI Mind Pro.
+ * Replace with the real product checkout URL before launch.
+ */
+export const LEMONSQUEEZY_CHECKOUT_URL = 'https://checkout.lemonsqueezy.com/buy/REPLACE_WITH_REAL_VARIANT_ID';
+
+/**
+ * NJ account dashboard URL.
+ * Replace with the real account portal URL before launch.
+ */
+export const ACCOUNT_DASHBOARD_URL = 'https://account.njohansson.eu/REPLACE_WITH_REAL_PATH';
+```
+
+- [ ] **Step 1.2: Create `src/admin/auth/AuthContext.jsx`**
+
+```jsx
+import { createContext, useContext, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * AuthContext — provides authentication state and entitlement data to all
+ * child components. Initial values are hydrated from `window.wpAiMindData`
+ * which is localised by PHP in Phase 5.
+ */
+const AuthContext = createContext( null );
+
+/**
+ * AuthProvider wraps all admin roots so that any component can call useAuth().
+ *
+ * @param {Object} props
+ * @param {import('@wordpress/element').ReactNode} props.children
+ */
+export function AuthProvider( { children } ) {
+    const seed = window.wpAiMindData ?? {};
+
+    const [ isAuthenticated, setIsAuthenticated ] = useState(
+        Boolean( seed.isAuthenticated )
+    );
+    const [ user, setUser ] = useState( seed.user ?? null );
+    const [ entitlement, setEntitlement ] = useState( seed.entitlement ?? null );
+    const [ authError, setAuthError ] = useState( null );
+
+    /**
+     * Log in with email and password.
+     * On success the context is updated with the user + entitlement returned
+     * by the REST endpoint.
+     *
+     * @param {string} email
+     * @param {string} password
+     */
+    async function login( email, password ) {
+        setAuthError( null );
+        const data = await apiFetch( {
+            path: '/wp-ai-mind/v1/nj/login',
+            method: 'POST',
+            data: { email, password },
+        } );
+        setUser( data.user ?? null );
+        setEntitlement( data.entitlement ?? null );
+        setIsAuthenticated( true );
+    }
+
+    /**
+     * Register a new account. The REST endpoint auto-logs the user in and
+     * returns the same shape as /login.
+     *
+     * @param {string} email
+     * @param {string} password
+     */
+    async function register( email, password ) {
+        setAuthError( null );
+        const data = await apiFetch( {
+            path: '/wp-ai-mind/v1/nj/register',
+            method: 'POST',
+            data: { email, password },
+        } );
+        setUser( data.user ?? null );
+        setEntitlement( data.entitlement ?? null );
+        setIsAuthenticated( true );
+    }
+
+    /**
+     * Log out the current user. Clears all auth state.
+     */
+    async function logout() {
+        setAuthError( null );
+        try {
+            await apiFetch( {
+                path: '/wp-ai-mind/v1/nj/logout',
+                method: 'POST',
+            } );
+        } finally {
+            // Always clear local state even if the server call fails.
+            setIsAuthenticated( false );
+            setUser( null );
+            setEntitlement( null );
+        }
+    }
+
+    /**
+     * Re-fetch entitlement from the server. Call this after a plan upgrade
+     * to get updated feature flags without a page reload.
+     */
+    async function refreshEntitlement() {
+        const data = await apiFetch( {
+            path: '/wp-ai-mind/v1/nj/me',
+        } );
+        setEntitlement( data.entitlement ?? null );
+        if ( data.user ) {
+            setUser( data.user );
+        }
+    }
+
+    return (
+        <AuthContext.Provider
+            value={ {
+                isAuthenticated,
+                user,
+                entitlement,
+                authError,
+                setAuthError,
+                login,
+                register,
+                logout,
+                refreshEntitlement,
+            } }
+        >
+            { children }
+        </AuthContext.Provider>
+    );
+}
+
+/**
+ * Hook to access the auth context from any component inside AuthProvider.
+ *
+ * @returns {{
+ *   isAuthenticated: boolean,
+ *   user: Object|null,
+ *   entitlement: Object|null,
+ *   authError: string|null,
+ *   setAuthError: Function,
+ *   login: Function,
+ *   register: Function,
+ *   logout: Function,
+ *   refreshEntitlement: Function,
+ * }}
+ */
+export function useAuth() {
+    const ctx = useContext( AuthContext );
+    if ( ! ctx ) {
+        throw new Error( 'useAuth must be used inside <AuthProvider>' );
+    }
+    return ctx;
+}
+```
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add src/admin/shared/constants.js src/admin/auth/AuthContext.jsx
+git commit -m "feat(auth): add AuthContext and shared constants scaffold"
+```
+
+---
+
+## Task 2: LoginForm + SignupForm components
+
+**Files:** `src/admin/auth/LoginForm.jsx`, `src/admin/auth/SignupForm.jsx`
+
+- [ ] **Step 2.1: Create `src/admin/auth/LoginForm.jsx`**
+
+```jsx
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useAuth } from './AuthContext';
+import { ACCOUNT_DASHBOARD_URL } from '../shared/constants';
+
+/**
+ * LoginForm — email + password form that calls auth.login().
+ *
+ * @param {Object}   props
+ * @param {Function} props.onSwitch - Callback to switch to the signup tab.
+ */
+export default function LoginForm( { onSwitch } ) {
+    const auth = useAuth();
+
+    const [ email, setEmail ] = useState( '' );
+    const [ password, setPassword ] = useState( '' );
+    const [ error, setError ] = useState( '' );
+    const [ isLoading, setIsLoading ] = useState( false );
+
+    async function handleSubmit( e ) {
+        e.preventDefault();
+        setError( '' );
+        setIsLoading( true );
+        try {
+            await auth.login( email, password );
+            // AuthContext sets isAuthenticated — GatedApp transitions automatically.
+        } catch ( err ) {
+            setError(
+                err?.message ?? __( 'Login failed. Please try again.', 'wp-ai-mind' )
+            );
+        } finally {
+            setIsLoading( false );
+        }
+    }
+
+    return (
+        <form
+            className="wpaim-auth-form"
+            onSubmit={ handleSubmit }
+            noValidate
+        >
+            <h2 className="wpaim-auth-form__heading">
+                { __( 'Log in to your account', 'wp-ai-mind' ) }
+            </h2>
+
+            { error && (
+                <p className="wpaim-auth-form__error" role="alert">
+                    { error }
+                </p>
+            ) }
+
+            <label className="wpaim-auth-form__label">
+                { __( 'Email address', 'wp-ai-mind' ) }
+                <input
+                    className="wpaim-auth-form__input"
+                    type="email"
+                    value={ email }
+                    onChange={ ( e ) => setEmail( e.target.value ) }
+                    required
+                    autoComplete="email"
+                    disabled={ isLoading }
+                />
+            </label>
+
+            <label className="wpaim-auth-form__label">
+                { __( 'Password', 'wp-ai-mind' ) }
+                <input
+                    className="wpaim-auth-form__input"
+                    type="password"
+                    value={ password }
+                    onChange={ ( e ) => setPassword( e.target.value ) }
+                    required
+                    autoComplete="current-password"
+                    disabled={ isLoading }
+                />
+            </label>
+
+            <p className="wpaim-auth-form__hint">
+                { __( 'Forgot your password? Reset it at', 'wp-ai-mind' ) }{ ' ' }
+                <a
+                    href={ ACCOUNT_DASHBOARD_URL }
+                    target="_blank"
+                    rel="noreferrer"
+                    className="wpaim-auth-form__link"
+                >
+                    { __( 'your account dashboard', 'wp-ai-mind' ) }
+                </a>
+                .
+            </p>
+
+            <button
+                type="submit"
+                className="wpaim-btn wpaim-btn--primary wpaim-btn--full"
+                disabled={ isLoading }
+            >
+                { isLoading
+                    ? __( 'Logging in…', 'wp-ai-mind' )
+                    : __( 'Log in', 'wp-ai-mind' ) }
+            </button>
+
+            <p className="wpaim-auth-form__switch">
+                { __( 'No account?', 'wp-ai-mind' ) }{ ' ' }
+                <button
+                    type="button"
+                    className="wpaim-auth-form__switch-btn"
+                    onClick={ onSwitch }
+                >
+                    { __( 'Sign up →', 'wp-ai-mind' ) }
+                </button>
+            </p>
+        </form>
+    );
+}
+```
+
+- [ ] **Step 2.2: Create `src/admin/auth/SignupForm.jsx`**
+
+```jsx
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useAuth } from './AuthContext';
+
+/**
+ * SignupForm — email + password + confirm form that calls auth.register().
+ * Client-side validation runs before the REST call.
+ *
+ * @param {Object}   props
+ * @param {Function} props.onSwitch - Callback to switch to the login tab.
+ */
+export default function SignupForm( { onSwitch } ) {
+    const auth = useAuth();
+
+    const [ email, setEmail ] = useState( '' );
+    const [ password, setPassword ] = useState( '' );
+    const [ confirmPassword, setConfirmPassword ] = useState( '' );
+    const [ error, setError ] = useState( '' );
+    const [ isLoading, setIsLoading ] = useState( false );
+
+    function validate() {
+        if ( password.length < 8 ) {
+            return __( 'Password must be at least 8 characters.', 'wp-ai-mind' );
+        }
+        if ( password !== confirmPassword ) {
+            return __( 'Passwords do not match.', 'wp-ai-mind' );
+        }
+        return null;
+    }
+
+    async function handleSubmit( e ) {
+        e.preventDefault();
+        setError( '' );
+
+        const validationError = validate();
+        if ( validationError ) {
+            setError( validationError );
+            return;
+        }
+
+        setIsLoading( true );
+        try {
+            await auth.register( email, password );
+            // AuthContext sets isAuthenticated — GatedApp transitions automatically.
+        } catch ( err ) {
+            setError(
+                err?.message ?? __( 'Registration failed. Please try again.', 'wp-ai-mind' )
+            );
+        } finally {
+            setIsLoading( false );
+        }
+    }
+
+    return (
+        <form
+            className="wpaim-auth-form"
+            onSubmit={ handleSubmit }
+            noValidate
+        >
+            <h2 className="wpaim-auth-form__heading">
+                { __( 'Create a free account', 'wp-ai-mind' ) }
+            </h2>
+
+            { error && (
+                <p className="wpaim-auth-form__error" role="alert">
+                    { error }
+                </p>
+            ) }
+
+            <label className="wpaim-auth-form__label">
+                { __( 'Email address', 'wp-ai-mind' ) }
+                <input
+                    className="wpaim-auth-form__input"
+                    type="email"
+                    value={ email }
+                    onChange={ ( e ) => setEmail( e.target.value ) }
+                    required
+                    autoComplete="email"
+                    disabled={ isLoading }
+                />
+            </label>
+
+            <label className="wpaim-auth-form__label">
+                { __( 'Password', 'wp-ai-mind' ) }
+                <input
+                    className="wpaim-auth-form__input"
+                    type="password"
+                    value={ password }
+                    onChange={ ( e ) => setPassword( e.target.value ) }
+                    required
+                    autoComplete="new-password"
+                    disabled={ isLoading }
+                    minLength={ 8 }
+                />
+            </label>
+
+            <label className="wpaim-auth-form__label">
+                { __( 'Confirm password', 'wp-ai-mind' ) }
+                <input
+                    className="wpaim-auth-form__input"
+                    type="password"
+                    value={ confirmPassword }
+                    onChange={ ( e ) => setConfirmPassword( e.target.value ) }
+                    required
+                    autoComplete="new-password"
+                    disabled={ isLoading }
+                />
+            </label>
+
+            <button
+                type="submit"
+                className="wpaim-btn wpaim-btn--primary wpaim-btn--full"
+                disabled={ isLoading }
+            >
+                { isLoading
+                    ? __( 'Creating account…', 'wp-ai-mind' )
+                    : __( 'Create account', 'wp-ai-mind' ) }
+            </button>
+
+            <p className="wpaim-auth-form__switch">
+                { __( 'Already have an account?', 'wp-ai-mind' ) }{ ' ' }
+                <button
+                    type="button"
+                    className="wpaim-auth-form__switch-btn"
+                    onClick={ onSwitch }
+                >
+                    { __( 'Log in →', 'wp-ai-mind' ) }
+                </button>
+            </p>
+        </form>
+    );
+}
+```
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add src/admin/auth/LoginForm.jsx src/admin/auth/SignupForm.jsx
+git commit -m "feat(auth): add LoginForm and SignupForm components"
+```
+
+---
+
+## Task 3: AuthApp tab switcher
+
+**File:** `src/admin/auth/AuthApp.jsx`
+
+- [ ] **Step 3.1: Create `src/admin/auth/AuthApp.jsx`**
+
+```jsx
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import LoginForm from './LoginForm';
+import SignupForm from './SignupForm';
+
+/**
+ * AuthApp — centered card shown to unauthenticated users.
+ * Renders either LoginForm or SignupForm based on activeTab state.
+ * Uses only BEM class names — no external CSS framework required.
+ */
+export default function AuthApp() {
+    const [ activeTab, setActiveTab ] = useState( 'login' );
+
+    return (
+        <div className="wpaim-auth-overlay">
+            <div className="wpaim-auth-card">
+                <div className="wpaim-auth-card__brand">
+                    <span className="wpaim-auth-card__logo" aria-hidden="true">
+                        ✦
+                    </span>
+                    <h1 className="wpaim-auth-card__title">
+                        { __( 'WP AI Mind', 'wp-ai-mind' ) }
+                    </h1>
+                    <p className="wpaim-auth-card__tagline">
+                        { __( 'AI-powered content creation for WordPress', 'wp-ai-mind' ) }
+                    </p>
+                </div>
+
+                <div className="wpaim-auth-card__body">
+                    { activeTab === 'login' ? (
+                        <LoginForm
+                            onSwitch={ () => setActiveTab( 'signup' ) }
+                        />
+                    ) : (
+                        <SignupForm
+                            onSwitch={ () => setActiveTab( 'login' ) }
+                        />
+                    ) }
+                </div>
+            </div>
+        </div>
+    );
+}
+```
+
+- [ ] **Step 3.2: Commit**
+
+```bash
+git add src/admin/auth/AuthApp.jsx
+git commit -m "feat(auth): add AuthApp tab switcher card"
+```
+
+---
+
+## Task 4: src/admin/index.js — auth gate
+
+**File:** `src/admin/index.js`
+
+The existing pattern renders each app directly. Replace the whole file with the gated pattern below.
+
+- [ ] **Step 4.1: Rewrite `src/admin/index.js`**
+
+```jsx
+import { render } from '@wordpress/element';
+import { AuthProvider, useAuth } from './auth/AuthContext';
+import AuthApp from './auth/AuthApp';
+import ChatApp from './components/Chat/ChatApp';
+import SettingsApp from './settings/SettingsApp';
+import DashboardApp from './dashboard/DashboardApp';
+import '../styles/tokens.css';
+import './admin.css';
+
+/**
+ * GatedApp renders either the auth card or the real app depending on whether
+ * the user is authenticated. It MUST be rendered inside <AuthProvider> so
+ * that useAuth() has a context to read from.
+ *
+ * @param {Object}                                props
+ * @param {import('@wordpress/element').FC} props.App - The real app component.
+ */
+function GatedApp( { App } ) {
+    const { isAuthenticated } = useAuth();
+    if ( ! isAuthenticated ) {
+        return <AuthApp />;
+    }
+    return <App />;
+}
+
+/**
+ * Mount a React root with AuthProvider + GatedApp wrapping.
+ *
+ * @param {string}                                rootId - DOM element ID.
+ * @param {import('@wordpress/element').FC} App    - Component to render when authenticated.
+ */
+function mount( rootId, App ) {
+    const el = document.getElementById( rootId );
+    if ( ! el ) {
+        return;
+    }
+    render(
+        <AuthProvider>
+            <GatedApp App={ App } />
+        </AuthProvider>,
+        el
+    );
+}
+
+mount( 'wp-ai-mind-chat', ChatApp );
+mount( 'wp-ai-mind-settings', SettingsApp );
+mount( 'wp-ai-mind-dashboard', DashboardApp );
+```
+
+**Important:** `GatedApp` calls `useAuth()` which requires `AuthProvider` to be an ancestor. The structure `<AuthProvider><GatedApp /></AuthProvider>` satisfies this. Do not hoist `GatedApp` outside of the `mount()` call.
+
+- [ ] **Step 4.2: Verify the build compiles cleanly**
+
+```bash
+npm run build
+# Expected: no errors; compiled assets/ updated
+```
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add src/admin/index.js
+git commit -m "feat(auth): gate all React roots behind AuthProvider"
+```
+
+---
+
+## Task 5: UsageMeter component
+
+**File:** `src/admin/shared/UsageMeter.jsx`
+
+- [ ] **Step 5.1: Create `src/admin/shared/UsageMeter.jsx`**
+
+```jsx
+import { __ } from '@wordpress/i18n';
+import { useAuth } from '../auth/AuthContext';
+import { LEMONSQUEEZY_CHECKOUT_URL } from './constants';
+
+/**
+ * Format a raw token count as a human-readable string.
+ * Counts >= 1000 are shown as e.g. "50k".
+ *
+ * @param {number} n
+ * @returns {string}
+ */
+function formatNumber( n ) {
+    if ( n >= 1000 ) {
+        return Math.round( n / 1000 ) + 'k';
+    }
+    return String( n );
+}
+
+/**
+ * UsageMeter — shows a coloured progress bar with token usage.
+ *
+ * Hidden when:
+ * - plan === 'pro'       (unlimited; no meter needed)
+ * - plan === 'none'      (no account; nothing to show)
+ * - tokens_limit is null (plan doesn't have a hard cap)
+ *
+ * At 80%+ usage: adds CSS modifier class `wpaim-usage-meter--warn` (yellow).
+ * At 100%:       adds `wpaim-usage-meter--hit` (red) + shows "Limit reached" copy.
+ *
+ * @returns {import('@wordpress/element').ReactNode|null}
+ */
+export default function UsageMeter() {
+    const { entitlement } = useAuth();
+
+    if ( ! entitlement ) {
+        return null;
+    }
+
+    const {
+        plan,
+        tokens_used = 0,
+        tokens_limit = null,
+        resets_at = null,
+    } = entitlement;
+
+    // Hidden conditions.
+    if ( plan === 'pro' || plan === 'none' || tokens_limit === null ) {
+        return null;
+    }
+
+    const pct = Math.min( ( tokens_used / tokens_limit ) * 100, 100 );
+    const isWarn = pct >= 80 && pct < 100;
+    const isHit = pct >= 100;
+
+    const meterClass = [
+        'wpaim-usage-meter',
+        isWarn ? 'wpaim-usage-meter--warn' : '',
+        isHit ? 'wpaim-usage-meter--hit' : '',
+    ]
+        .filter( Boolean )
+        .join( ' ' );
+
+    const resetsDate = resets_at
+        ? new Date( resets_at ).toLocaleDateString( undefined, {
+              month: 'short',
+              day: 'numeric',
+          } )
+        : null;
+
+    return (
+        <div className={ meterClass } role="status" aria-label={ __( 'Token usage', 'wp-ai-mind' ) }>
+            <div className="wpaim-usage-meter__bar-track">
+                <div
+                    className="wpaim-usage-meter__bar-fill"
+                    style={ { width: `${ pct }%` } }
+                    aria-valuenow={ Math.round( pct ) }
+                    aria-valuemin={ 0 }
+                    aria-valuemax={ 100 }
+                    role="progressbar"
+                />
+            </div>
+
+            <div className="wpaim-usage-meter__labels">
+                { isHit ? (
+                    <span className="wpaim-usage-meter__count wpaim-usage-meter__count--hit">
+                        { __( 'Limit reached', 'wp-ai-mind' ) }
+                    </span>
+                ) : (
+                    <span className="wpaim-usage-meter__count">
+                        { formatNumber( tokens_used ) }
+                        { ' / ' }
+                        { formatNumber( tokens_limit ) }
+                        { ' ' }
+                        { __( 'tokens', 'wp-ai-mind' ) }
+                    </span>
+                ) }
+
+                { resetsDate && (
+                    <span className="wpaim-usage-meter__resets">
+                        { __( 'Resets', 'wp-ai-mind' ) }
+                        { ' ' }
+                        { resetsDate }
+                    </span>
+                ) }
+            </div>
+
+            <a
+                href={ LEMONSQUEEZY_CHECKOUT_URL }
+                className="wpaim-usage-meter__upgrade"
+                target="_blank"
+                rel="noreferrer"
+            >
+                { __( 'Upgrade to Pro →', 'wp-ai-mind' ) }
+            </a>
+        </div>
+    );
+}
+```
+
+- [ ] **Step 5.2: Commit**
+
+```bash
+git add src/admin/shared/UsageMeter.jsx
+git commit -m "feat(usage): add UsageMeter component"
+```
+
+---
+
+## Task 6: UsageWarning + UpgradeModal components
+
+**Files:** `src/admin/shared/UsageWarning.jsx`, `src/admin/shared/UpgradeModal.jsx`
+
+- [ ] **Step 6.1: Create `src/admin/shared/UsageWarning.jsx`**
+
+```jsx
+import { __ } from '@wordpress/i18n';
+import { useAuth } from '../auth/AuthContext';
+import { LEMONSQUEEZY_CHECKOUT_URL } from './constants';
+
+/**
+ * UsageWarning — inline banner shown when token usage is >= 80%.
+ *
+ * Hidden when:
+ * - pct < 80
+ * - plan === 'pro'
+ * - plan === 'none'
+ * - tokens_limit is null
+ *
+ * At 80–99%: yellow warning banner.
+ * At 100%:   red "limit reached" banner with resets_at date.
+ *
+ * @returns {import('@wordpress/element').ReactNode|null}
+ */
+export default function UsageWarning() {
+    const { entitlement } = useAuth();
+
+    if ( ! entitlement ) {
+        return null;
+    }
+
+    const {
+        plan,
+        tokens_used = 0,
+        tokens_limit = null,
+        resets_at = null,
+    } = entitlement;
+
+    if ( plan === 'pro' || plan === 'none' || tokens_limit === null ) {
+        return null;
+    }
+
+    const pct = Math.min( ( tokens_used / tokens_limit ) * 100, 100 );
+
+    if ( pct < 80 ) {
+        return null;
+    }
+
+    const isHit = pct >= 100;
+
+    const resetsDate = resets_at
+        ? new Date( resets_at ).toLocaleDateString( undefined, {
+              month: 'long',
+              day: 'numeric',
+          } )
+        : null;
+
+    const bannerClass = isHit
+        ? 'wpaim-usage-warning wpaim-usage-warning--hit'
+        : 'wpaim-usage-warning wpaim-usage-warning--warn';
+
+    return (
+        <div className={ bannerClass } role="alert">
+            <p className="wpaim-usage-warning__text">
+                { isHit ? (
+                    <>
+                        { __( 'Monthly limit reached. Chats unavailable until', 'wp-ai-mind' ) }
+                        { resetsDate ? ` ${ resetsDate }.` : '.' }
+                    </>
+                ) : (
+                    <>
+                        { __( "You've used", 'wp-ai-mind' ) }
+                        { ` ${ Math.round( pct ) }% ` }
+                        { __( 'of your monthly credits.', 'wp-ai-mind' ) }
+                    </>
+                ) }
+            </p>
+            <a
+                href={ LEMONSQUEEZY_CHECKOUT_URL }
+                className="wpaim-usage-warning__upgrade"
+                target="_blank"
+                rel="noreferrer"
+            >
+                { __( 'Upgrade to Pro →', 'wp-ai-mind' ) }
+            </a>
+        </div>
+    );
+}
+```
+
+- [ ] **Step 6.2: Create `src/admin/shared/UpgradeModal.jsx`**
+
+```jsx
+import { __ } from '@wordpress/i18n';
+import { useAuth } from '../auth/AuthContext';
+import { LEMONSQUEEZY_CHECKOUT_URL } from './constants';
+
+/**
+ * UpgradeModal — overlay modal shown when a 429 / token_limit_exceeded error
+ * is received from any AI feature.
+ *
+ * @param {Object}   props
+ * @param {boolean}  props.isOpen  - Whether the modal is visible.
+ * @param {Function} props.onClose - Callback to close the modal.
+ * @returns {import('@wordpress/element').ReactNode|null}
+ */
+export default function UpgradeModal( { isOpen, onClose } ) {
+    const { entitlement } = useAuth();
+
+    if ( ! isOpen ) {
+        return null;
+    }
+
+    const resets_at = entitlement?.resets_at ?? null;
+    const resetsDate = resets_at
+        ? new Date( resets_at ).toLocaleDateString( undefined, {
+              month: 'long',
+              day: 'numeric',
+          } )
+        : null;
+
+    function handleOverlayClick() {
+        onClose();
+    }
+
+    function handleCardClick( e ) {
+        // Prevent clicks inside the card from bubbling to the overlay.
+        e.stopPropagation();
+    }
+
+    return (
+        /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+        <div className="wpaim-modal-overlay" onClick={ handleOverlayClick }>
+            { /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */ }
+            <div
+                className="wpaim-modal-card"
+                onClick={ handleCardClick }
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="wpaim-upgrade-modal-title"
+            >
+                <h2
+                    id="wpaim-upgrade-modal-title"
+                    className="wpaim-modal-card__title"
+                >
+                    { __( 'Monthly limit reached', 'wp-ai-mind' ) }
+                </h2>
+
+                <p className="wpaim-modal-card__body">
+                    { __( "You've used all of your free monthly tokens. Upgrade to Pro for unlimited usage, or wait until your allowance resets.", 'wp-ai-mind' ) }
+                </p>
+
+                { resetsDate && (
+                    <p className="wpaim-modal-card__resets">
+                        { __( 'Your free allowance resets on', 'wp-ai-mind' ) }
+                        { ` ${ resetsDate }.` }
+                    </p>
+                ) }
+
+                <div className="wpaim-modal-card__actions">
+                    <a
+                        href={ LEMONSQUEEZY_CHECKOUT_URL }
+                        className="wpaim-btn wpaim-btn--primary"
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        { __( 'Upgrade to Pro', 'wp-ai-mind' ) }
+                    </a>
+
+                    <button
+                        type="button"
+                        className="wpaim-btn wpaim-btn--ghost"
+                        onClick={ onClose }
+                    >
+                        { resetsDate
+                            ? `${ __( 'Wait until', 'wp-ai-mind' ) } ${ resetsDate }`
+                            : __( 'Wait for reset', 'wp-ai-mind' ) }
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+```
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add src/admin/shared/UsageWarning.jsx src/admin/shared/UpgradeModal.jsx
+git commit -m "feat(usage): add UsageWarning and UpgradeModal components"
+```
+
+---
+
+## Task 7: ProvidersTab.jsx — conditional API key section
+
+**File:** `src/admin/settings/ProvidersTab.jsx`
+
+The existing file has two sections: "Default Providers" and "API Keys" (lines 84–119). Wrap the API Keys section with a Pro gate.
+
+- [ ] **Step 7.1: Add imports at the top of `ProvidersTab.jsx`**
+
+Add these two imports immediately after the existing `import { useState } from '@wordpress/element';` line:
+
+```jsx
+import { __ } from '@wordpress/i18n';
+import { useAuth } from '../auth/AuthContext';
+import { LEMONSQUEEZY_CHECKOUT_URL } from '../shared/constants';
+```
+
+- [ ] **Step 7.2: Read the feature flag inside the component**
+
+Add the following two lines at the top of the `ProvidersTab` function body, immediately after the `const apiKeys = settings?.api_keys ?? {};` line:
+
+```jsx
+const { entitlement } = useAuth();
+const isPro = Boolean( entitlement?.features?.own_key );
+```
+
+- [ ] **Step 7.3: Replace the API Keys section**
+
+Locate the existing `{ /* API key inputs */ }` section (starts at `<section className="wpaim-settings-section">` after the Default Providers section). Replace it with the gated version:
+
+```jsx
+{ /* API key inputs — Pro only */ }
+{ isPro ? (
+    <section className="wpaim-settings-section">
+        <h3 className="wpaim-settings-section-title">
+            { __( 'API Keys', 'wp-ai-mind' ) }
+        </h3>
+
+        { API_KEY_PROVIDERS.map( ( { id, label } ) => (
+            <div
+                key={ id }
+                className="wpaim-field-row wpaim-field-row--key"
+            >
+                <div className="wpaim-field-input-group">
+                    <TextControl
+                        label={ label }
+                        type="password"
+                        value={ dirty[ id ] ?? '' }
+                        placeholder={
+                            apiKeys[ id ]
+                                ? '••••••••••••'
+                                : __( 'Enter API key…', 'wp-ai-mind' )
+                        }
+                        onChange={ ( val ) =>
+                            handleKeyChange( id, val )
+                        }
+                        autoComplete="new-password"
+                        __nextHasNoMarginBottom
+                    />
+                    <Button
+                        variant="primary"
+                        disabled={
+                            isSaving || dirty[ id ] === undefined
+                        }
+                        onClick={ () => handleSaveKey( id ) }
+                    >
+                        { isSaving
+                            ? __( 'Saving…', 'wp-ai-mind' )
+                            : __( 'Save', 'wp-ai-mind' ) }
+                    </Button>
+                </div>
+            </div>
+        ) ) }
+    </section>
+) : (
+    <section className="wpaim-settings-section wpaim-settings-section--locked">
+        <h3 className="wpaim-settings-section-title">
+            { __( 'API Keys', 'wp-ai-mind' ) }
+        </h3>
+        <p className="wpaim-settings-section__description">
+            { __( 'Your plan uses shared infrastructure. Upgrade to Pro to connect your own API keys.', 'wp-ai-mind' ) }
+        </p>
+        <a
+            href={ LEMONSQUEEZY_CHECKOUT_URL }
+            className="wpaim-btn wpaim-btn--primary"
+            target="_blank"
+            rel="noreferrer"
+        >
+            { __( 'Upgrade to Pro', 'wp-ai-mind' ) }
+        </a>
+    </section>
+) }
+```
+
+Note: The `label` prop on `TextControl` inside the Pro gate now uses `{ label }` from the `API_KEY_PROVIDERS` array (unchanged from the original). The `isSaving` and `dirty` variables are already in scope from the existing component props and state.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add src/admin/settings/ProvidersTab.jsx
+git commit -m "feat(settings): gate API key inputs behind Pro entitlement"
+```
+
+---
+
+## Task 8: 429 error handling in ChatApp + other AI feature components
+
+**File:** `src/admin/components/Chat/ChatApp.jsx` (and pattern for other AI components)
+
+- [ ] **Step 8.1: Add UpgradeModal import to `ChatApp.jsx`**
+
+Add this import at the top of `ChatApp.jsx`, after the existing `apiFetch` import:
+
+```jsx
+import { useState } from '@wordpress/element'; // already present — ensure it's there
+import { __ } from '@wordpress/i18n';
+import UpgradeModal from '../../shared/UpgradeModal';
+```
+
+Note: `useState` is already imported. Only add `__` and `UpgradeModal` imports.
+
+- [ ] **Step 8.2: Add `showUpgrade` state and `handleApiError` helper to `ChatApp`**
+
+Inside the `ChatApp` function body, add the following after the existing `useState` declarations:
+
+```jsx
+const [ showUpgrade, setShowUpgrade ] = useState( false );
+
+function handleApiError( err ) {
+    if ( err?.status === 429 || err?.data?.code === 'token_limit_exceeded' ) {
+        setShowUpgrade( true );
+        return;
+    }
+    const errorText =
+        err?.message ?? __( 'Something went wrong. Please try again.', 'wp-ai-mind' );
+    setMessages( ( prev ) => [
+        ...prev,
+        { role: 'assistant', content: errorText, isError: true },
+    ] );
+}
+```
+
+- [ ] **Step 8.3: Replace the catch block in `sendMessage()`**
+
+Locate the existing `catch ( err )` block in `sendMessage()`:
+
+```jsx
+// BEFORE:
+} catch ( err ) {
+    const errorText =
+        err?.message ?? 'Something went wrong. Please try again.';
+    setMessages( ( prev ) => [
+        ...prev,
+        { role: 'assistant', content: errorText, isError: true },
+    ] );
+}
+```
+
+Replace it with:
+
+```jsx
+// AFTER:
+} catch ( err ) {
+    handleApiError( err );
+}
+```
+
+- [ ] **Step 8.4: Add `<UpgradeModal>` to the JSX return**
+
+Inside the `return (...)` of `ChatApp`, add the modal immediately before the closing `</div>` of `wpaim-shell`:
+
+```jsx
+<UpgradeModal
+    isOpen={ showUpgrade }
+    onClose={ () => setShowUpgrade( false ) }
+/>
+```
+
+The full `return` structure becomes:
+
+```jsx
+return (
+    <div className="wpaim-shell">
+        <aside className="wpaim-sidebar">
+            { /* ... sidebar content unchanged ... */ }
+        </aside>
+
+        <main className="wpaim-main">
+            { /* ... main content unchanged ... */ }
+        </main>
+
+        <aside className="wpaim-right-panel">
+            { /* ... right panel content unchanged ... */ }
+        </aside>
+
+        <UpgradeModal
+            isOpen={ showUpgrade }
+            onClose={ () => setShowUpgrade( false ) }
+        />
+    </div>
+);
+```
+
+- [ ] **Step 8.5: Apply the same pattern to other AI feature components**
+
+The identical pattern (import `UpgradeModal`, add `showUpgrade` state, add `handleApiError`, replace catch block, add `<UpgradeModal>` in JSX) must be applied to:
+
+- `src/admin/components/Generator/GeneratorWizard.jsx` — replace the `catch` in the generate API call
+- `src/admin/components/Seo/SeoWorkArea.jsx` — replace the `catch` in the SEO analysis API call
+- `src/admin/components/Images/ImagesWorkArea.jsx` — replace the `catch` in the image generation API call
+
+The only difference in each file is the path to `UpgradeModal`:
+
+```jsx
+// From GeneratorWizard (adjust depth as needed):
+import UpgradeModal from '../../shared/UpgradeModal';
+```
+
+Verify the relative path depth matches the file location before committing.
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add src/admin/components/Chat/ChatApp.jsx
+# Add any other AI feature files edited in step 8.5:
+# git add src/admin/components/Generator/GeneratorWizard.jsx
+# git add src/admin/components/Seo/SeoWorkArea.jsx
+# git add src/admin/components/Images/ImagesWorkArea.jsx
+git commit -m "feat(chat): show UpgradeModal on 429 token limit error"
+```
+
+---
+
+## Task 9: DashboardApp — add UsageMeter + UsageWarning
+
+**File:** `src/admin/dashboard/DashboardApp.jsx`
+
+- [ ] **Step 9.1: Add imports**
+
+Add these two imports at the top of `DashboardApp.jsx`, after the existing component imports:
+
+```jsx
+import UsageMeter from '../shared/UsageMeter';
+import UsageWarning from '../shared/UsageWarning';
+```
+
+- [ ] **Step 9.2: Insert components into the JSX**
+
+Locate the existing JSX inside `DashboardApp`. The current structure (simplified) is:
+
+```jsx
+return (
+    <div className="wpaim-dashboard">
+        { /* Top bar */ }
+        <div className="wpaim-dash-topbar">...</div>
+        <StatusBanner bannerState={ bannerState } urls={ urls } />
+        <div className="wpaim-dash-body">
+            <StartTiles urls={ urls } />
+            <ResourceList ... />
+        </div>
+        <PageFooter ... />
+    </div>
+);
+```
+
+Replace with:
+
+```jsx
+return (
+    <div className="wpaim-dashboard">
+        { /* Top bar */ }
+        <div className="wpaim-dash-topbar">
+            <div>
+                <div className="wpaim-dash-title">WP AI Mind</div>
+                <div className="wpaim-dash-subtitle">
+                    AI-powered content creation for WordPress
+                </div>
+            </div>
+            <span className="wpaim-dash-version">v{ version }</span>
+        </div>
+
+        { /* Usage warning — shown at top when >= 80% used */ }
+        <UsageWarning />
+
+        <StatusBanner bannerState={ bannerState } urls={ urls } />
+
+        { /* Usage meter — shown below status banner */ }
+        <UsageMeter />
+
+        <div className="wpaim-dash-body">
+            <StartTiles urls={ urls } />
+            <ResourceList
+                resourceUrls={ resourceUrls }
+                version={ version }
+            />
+        </div>
+
+        <PageFooter urls={ urls } runSetupUrl={ runSetupUrl } />
+    </div>
+);
+```
+
+`UsageWarning` goes at the very top so it's impossible to miss at 80%+. `UsageMeter` sits between `StatusBanner` and the main body tiles where it reads naturally.
+
+- [ ] **Step 9.3: Commit**
+
+```bash
+git add src/admin/dashboard/DashboardApp.jsx
+git commit -m "feat(dashboard): add UsageMeter and UsageWarning to dashboard"
+```
+
+---
+
+## Task 10: Manual integration verification
+
+No unit tests are written for React components in this plugin. Verify the full flow manually in the browser after `npm run build`.
+
+- [ ] **Step 10.1: Build assets**
+
+```bash
+npm run build
+# Expected: exits 0, no TypeScript/JSX errors, assets/ directory updated
+```
+
+- [ ] **Step 10.2: Restart Docker to clear OPcache**
+
+```bash
+docker restart blognjohanssoneu-wordpress-1
+```
+
+- [ ] **Step 10.3: Auth gate — unauthenticated**
+
+1. Log out of the NJ account from the plugin (or manually set `window.wpAiMindData.isAuthenticated = false` in DevTools for a quick smoke test).
+2. Navigate to each admin page: Chat, Dashboard, Settings.
+3. Expected: every page shows the `wpaim-auth-card` with the "WP AI Mind" heading — NOT the AI interface.
+4. Confirm the tab switcher works: click "Sign up →" → SignupForm appears; click "Log in →" → LoginForm appears.
+
+- [ ] **Step 10.4: Auth gate — login flow**
+
+1. Enter valid credentials in the LoginForm.
+2. Expected: on successful POST to `/wp-ai-mind/v1/nj/login`, the auth card disappears and the full UI renders.
+3. Reload the page — expected: stays authenticated (PHP still serves `isAuthenticated: true` in localised data).
+
+- [ ] **Step 10.5: ProvidersTab — free-tier vs Pro**
+
+1. Log in as a **free-tier** account.
+2. Navigate to Settings → Providers tab.
+3. Expected: "API Keys" section shows the upgrade CTA paragraph and "Upgrade to Pro" link — no TextControl inputs visible.
+4. Log in as a **Pro** account.
+5. Expected: "API Keys" section shows the three TextControl fields for Claude, OpenAI, Gemini.
+
+- [ ] **Step 10.6: UpgradeModal — simulate 429**
+
+1. In DevTools, temporarily intercept the POST to `/wp-ai-mind/v1/conversations/{id}/messages` to return `{ status: 429, data: { code: 'token_limit_exceeded' } }`.
+2. Send a chat message.
+3. Expected: `UpgradeModal` appears with "Monthly limit reached" heading.
+4. Click the overlay → modal closes.
+5. Click "Upgrade to Pro" → opens `LEMONSQUEEZY_CHECKOUT_URL` in a new tab.
+6. Click "Wait until [date]" → modal closes.
+
+- [ ] **Step 10.7: UsageMeter and UsageWarning — Dashboard**
+
+1. With a free-tier account that has consumed > 0 tokens, open the Dashboard.
+2. Expected: `UsageMeter` progress bar visible below `StatusBanner`, showing correct token counts and resets date.
+3. With a Pro account, open the Dashboard.
+4. Expected: `UsageMeter` and `UsageWarning` are both absent (hidden by `plan === 'pro'`).
+5. Manually set `entitlement.tokens_used` to ≥ 80% of `tokens_limit` in DevTools to verify the `--warn` class and yellow warning banner appear.
+6. Set to 100% to verify `--hit` class, "Limit reached" text, and red banner with resets date.
+
+- [ ] **Step 10.8: Final build + lint check**
+
+```bash
+npm run build
+./vendor/bin/phpcs --standard=phpcs.xml.dist
+# Both must exit 0 before the PR is raised.
+```
+
+- [ ] **Step 10.9: Commit verification step (no code changes — just the confirmation)**
+
+If all checks pass, note the following in the PR description:
+- Auth gate verified on Chat, Dashboard, Settings pages
+- Login and signup flows tested
+- ProvidersTab Pro/free-tier gating confirmed
+- 429 → UpgradeModal flow confirmed
+- UsageMeter and UsageWarning percentages verified
+- Build exits 0, PHPCS exits 0
+
+---
+
+## Pre-launch Checklist
+
+Before merging to `main`, ensure these items are actioned:
+
+- [ ] Replace `LEMONSQUEEZY_CHECKOUT_URL` placeholder in `src/admin/shared/constants.js` with the real LemonSqueezy variant checkout URL.
+- [ ] Replace `ACCOUNT_DASHBOARD_URL` placeholder in `src/admin/shared/constants.js` with the real NJ account dashboard URL.
+- [ ] Confirm that `window.wpAiMindData` includes `isAuthenticated`, `user`, `entitlement` (with `plan`, `tokens_used`, `tokens_limit`, `resets_at`, `features`) — these keys are set by Phase 5's PHP localisation. If Phase 5 is not yet deployed, `AuthProvider` falls back safely to `isAuthenticated: false`.
+- [ ] CSS for BEM classes (`wpaim-auth-card`, `wpaim-auth-form`, `wpaim-usage-meter`, `wpaim-usage-warning`, `wpaim-modal-overlay`, `wpaim-modal-card`) must be added to `src/admin/admin.css` or a dedicated `src/admin/auth/auth.css` (enqueued via `wp_enqueue_block_style()` if scoped, or `admin.css` if global admin-only). CSS authoring is not in scope for this plan but must be done before QA sign-off.

--- a/docs/superpowers/plans/phases/phase-7-cf-worker-hardening.md
+++ b/docs/superpowers/plans/phases/phase-7-cf-worker-hardening.md
@@ -8,7 +8,41 @@
 
 **Tech Stack:** Cloudflare Workers (TypeScript), Cloudflare Durable Objects, Cloudflare KV (usage tracking only), Wrangler CLI, Vitest.
 
-**Depends on:** Phase 3 complete (Worker chat endpoint live).
+**Depends on:** Phase 3 complete (Worker chat endpoint live, `src/tier-config.ts` in place).
+
+---
+
+## Task 0: Pre-implementation Reuse Audit
+
+> **Mandatory.** Complete before writing any new Worker code.
+
+- [ ] **Step 0.1: Read existing `src/tier-config.ts`**
+
+```bash
+cat wp-ai-mind-proxy/src/tier-config.ts
+# Understand TierConfig shape. The refactored chat.ts in this phase must import getTierConfig()
+# and NOT redefine PLAN_LIMITS locally.
+```
+
+- [ ] **Step 0.2: Read existing `src/chat.ts`** (Phase 3 version)
+
+```bash
+cat wp-ai-mind-proxy/src/chat.ts
+# Understand what already exists. The refactor replaces the Anthropic-only implementation
+# with provider adapters, but must preserve model allowlist and per-tier cap logic.
+```
+
+- [ ] **Step 0.3: Read existing `src/utils.ts` and `src/middleware.ts`**
+
+```bash
+cat wp-ai-mind-proxy/src/utils.ts
+cat wp-ai-mind-proxy/src/middleware.ts
+# Import from these — do not re-implement json(), requireAuth(), etc.
+```
+
+- [ ] **Step 0.4: List what can be reused from Phases 1–3**
+
+Before implementing Task 4 (provider adapters), confirm which utilities from `src/utils.ts` the adapters can reuse (hint: `json()` is useful for error responses).
 
 ---
 
@@ -486,6 +520,8 @@ Expected: no errors
 - [ ] Replace the entire `handleChat` function in `wp-ai-mind-proxy/src/chat.ts` with the following implementation. Add the new imports at the top of the file:
 
 ```typescript
+import { yyyyMM, secondsUntilMonthEnd, nextMonthStart, json } from './utils'; // reuse from Phase 1
+import { getTierConfig } from './tier-config'; // single source of truth — no local PLAN_LIMITS
 import { anthropicAdapter } from './providers/anthropic';
 import { openaiAdapter }    from './providers/openai';
 import { geminiAdapter }    from './providers/gemini';
@@ -496,23 +532,6 @@ import type { Env, AuthUser } from './types';
 - [ ] Replace `handleChat` with:
 
 ```typescript
-const PLAN_LIMITS: Record<string, number | null> = {
-    free:  50_000,
-    trial: 300_000,
-    pro:   null,
-};
-
-function yyyyMM(): string {
-    const d = new Date();
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
-}
-
-function secondsUntilMonthEnd(): number {
-    const now  = new Date();
-    const next = new Date(now.getFullYear(), now.getMonth() + 1, 1);
-    return Math.floor((next.getTime() - now.getTime()) / 1000);
-}
-
 function getAdapter(provider: string): ProviderAdapter {
     switch (provider) {
         case 'openai':  return openaiAdapter;
@@ -530,29 +549,47 @@ function getApiKey(provider: string, env: Env): string {
 }
 
 export async function handleChat(req: Request, env: Env, user: AuthUser): Promise<Response> {
-    const limit = PLAN_LIMITS[user.plan] ?? null;
+    const config        = getTierConfig(user.plan);  // all limits/allowlists from tier-config
+    const limit         = config.tokens_per_month;
+    const allowedModels = config.allowed_models;
 
-    // Enforce token limits for free/trial users.
+    // Step 1: Enforce token limits for managed tiers (free, trial, pro_managed).
     if (limit !== null) {
         const monthKey = `usage:${user.sub}:${yyyyMM()}`;
         const used     = parseInt((await env.USAGE_KV.get(monthKey)) ?? '0', 10);
         if (used >= limit) {
-            return new Response(JSON.stringify({
+            return json({
                 error:     'token_limit_exceeded',
                 used,
                 limit,
-                resets_at: new Date(new Date().getFullYear(), new Date().getMonth() + 1, 1).toISOString(),
-            }), { status: 429, headers: { 'Content-Type': 'application/json' } });
+                resets_at: nextMonthStart(),
+            }, 429);
         }
     }
 
-    const body     = await req.json<Record<string, unknown> & { provider?: string; stream?: boolean }>();
-    const provider = (body.provider as string | undefined) ?? 'anthropic';
-    const isStream = body.stream === true;
-    const adapter  = getAdapter(provider);
-    const apiKey   = getApiKey(provider, env);
+    const body           = await req.json<Record<string, unknown> & { provider?: string; stream?: boolean }>();
+    const requestedModel = (body.model as string | undefined) ?? 'claude-haiku-4-5';
+    const provider       = (body.provider as string | undefined) ?? 'anthropic';
+    const isStream       = body.stream === true;
 
-    const upstreamReq  = adapter.buildRequest(body as any, apiKey);
+    // Step 2: Validate model against tier allowlist (managed tiers only).
+    if (allowedModels.length > 0 && !allowedModels.includes(requestedModel)) {
+        return json({ error: 'model_not_allowed', requested_model: requestedModel, allowed_models: allowedModels }, 403);
+    }
+
+    // Step 3: Apply per-request max_tokens cap.
+    const maxCap = config.max_tokens_per_request;
+    const patchedBody = {
+        ...body,
+        model:      requestedModel,
+        max_tokens: maxCap !== null
+            ? Math.min((body.max_tokens as number | undefined) ?? maxCap, maxCap)
+            : body.max_tokens,
+    };
+
+    const adapter      = getAdapter(provider);
+    const apiKey       = getApiKey(provider, env);
+    const upstreamReq  = adapter.buildRequest(patchedBody as any, apiKey);
     const upstreamResp = await fetch(upstreamReq);
 
     if (!upstreamResp.ok) {
@@ -569,7 +606,7 @@ export async function handleChat(req: Request, env: Env, user: AuthUser): Promis
         });
     }
 
-    // For streaming: pipe body directly without buffering.
+    // Step 4: For streaming — pipe body directly without buffering.
     if (isStream) {
         const { readable, writable } = new TransformStream();
         upstreamResp.body!.pipeTo(writable);
@@ -583,7 +620,7 @@ export async function handleChat(req: Request, env: Env, user: AuthUser): Promis
         });
     }
 
-    // Non-streaming: update KV usage.
+    // Step 5: Non-streaming — update KV usage for managed tiers.
     if (limit !== null) {
         const cloned   = upstreamResp.clone();
         const respData = await cloned.json<{
@@ -788,13 +825,52 @@ curl -X POST https://wp-ai-mind-proxy.YOUR_SUBDOMAIN.workers.dev/v1/chat \
 
 ---
 
+## Task 13: Post-implementation Code Reuse Verification
+
+> **Mandatory.** Run before marking Phase 7 complete.
+
+- [ ] **Step 13.1: No local plan constants in chat.ts**
+
+```bash
+grep -n "PLAN_LIMITS\|50_000\|300_000\|2_000_000\|claude-haiku\|claude-sonnet" \
+  wp-ai-mind-proxy/src/chat.ts
+# Expected: 0 matches — all limits and model names come from getTierConfig()
+```
+
+- [ ] **Step 13.2: No provider-specific logic outside providers/ directory**
+
+```bash
+grep -n "api.anthropic\|openai.com\|googleapis" wp-ai-mind-proxy/src/chat.ts
+# Expected: 0 matches — all provider URLs are encapsulated in adapter files
+```
+
+- [ ] **Step 13.3: Utils are imported, not re-implemented**
+
+```bash
+grep -n "yyyyMM\|secondsUntilMonthEnd\|nextMonthStart" wp-ai-mind-proxy/src/chat.ts
+# Expected: only import declaration; no function re-definitions
+```
+
+- [ ] **Step 13.4: Full Vitest suite passes**
+
+```bash
+cd wp-ai-mind-proxy && npx vitest run
+# Expected: all tests pass
+```
+
+---
+
 ## Acceptance Criteria
 
 - [ ] `POST /v1/auth/token` returns `429` after 10 attempts from the same IP within 15 minutes (enforced by `RateLimiterDO` — strongly consistent, no race condition)
 - [ ] `POST /v1/auth/register` is also rate-limited with the same 15-minute window via `RateLimiterDO`
 - [ ] Streaming: `POST /v1/chat` with `stream: true` returns `Content-Type: text/event-stream` with tokens arriving incrementally (verified via `wrangler dev` + curl)
+- [ ] `pro_managed` user requesting Sonnet via `stream: true` → streams correctly; model allowlist still enforced
+- [ ] Free user requesting Sonnet via `stream: true` → 403 `model_not_allowed` (no stream started)
 - [ ] OpenAI requests proxied correctly — model `gpt-4o-mini` routes via `openaiAdapter`
 - [ ] Gemini requests proxied correctly — model `gemini-1.5-flash` routes via `geminiAdapter`
+- [ ] Token usage counted correctly for both Anthropic (input/output_tokens) and OpenAI (prompt/completion_tokens) response shapes
 - [ ] Error events logged as structured JSON to Cloudflare Workers dashboard (Logs tab)
 - [ ] Staging environment deployable via `wrangler deploy --env staging` with isolated D1 + KV bindings
+- [ ] `src/chat.ts` has zero local plan constants (no PLAN_LIMITS, no hardcoded model names outside tier-config)
 - [ ] All Vitest tests pass: `npx vitest run` exits 0

--- a/docs/superpowers/plans/phases/phase-7-cf-worker-hardening.md
+++ b/docs/superpowers/plans/phases/phase-7-cf-worker-hardening.md
@@ -1,0 +1,713 @@
+# Phase 7: CF Worker — Hardening
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the Cloudflare Worker with brute-force rate limiting, real SSE streaming, multi-provider support (OpenAI + Gemini), structured error logging, and a staging environment.
+
+**Architecture:** New `src/ratelimit.ts` module for KV-backed IP rate limiting. Chat handler refactored to use `TransformStream` for real streaming. Provider routing added via a `provider` field in the chat request body. Staging environment configured in `wrangler.toml`.
+
+**Tech Stack:** Cloudflare Workers (TypeScript), Cloudflare KV, Wrangler CLI, Vitest.
+
+**Depends on:** Phase 3 complete (Worker chat endpoint live).
+
+---
+
+## File Map
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `wp-ai-mind-proxy/src/ratelimit.ts` | `checkLoginRateLimit(env, clientIP)` returns boolean; uses KV with 15-min TTL |
+| `wp-ai-mind-proxy/src/providers/anthropic.ts` | Anthropic-specific request builder + response normaliser |
+| `wp-ai-mind-proxy/src/providers/openai.ts` | OpenAI-specific request builder + response normaliser |
+| `wp-ai-mind-proxy/src/providers/gemini.ts` | Gemini-specific request builder + response normaliser |
+| `wp-ai-mind-proxy/src/providers/types.ts` | Shared `ProviderAdapter` interface, `ChatRequest` type, `NormalizedResponse` type |
+| `wp-ai-mind-proxy/test/ratelimit.test.ts` | Vitest tests for rate limiter |
+| `wp-ai-mind-proxy/test/streaming.test.ts` | Vitest tests for streaming path |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `wp-ai-mind-proxy/src/auth.ts` | `handleToken` + `handleRegister`: add rate limit check at entry |
+| `wp-ai-mind-proxy/src/chat.ts` | Refactor to use provider adapters + real SSE streaming via TransformStream |
+| `wp-ai-mind-proxy/src/types.ts` | Add `OPENAI_API_KEY` and `GEMINI_API_KEY` to `Env` interface |
+| `wp-ai-mind-proxy/wrangler.toml` | Add `[env.staging]` block |
+
+---
+
+## Tasks
+
+### Task 1: Rate limiter — tests first
+
+- [ ] Create `wp-ai-mind-proxy/test/ratelimit.test.ts` with the following content:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { checkLoginRateLimit } from '../src/ratelimit';
+
+// Mock Env
+function makeEnv(stored: string | null): any {
+    return {
+        USAGE_KV: {
+            get: vi.fn().mockResolvedValue(stored),
+            put: vi.fn().mockResolvedValue(undefined),
+        },
+    };
+}
+
+describe('checkLoginRateLimit', () => {
+    it('allows first attempt (no key in KV)', async () => {
+        const env = makeEnv(null);
+        const result = await checkLoginRateLimit(env, '1.2.3.4');
+        expect(result).toBe(true);
+        expect(env.USAGE_KV.put).toHaveBeenCalledWith(
+            'ratelimit:login:1.2.3.4', '1', { expirationTtl: 900 }
+        );
+    });
+
+    it('allows attempt 9 (below limit)', async () => {
+        const env = makeEnv('9');
+        const result = await checkLoginRateLimit(env, '1.2.3.4');
+        expect(result).toBe(true);
+    });
+
+    it('blocks attempt 10 (at limit)', async () => {
+        const env = makeEnv('10');
+        const result = await checkLoginRateLimit(env, '1.2.3.4');
+        expect(result).toBe(false);
+        expect(env.USAGE_KV.put).not.toHaveBeenCalled();
+    });
+
+    it('blocks attempts beyond limit', async () => {
+        const env = makeEnv('15');
+        const result = await checkLoginRateLimit(env, '1.2.3.4');
+        expect(result).toBe(false);
+    });
+});
+```
+
+- [ ] Run the tests — they must fail (red) because `ratelimit.ts` does not exist yet:
+
+```bash
+cd wp-ai-mind-proxy && npx vitest run test/ratelimit.test.ts
+```
+
+Expected output: `FAIL` — cannot find module `../src/ratelimit`
+
+---
+
+### Task 2: Rate limiter — implementation
+
+- [ ] Create `wp-ai-mind-proxy/src/ratelimit.ts`:
+
+```typescript
+import type { Env } from './types';
+
+const MAX_ATTEMPTS   = 10;
+const WINDOW_SECONDS = 900; // 15 minutes
+
+export async function checkLoginRateLimit(env: Env, clientIP: string): Promise<boolean> {
+    const key     = `ratelimit:login:${clientIP}`;
+    const current = parseInt((await env.USAGE_KV.get(key)) ?? '0', 10);
+    if (current >= MAX_ATTEMPTS) return false;
+    await env.USAGE_KV.put(key, String(current + 1), { expirationTtl: WINDOW_SECONDS });
+    return true;
+}
+```
+
+- [ ] Run the tests — they must now pass (green):
+
+```bash
+cd wp-ai-mind-proxy && npx vitest run test/ratelimit.test.ts
+```
+
+Expected output: `PASS` — 4 tests passing
+
+---
+
+### Task 3: Apply rate limiting to auth handlers
+
+- [ ] Open `wp-ai-mind-proxy/src/auth.ts` and add the following import at the top of the file, alongside the existing imports:
+
+```typescript
+import { checkLoginRateLimit } from './ratelimit';
+```
+
+- [ ] Modify `handleToken` to add the rate limit check as the very first action (before body parsing). Replace the existing function signature and opening lines with:
+
+```typescript
+export async function handleToken(req: Request, env: Env): Promise<Response> {
+    const ip = req.headers.get('CF-Connecting-IP') ?? 'unknown';
+    if (!(await checkLoginRateLimit(env, ip))) {
+        return json({ error: 'Too many attempts. Try again in 15 minutes.' }, 429);
+    }
+    // ... rest of existing implementation unchanged ...
+}
+```
+
+- [ ] Modify `handleRegister` identically — add the rate limit check as the very first action:
+
+```typescript
+export async function handleRegister(req: Request, env: Env): Promise<Response> {
+    const ip = req.headers.get('CF-Connecting-IP') ?? 'unknown';
+    if (!(await checkLoginRateLimit(env, ip))) {
+        return json({ error: 'Too many attempts. Try again in 15 minutes.' }, 429);
+    }
+    // ... rest of existing implementation unchanged ...
+}
+```
+
+- [ ] Run the full test suite to confirm no regressions:
+
+```bash
+cd wp-ai-mind-proxy && npx vitest run
+```
+
+Expected: all previously passing tests continue to pass, plus the 4 ratelimit tests.
+
+---
+
+### Task 4: Provider adapter interface + types
+
+- [ ] Create the directory `wp-ai-mind-proxy/src/providers/` if it does not exist:
+
+```bash
+mkdir -p wp-ai-mind-proxy/src/providers
+```
+
+- [ ] Create `wp-ai-mind-proxy/src/providers/types.ts`:
+
+```typescript
+export interface ChatRequest {
+    model:      string;
+    max_tokens: number;
+    messages:   Array<{ role: string; content: string }>;
+    system?:    string;
+    stream?:    boolean;
+}
+
+export interface ProviderAdapter {
+    buildRequest(body: ChatRequest, apiKey: string): Request;
+    normalizeResponse(raw: Response): Response; // passthrough for streaming
+}
+```
+
+No tests are needed for this task — it is a pure type definition file with no runtime logic.
+
+---
+
+### Task 5: Anthropic provider adapter
+
+- [ ] Create `wp-ai-mind-proxy/src/providers/anthropic.ts`:
+
+```typescript
+import type { ChatRequest, ProviderAdapter } from './types';
+
+export const anthropicAdapter: ProviderAdapter = {
+    buildRequest(body: ChatRequest, apiKey: string): Request {
+        return new Request('https://api.anthropic.com/v1/messages', {
+            method: 'POST',
+            headers: {
+                'x-api-key':         apiKey,
+                'anthropic-version': '2023-06-01',
+                'content-type':      'application/json',
+            },
+            body: JSON.stringify(body),
+        });
+    },
+    normalizeResponse(raw: Response): Response {
+        return raw; // Anthropic response shape is native; no normalisation needed
+    },
+};
+```
+
+- [ ] Confirm TypeScript compiles without errors:
+
+```bash
+cd wp-ai-mind-proxy && npx tsc --noEmit
+```
+
+Expected: no errors
+
+---
+
+### Task 6: OpenAI provider adapter
+
+- [ ] Create `wp-ai-mind-proxy/src/providers/openai.ts`:
+
+```typescript
+import type { ChatRequest, ProviderAdapter } from './types';
+
+interface OpenAIMessage {
+    role:    string;
+    content: string;
+}
+
+export const openaiAdapter: ProviderAdapter = {
+    buildRequest(body: ChatRequest, apiKey: string): Request {
+        // Convert Anthropic messages shape to OpenAI: inject system as first message
+        const messages: OpenAIMessage[] = [];
+        if (body.system) {
+            messages.push({ role: 'system', content: body.system });
+        }
+        messages.push(...body.messages);
+
+        const openaiBody = {
+            model:      body.model,
+            max_tokens: body.max_tokens,
+            messages,
+            stream:     body.stream ?? false,
+        };
+
+        return new Request('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${apiKey}`,
+                'content-type':  'application/json',
+            },
+            body: JSON.stringify(openaiBody),
+        });
+    },
+    normalizeResponse(raw: Response): Response {
+        return raw; // Consumer handles OpenAI response shape directly
+    },
+};
+```
+
+- [ ] Confirm TypeScript compiles without errors:
+
+```bash
+cd wp-ai-mind-proxy && npx tsc --noEmit
+```
+
+Expected: no errors
+
+---
+
+### Task 7: Gemini provider adapter
+
+- [ ] Create `wp-ai-mind-proxy/src/providers/gemini.ts`:
+
+```typescript
+import type { ChatRequest, ProviderAdapter } from './types';
+
+export const geminiAdapter: ProviderAdapter = {
+    buildRequest(body: ChatRequest, apiKey: string): Request {
+        // Gemini uses its own message format
+        const parts = body.messages.map(m => ({
+            role:  m.role === 'assistant' ? 'model' : 'user',
+            parts: [{ text: m.content }],
+        }));
+
+        const geminiBody: Record<string, unknown> = {
+            contents:         parts,
+            generationConfig: { maxOutputTokens: body.max_tokens },
+        };
+        if (body.system) {
+            geminiBody.systemInstruction = { parts: [{ text: body.system }] };
+        }
+
+        const url = `https://generativelanguage.googleapis.com/v1beta/models/${body.model}:generateContent?key=${apiKey}`;
+        return new Request(url, {
+            method:  'POST',
+            headers: { 'content-type': 'application/json' },
+            body:    JSON.stringify(geminiBody),
+        });
+    },
+    normalizeResponse(raw: Response): Response {
+        return raw;
+    },
+};
+```
+
+- [ ] Confirm TypeScript compiles without errors:
+
+```bash
+cd wp-ai-mind-proxy && npx tsc --noEmit
+```
+
+Expected: no errors
+
+---
+
+### Task 8: Update Env types + wrangler.toml for new provider secrets
+
+- [ ] Open `wp-ai-mind-proxy/src/types.ts` and add the two new API key fields to the `Env` interface:
+
+```typescript
+OPENAI_API_KEY: string;
+GEMINI_API_KEY: string;
+```
+
+The complete `Env` interface should now include (in addition to existing fields):
+
+```typescript
+export interface Env {
+    // ... existing fields ...
+    OPENAI_API_KEY: string;
+    GEMINI_API_KEY: string;
+}
+```
+
+- [ ] Open `wp-ai-mind-proxy/wrangler.toml` and append the staging environment block at the end of the file:
+
+```toml
+[env.staging]
+name = "wp-ai-mind-proxy-staging"
+
+[env.staging.vars]
+ENVIRONMENT = "staging"
+
+[[env.staging.d1_databases]]
+binding        = "DB"
+database_name  = "wp-ai-mind-staging"
+database_id    = "<set after: wrangler d1 create wp-ai-mind-staging>"
+migrations_dir = "migrations"
+
+[[env.staging.kv_namespaces]]
+binding    = "USAGE_KV"
+id         = "<set after: wrangler kv:namespace create USAGE_KV_STAGING>"
+preview_id = "<set after: wrangler kv:namespace create USAGE_KV_STAGING --preview>"
+```
+
+- [ ] Register the new secrets in Wrangler for both production and staging:
+
+```bash
+# Production secrets
+wrangler secret put OPENAI_API_KEY
+wrangler secret put GEMINI_API_KEY
+
+# Staging secrets
+wrangler secret put OPENAI_API_KEY --env staging
+wrangler secret put GEMINI_API_KEY --env staging
+```
+
+- [ ] Confirm TypeScript still compiles without errors:
+
+```bash
+cd wp-ai-mind-proxy && npx tsc --noEmit
+```
+
+Expected: no errors
+
+---
+
+### Task 9: Refactor chat.ts — provider routing + SSE streaming
+
+- [ ] Replace the entire `handleChat` function in `wp-ai-mind-proxy/src/chat.ts` with the following implementation. Add the new imports at the top of the file:
+
+```typescript
+import { anthropicAdapter } from './providers/anthropic';
+import { openaiAdapter }    from './providers/openai';
+import { geminiAdapter }    from './providers/gemini';
+import type { ProviderAdapter } from './providers/types';
+import type { Env, AuthUser } from './types';
+```
+
+- [ ] Replace `handleChat` with:
+
+```typescript
+const PLAN_LIMITS: Record<string, number | null> = {
+    free:  50_000,
+    trial: 300_000,
+    pro:   null,
+};
+
+function yyyyMM(): string {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function secondsUntilMonthEnd(): number {
+    const now  = new Date();
+    const next = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    return Math.floor((next.getTime() - now.getTime()) / 1000);
+}
+
+function getAdapter(provider: string): ProviderAdapter {
+    switch (provider) {
+        case 'openai':  return openaiAdapter;
+        case 'gemini':  return geminiAdapter;
+        default:        return anthropicAdapter;
+    }
+}
+
+function getApiKey(provider: string, env: Env): string {
+    switch (provider) {
+        case 'openai':  return env.OPENAI_API_KEY;
+        case 'gemini':  return env.GEMINI_API_KEY;
+        default:        return env.ANTHROPIC_API_KEY;
+    }
+}
+
+export async function handleChat(req: Request, env: Env, user: AuthUser): Promise<Response> {
+    const limit = PLAN_LIMITS[user.plan] ?? null;
+
+    // Enforce token limits for free/trial users.
+    if (limit !== null) {
+        const monthKey = `usage:${user.sub}:${yyyyMM()}`;
+        const used     = parseInt((await env.USAGE_KV.get(monthKey)) ?? '0', 10);
+        if (used >= limit) {
+            return new Response(JSON.stringify({
+                error:     'token_limit_exceeded',
+                used,
+                limit,
+                resets_at: new Date(new Date().getFullYear(), new Date().getMonth() + 1, 1).toISOString(),
+            }), { status: 429, headers: { 'Content-Type': 'application/json' } });
+        }
+    }
+
+    const body     = await req.json<Record<string, unknown> & { provider?: string; stream?: boolean }>();
+    const provider = (body.provider as string | undefined) ?? 'anthropic';
+    const isStream = body.stream === true;
+    const adapter  = getAdapter(provider);
+    const apiKey   = getApiKey(provider, env);
+
+    const upstreamReq  = adapter.buildRequest(body as any, apiKey);
+    const upstreamResp = await fetch(upstreamReq);
+
+    if (!upstreamResp.ok) {
+        console.error(JSON.stringify({
+            event:    'upstream_error',
+            userId:   user.sub,
+            provider,
+            status:   upstreamResp.status,
+            ts:       new Date().toISOString(),
+        }));
+        return new Response(upstreamResp.body, {
+            status:  upstreamResp.status,
+            headers: { 'Content-Type': upstreamResp.headers.get('Content-Type') ?? 'application/json' },
+        });
+    }
+
+    // For streaming: pipe body directly without buffering.
+    if (isStream) {
+        const { readable, writable } = new TransformStream();
+        upstreamResp.body!.pipeTo(writable);
+        return new Response(readable, {
+            status:  200,
+            headers: {
+                'Content-Type':  'text/event-stream',
+                'Cache-Control': 'no-cache',
+                'Connection':    'keep-alive',
+            },
+        });
+    }
+
+    // Non-streaming: update KV usage.
+    if (limit !== null) {
+        const cloned   = upstreamResp.clone();
+        const respData = await cloned.json<{
+            usage?: {
+                input_tokens?:      number;
+                output_tokens?:     number;
+                prompt_tokens?:     number;
+                completion_tokens?: number;
+            };
+        }>();
+        // Support both Anthropic (input_tokens/output_tokens) and OpenAI (prompt_tokens/completion_tokens)
+        const tokens = (respData.usage?.input_tokens  ?? respData.usage?.prompt_tokens     ?? 0)
+                     + (respData.usage?.output_tokens ?? respData.usage?.completion_tokens ?? 0);
+        if (tokens > 0) {
+            const monthKey = `usage:${user.sub}:${yyyyMM()}`;
+            const current  = parseInt((await env.USAGE_KV.get(monthKey)) ?? '0', 10);
+            await env.USAGE_KV.put(monthKey, String(current + tokens), {
+                expirationTtl: secondsUntilMonthEnd(),
+            });
+        }
+    }
+
+    return new Response(upstreamResp.body, {
+        status:  upstreamResp.status,
+        headers: { 'Content-Type': upstreamResp.headers.get('Content-Type') ?? 'application/json' },
+    });
+}
+```
+
+- [ ] Confirm TypeScript compiles without errors:
+
+```bash
+cd wp-ai-mind-proxy && npx tsc --noEmit
+```
+
+Expected: no errors
+
+---
+
+### Task 10: Streaming test
+
+- [ ] Create `wp-ai-mind-proxy/test/streaming.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+// Note: TransformStream streaming is hard to unit-test in isolation.
+// This test validates that the chat handler returns correct headers for streaming requests
+// and does NOT buffer the response body.
+
+describe('handleChat streaming path', () => {
+    it('returns text/event-stream content-type for stream:true requests', async () => {
+        // Minimal smoke test — full streaming E2E is validated via curl against deployed worker
+        const mockBody = {
+            model:      'claude-haiku-4-5',
+            max_tokens: 100,
+            messages:   [{ role: 'user', content: 'hi' }],
+            stream:     true,
+        };
+        // This is a documentation-level test: streaming correctness is verified via wrangler dev + curl
+        expect(mockBody.stream).toBe(true);
+    });
+});
+```
+
+- [ ] Run the streaming tests:
+
+```bash
+cd wp-ai-mind-proxy && npx vitest run test/streaming.test.ts
+```
+
+Expected: PASS (1 test)
+
+**Note — streaming E2E verification (required before marking this task complete):**
+
+Full streaming correctness must be verified manually against the local worker using `wrangler dev`:
+
+```bash
+# Terminal 1: start the local worker
+cd wp-ai-mind-proxy && wrangler dev
+
+# Terminal 2: send a streaming chat request (replace $ACCESS_TOKEN with a valid JWT)
+curl -X POST http://localhost:8787/v1/chat \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"claude-haiku-4-5","max_tokens":500,"messages":[{"role":"user","content":"Count to 5"}],"stream":true}' \
+  --no-buffer
+```
+
+Expected: SSE events arrive incrementally in real time (tokens stream; the connection does not wait for the full response before sending).
+
+---
+
+### Task 11: Staging environment + deploy
+
+- [ ] Create the staging D1 database and KV namespace, then fill in the placeholder IDs in `wrangler.toml`:
+
+```bash
+# Create staging D1 database
+wrangler d1 create wp-ai-mind-staging
+# Copy the returned database_id and replace the placeholder in wrangler.toml
+
+# Create staging KV namespace
+wrangler kv:namespace create USAGE_KV_STAGING
+# Copy the returned id and replace the <id> placeholder in wrangler.toml
+
+wrangler kv:namespace create USAGE_KV_STAGING --preview
+# Copy the returned id and replace the <preview_id> placeholder in wrangler.toml
+```
+
+- [ ] Apply migrations to the staging database:
+
+```bash
+wrangler d1 migrations apply wp-ai-mind-staging --remote --env staging
+```
+
+- [ ] Set all staging secrets:
+
+```bash
+wrangler secret put JWT_SECRET                   --env staging
+wrangler secret put ANTHROPIC_API_KEY            --env staging
+wrangler secret put LEMONSQUEEZY_WEBHOOK_SECRET  --env staging
+wrangler secret put OPENAI_API_KEY               --env staging
+wrangler secret put GEMINI_API_KEY               --env staging
+```
+
+- [ ] Deploy to staging:
+
+```bash
+wrangler deploy --env staging
+```
+
+Expected: deployment succeeds; Wrangler prints the staging worker URL (e.g. `https://wp-ai-mind-proxy-staging.YOUR_SUBDOMAIN.workers.dev`)
+
+- [ ] Smoke-test the staging deployment — confirm the base route is reachable:
+
+```bash
+curl -s https://wp-ai-mind-proxy-staging.YOUR_SUBDOMAIN.workers.dev/
+# Expected: 200 or known JSON response (not a 5xx)
+```
+
+---
+
+### Task 12: Full test suite + deploy production
+
+- [ ] Run the complete Vitest suite:
+
+```bash
+cd wp-ai-mind-proxy && npx vitest run
+```
+
+Expected: all tests pass — ratelimit.test.ts (4), streaming.test.ts (1), plus all tests from Phases 1 and 3.
+
+- [ ] Deploy to production:
+
+```bash
+wrangler deploy
+```
+
+Expected: deployment succeeds with no errors.
+
+- [ ] Smoke-test rate limiting against the production worker:
+
+```bash
+for i in {1..11}; do
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    -X POST https://wp-ai-mind-proxy.YOUR_SUBDOMAIN.workers.dev/v1/auth/token \
+    -H "Content-Type: application/json" \
+    -d '{"email":"test@test.com","password":"wrongpassword"}';
+done
+# Expected: first 10 responses return 401, the 11th returns 429
+```
+
+- [ ] Smoke-test OpenAI routing (requires `gpt-4o-mini` and a valid `OPENAI_API_KEY` secret):
+
+```bash
+curl -X POST https://wp-ai-mind-proxy.YOUR_SUBDOMAIN.workers.dev/v1/chat \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"provider":"openai","model":"gpt-4o-mini","max_tokens":50,"messages":[{"role":"user","content":"Say hello"}]}'
+# Expected: 200 with OpenAI response JSON
+```
+
+- [ ] Smoke-test Gemini routing (requires `gemini-1.5-flash` and a valid `GEMINI_API_KEY` secret):
+
+```bash
+curl -X POST https://wp-ai-mind-proxy.YOUR_SUBDOMAIN.workers.dev/v1/chat \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"provider":"gemini","model":"gemini-1.5-flash","max_tokens":50,"messages":[{"role":"user","content":"Say hello"}]}'
+# Expected: 200 with Gemini response JSON
+```
+
+- [ ] Verify structured error logging is visible in the Cloudflare Workers dashboard (Logs tab) after triggering a deliberate upstream error (e.g. sending an invalid model name):
+
+```bash
+curl -X POST https://wp-ai-mind-proxy.YOUR_SUBDOMAIN.workers.dev/v1/chat \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"invalid-model","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}'
+# Expected in Workers dashboard logs: {"event":"upstream_error","userId":"...","provider":"anthropic","status":400,"ts":"..."}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] `POST /v1/auth/token` returns `429` after 10 attempts from the same IP within 15 minutes
+- [ ] `POST /v1/auth/register` is also rate-limited with the same 15-minute window
+- [ ] Streaming: `POST /v1/chat` with `stream: true` returns `Content-Type: text/event-stream` with tokens arriving incrementally (verified via `wrangler dev` + curl)
+- [ ] OpenAI requests proxied correctly — model `gpt-4o-mini` routes via `openaiAdapter`
+- [ ] Gemini requests proxied correctly — model `gemini-1.5-flash` routes via `geminiAdapter`
+- [ ] Error events logged as structured JSON to Cloudflare Workers dashboard (Logs tab)
+- [ ] Staging environment deployable via `wrangler deploy --env staging` with isolated D1 + KV bindings
+- [ ] All Vitest tests pass: `npx vitest run` exits 0

--- a/docs/superpowers/plans/phases/phase-7-cf-worker-hardening.md
+++ b/docs/superpowers/plans/phases/phase-7-cf-worker-hardening.md
@@ -4,9 +4,9 @@
 
 **Goal:** Harden the Cloudflare Worker with brute-force rate limiting, real SSE streaming, multi-provider support (OpenAI + Gemini), structured error logging, and a staging environment.
 
-**Architecture:** New `src/ratelimit.ts` module for KV-backed IP rate limiting. Chat handler refactored to use `TransformStream` for real streaming. Provider routing added via a `provider` field in the chat request body. Staging environment configured in `wrangler.toml`.
+**Architecture:** New `src/ratelimit.ts` module for Durable Object-backed IP rate limiting (strongly consistent, race-condition-free). New `src/rate-limiter-do.ts` defines the `RateLimiterDO` class. Chat handler refactored to use `TransformStream` for real streaming. Provider routing added via a `provider` field in the chat request body. Staging environment configured in `wrangler.toml`.
 
-**Tech Stack:** Cloudflare Workers (TypeScript), Cloudflare KV, Wrangler CLI, Vitest.
+**Tech Stack:** Cloudflare Workers (TypeScript), Cloudflare Durable Objects, Cloudflare KV (usage tracking only), Wrangler CLI, Vitest.
 
 **Depends on:** Phase 3 complete (Worker chat endpoint live).
 
@@ -18,7 +18,8 @@
 
 | File | Purpose |
 |------|---------|
-| `wp-ai-mind-proxy/src/ratelimit.ts` | `checkLoginRateLimit(env, clientIP)` returns boolean; uses KV with 15-min TTL |
+| `wp-ai-mind-proxy/src/rate-limiter-do.ts` | `RateLimiterDO` Durable Object class — single-threaded counter with 15-min sliding window |
+| `wp-ai-mind-proxy/src/ratelimit.ts` | `checkLoginRateLimit(env, clientIP)` returns boolean; calls the `RateLimiterDO` stub (strongly consistent) |
 | `wp-ai-mind-proxy/src/providers/anthropic.ts` | Anthropic-specific request builder + response normaliser |
 | `wp-ai-mind-proxy/src/providers/openai.ts` | OpenAI-specific request builder + response normaliser |
 | `wp-ai-mind-proxy/src/providers/gemini.ts` | Gemini-specific request builder + response normaliser |
@@ -32,7 +33,7 @@
 |------|--------|
 | `wp-ai-mind-proxy/src/auth.ts` | `handleToken` + `handleRegister`: add rate limit check at entry |
 | `wp-ai-mind-proxy/src/chat.ts` | Refactor to use provider adapters + real SSE streaming via TransformStream |
-| `wp-ai-mind-proxy/src/types.ts` | Add `OPENAI_API_KEY` and `GEMINI_API_KEY` to `Env` interface |
+| `wp-ai-mind-proxy/src/types.ts` | Add `RATE_LIMITER` DO binding, `OPENAI_API_KEY`, and `GEMINI_API_KEY` to `Env` interface |
 | `wp-ai-mind-proxy/wrangler.toml` | Add `[env.staging]` block |
 
 ---
@@ -41,48 +42,66 @@
 
 ### Task 1: Rate limiter — tests first
 
+> **Why Durable Objects?** Cloudflare KV has eventual consistency: concurrent requests hitting
+> different edge nodes can each read a stale counter and all pass the `>= 10` check before any
+> increment propagates, breaking the security guarantee. Durable Objects are single-threaded and
+> strongly consistent — every `fetch()` to a given stub is serialised, making the counter
+> race-condition-free.
+
 - [ ] Create `wp-ai-mind-proxy/test/ratelimit.test.ts` with the following content:
 
 ```typescript
 import { describe, it, expect, vi } from 'vitest';
 import { checkLoginRateLimit } from '../src/ratelimit';
 
-// Mock Env
-function makeEnv(stored: string | null): any {
+// Mock a Durable Object stub that returns a given { allowed } response.
+function makeStub(allowed: boolean) {
     return {
-        USAGE_KV: {
-            get: vi.fn().mockResolvedValue(stored),
-            put: vi.fn().mockResolvedValue(undefined),
+        fetch: vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ allowed }), {
+                status:  200,
+                headers: { 'Content-Type': 'application/json' },
+            })
+        ),
+    };
+}
+
+function makeEnv(allowed: boolean): { RATE_LIMITER: any; _stub: ReturnType<typeof makeStub> } {
+    const stub = makeStub(allowed);
+    return {
+        RATE_LIMITER: {
+            idFromName: vi.fn().mockReturnValue('mock-do-id'),
+            get:        vi.fn().mockReturnValue(stub),
         },
+        _stub: stub,
     };
 }
 
 describe('checkLoginRateLimit', () => {
-    it('allows first attempt (no key in KV)', async () => {
-        const env = makeEnv(null);
-        const result = await checkLoginRateLimit(env, '1.2.3.4');
+    it('allows attempt when DO returns { allowed: true }', async () => {
+        const env    = makeEnv(true);
+        const result = await checkLoginRateLimit(env as any, '1.2.3.4');
         expect(result).toBe(true);
-        expect(env.USAGE_KV.put).toHaveBeenCalledWith(
-            'ratelimit:login:1.2.3.4', '1', { expirationTtl: 900 }
-        );
+        expect(env.RATE_LIMITER.idFromName).toHaveBeenCalledWith('login:1.2.3.4');
+        expect(env.RATE_LIMITER.get).toHaveBeenCalledWith('mock-do-id');
+        expect(env._stub.fetch).toHaveBeenCalledOnce();
     });
 
-    it('allows attempt 9 (below limit)', async () => {
-        const env = makeEnv('9');
-        const result = await checkLoginRateLimit(env, '1.2.3.4');
-        expect(result).toBe(true);
-    });
-
-    it('blocks attempt 10 (at limit)', async () => {
-        const env = makeEnv('10');
-        const result = await checkLoginRateLimit(env, '1.2.3.4');
+    it('blocks attempt when DO returns { allowed: false }', async () => {
+        const env    = makeEnv(false);
+        const result = await checkLoginRateLimit(env as any, '1.2.3.4');
         expect(result).toBe(false);
-        expect(env.USAGE_KV.put).not.toHaveBeenCalled();
     });
 
-    it('blocks attempts beyond limit', async () => {
-        const env = makeEnv('15');
-        const result = await checkLoginRateLimit(env, '1.2.3.4');
+    it('uses a per-IP DO instance (idFromName keyed on IP)', async () => {
+        const env = makeEnv(true);
+        await checkLoginRateLimit(env as any, '5.6.7.8');
+        expect(env.RATE_LIMITER.idFromName).toHaveBeenCalledWith('login:5.6.7.8');
+    });
+
+    it('returns false for unknown IP when DO blocks', async () => {
+        const env    = makeEnv(false);
+        const result = await checkLoginRateLimit(env as any, 'unknown');
         expect(result).toBe(false);
     });
 });
@@ -100,20 +119,63 @@ Expected output: `FAIL` — cannot find module `../src/ratelimit`
 
 ### Task 2: Rate limiter — implementation
 
+- [ ] Create `wp-ai-mind-proxy/src/rate-limiter-do.ts` (the Durable Object class):
+
+```typescript
+/**
+ * RateLimiterDO — Cloudflare Durable Object for strongly-consistent IP rate limiting.
+ *
+ * Each IP gets its own DO instance (keyed via `idFromName`). Because a DO is
+ * single-threaded, every fetch() call is serialised — there is no read-modify-write
+ * race condition that would exist with a KV-backed counter.
+ *
+ * State stored in DO storage:
+ *   count  — number of attempts in the current window
+ *   expiry — window expiry timestamp (ms since epoch)
+ */
+export class RateLimiterDO {
+    private readonly state: DurableObjectState;
+
+    constructor(state: DurableObjectState) {
+        this.state = state;
+    }
+
+    async fetch(_req: Request): Promise<Response> {
+        const MAX_ATTEMPTS   = 10;
+        const WINDOW_MS      = 900_000; // 15 minutes
+
+        const now    = Date.now();
+        let count:  number = (await this.state.storage.get<number>('count'))  ?? 0;
+        let expiry: number = (await this.state.storage.get<number>('expiry')) ?? 0;
+
+        // Reset counter when the window has elapsed.
+        if (now > expiry) {
+            count  = 0;
+            expiry = now + WINDOW_MS;
+            await this.state.storage.put('expiry', expiry);
+        }
+
+        if (count >= MAX_ATTEMPTS) {
+            return Response.json({ allowed: false });
+        }
+
+        await this.state.storage.put('count', count + 1);
+        return Response.json({ allowed: true });
+    }
+}
+```
+
 - [ ] Create `wp-ai-mind-proxy/src/ratelimit.ts`:
 
 ```typescript
 import type { Env } from './types';
 
-const MAX_ATTEMPTS   = 10;
-const WINDOW_SECONDS = 900; // 15 minutes
-
 export async function checkLoginRateLimit(env: Env, clientIP: string): Promise<boolean> {
-    const key     = `ratelimit:login:${clientIP}`;
-    const current = parseInt((await env.USAGE_KV.get(key)) ?? '0', 10);
-    if (current >= MAX_ATTEMPTS) return false;
-    await env.USAGE_KV.put(key, String(current + 1), { expirationTtl: WINDOW_SECONDS });
-    return true;
+    const id   = env.RATE_LIMITER.idFromName(`login:${clientIP}`);
+    const stub = env.RATE_LIMITER.get(id);
+    const resp = await stub.fetch('https://do/check');
+    const { allowed } = await resp.json<{ allowed: boolean }>();
+    return allowed;
 }
 ```
 
@@ -334,9 +396,10 @@ Expected: no errors
 
 ### Task 8: Update Env types + wrangler.toml for new provider secrets
 
-- [ ] Open `wp-ai-mind-proxy/src/types.ts` and add the two new API key fields to the `Env` interface:
+- [ ] Open `wp-ai-mind-proxy/src/types.ts` and add the Durable Object binding and the two new API key fields to the `Env` interface:
 
 ```typescript
+RATE_LIMITER:  DurableObjectNamespace;
 OPENAI_API_KEY: string;
 GEMINI_API_KEY: string;
 ```
@@ -346,12 +409,32 @@ The complete `Env` interface should now include (in addition to existing fields)
 ```typescript
 export interface Env {
     // ... existing fields ...
+    RATE_LIMITER:   DurableObjectNamespace;
     OPENAI_API_KEY: string;
     GEMINI_API_KEY: string;
 }
 ```
 
-- [ ] Open `wp-ai-mind-proxy/wrangler.toml` and append the staging environment block at the end of the file:
+- [ ] Open `wp-ai-mind-proxy/src/index.ts` (or wherever the Worker entry point exports bindings) and export the `RateLimiterDO` class so the runtime can instantiate it:
+
+```typescript
+export { RateLimiterDO } from './rate-limiter-do';
+```
+
+- [ ] Open `wp-ai-mind-proxy/wrangler.toml` and:
+  1. Add the Durable Object class declaration and binding to the **production** section (before any `[env.*]` blocks):
+
+```toml
+[[durable_objects.bindings]]
+name       = "RATE_LIMITER"
+class_name = "RateLimiterDO"
+
+[[migrations]]
+tag               = "v1"
+new_classes       = ["RateLimiterDO"]
+```
+
+  2. Append the staging environment block at the end of the file:
 
 ```toml
 [env.staging]
@@ -370,6 +453,10 @@ migrations_dir = "migrations"
 binding    = "USAGE_KV"
 id         = "<set after: wrangler kv:namespace create USAGE_KV_STAGING>"
 preview_id = "<set after: wrangler kv:namespace create USAGE_KV_STAGING --preview>"
+
+[[env.staging.durable_objects.bindings]]
+name       = "RATE_LIMITER"
+class_name = "RateLimiterDO"
 ```
 
 - [ ] Register the new secrets in Wrangler for both production and staging:
@@ -703,8 +790,8 @@ curl -X POST https://wp-ai-mind-proxy.YOUR_SUBDOMAIN.workers.dev/v1/chat \
 
 ## Acceptance Criteria
 
-- [ ] `POST /v1/auth/token` returns `429` after 10 attempts from the same IP within 15 minutes
-- [ ] `POST /v1/auth/register` is also rate-limited with the same 15-minute window
+- [ ] `POST /v1/auth/token` returns `429` after 10 attempts from the same IP within 15 minutes (enforced by `RateLimiterDO` — strongly consistent, no race condition)
+- [ ] `POST /v1/auth/register` is also rate-limited with the same 15-minute window via `RateLimiterDO`
 - [ ] Streaming: `POST /v1/chat` with `stream: true` returns `Content-Type: text/event-stream` with tokens arriving incrementally (verified via `wrangler dev` + curl)
 - [ ] OpenAI requests proxied correctly — model `gpt-4o-mini` routes via `openaiAdapter`
 - [ ] Gemini requests proxied correctly — model `gemini-1.5-flash` routes via `geminiAdapter`


### PR DESCRIPTION
## Summary

- Adds full technical architecture specification for the JWT auth + Cloudflare Worker proxy overhaul
- Adds 7-phase implementation plans covering CF Worker foundation, PHP auth/entitlement, chat webhooks, proxy routing, legacy removal, React auth UI, and CF Worker hardening
- Adds `.worktrees/` to `.gitignore` to keep worktree directories untracked

## Test plan

- [ ] Review architecture spec at `docs/plans/2026-04-17-wp-ai-mind-architecture-overhaul.md`
- [ ] Review each phase plan under `docs/plans/phases/`
- [ ] Confirm no code changes are included — this is documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)