### PR TITLE
fix(workflows): use $'...' quoting in issue body to render newlines correctly

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -94,9 +94,10 @@ jobs:
             Example command for a blocking issue (use this exact body format — the auto-fix
             workflow parses it to find the PR number and base branch):
 
+              # Use $'...' quoting so \n is interpreted as real newlines by bash (double quotes do not expand \n).
               ISSUE_URL=$(gh issue create \
                 --title "<concise title for the finding>" \
-                --body "Found during review of PR #${{ github.event.pull_request.number }}\n\n**PR:** ${{ github.event.pull_request.html_url }}\n**Base branch:** ${{ github.event.pull_request.base.ref }}\n\n## Description\n\n<details>" \
+                --body $'Found during review of PR #${{ github.event.pull_request.number }}\n\n**PR:** ${{ github.event.pull_request.html_url }}\n**Base branch:** ${{ github.event.pull_request.base.ref }}\n\n## Description\n\n<details>' \
                 --label "code-review,blocking" \
                 --repo ${{ github.repository }})
               ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')


### PR DESCRIPTION
## Summary
Fixed the GitHub Actions workflow to properly interpret newline characters (`\n`) in the issue body when creating blocking code review issues.

## Key Changes
- Changed the `--body` argument from double-quoted string to `$'...'` quoting syntax
- This ensures bash interprets `\n` escape sequences as actual newlines instead of literal characters
- Added explanatory comment documenting why `$'...'` quoting is necessary

## Implementation Details
The issue was that double quotes in bash do not expand `\n` escape sequences. By switching to ANSI-C quoting (`$'...'`), the newlines in the issue body are now properly interpreted, resulting in correctly formatted GitHub issues with proper line breaks between the PR reference, base branch information, and description section.

https://claude.ai/code/session_01Bpmq2ohcb6mEscGBBjEHv7