### PR TITLE
feat(auth): Phase 2.1 — site-token Bearer auth and zero-friction registration

### DIFF
--- a/.github/workflows/auto-fix-review-issue.yml
+++ b/.github/workflows/auto-fix-review-issue.yml
@@ -94,11 +94,36 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
 
-      - uses: anthropics/claude-code-action@aee99972d0cfa0c47a4563e6fca42d7a5a0cb9bd  # v1
+      # Pre-flight: checkout the target branch and install all dependencies so
+      # Claude's turn budget is spent on the actual fix, not infrastructure.
+      # For OPEN PRs we switch to the PR's head branch so Claude can commit
+      # directly. For CLOSED/MERGED PRs we stay on the base branch (main) so
+      # Claude can create a new fix branch from the correct base.
+      - name: Prepare workspace
+        id: workspace
         if: |
           steps.guard.outputs.skip != 'true' &&
           steps.parse.outputs.pr_number != '' &&
           steps.pr_state.outcome == 'success'
+        run: |
+          if [[ "${{ steps.pr_state.outputs.state }}" == "OPEN" ]]; then
+            git fetch origin ${{ steps.pr_state.outputs.head }}
+            git checkout ${{ steps.pr_state.outputs.head }}
+          else
+            git pull origin ${{ steps.parse.outputs.base_branch }}
+          fi
+          npm ci
+          composer install --no-interaction --prefer-dist
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+
+      - uses: anthropics/claude-code-action@aee99972d0cfa0c47a4563e6fca42d7a5a0cb9bd  # v1
+        id: claude
+        if: |
+          steps.guard.outputs.skip != 'true' &&
+          steps.parse.outputs.pr_number != '' &&
+          steps.pr_state.outcome == 'success' &&
+          steps.workspace.outcome == 'success'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -107,11 +132,14 @@ jobs:
 
             Read /tmp/issue-body.txt for the full description of what needs to be fixed.
 
-            **Context — already resolved, no further lookups needed:**
+            **Already done — no further lookups needed:**
             - Source PR: #${{ steps.parse.outputs.pr_number }}
             - PR state: **${{ steps.pr_state.outputs.state }}**
             - Head branch: `${{ steps.pr_state.outputs.head }}`
             - Base branch: `${{ steps.parse.outputs.base_branch }}`
+            - `node_modules/` and PHP vendor dependencies are already installed.
+            - **OPEN PR:** branch `${{ steps.pr_state.outputs.head }}` is already checked out — go directly to Step 2.
+            - **CLOSED/MERGED PR:** base branch `${{ steps.parse.outputs.base_branch }}` is checked out and up to date — create your fix branch in Step 2.
 
             ---
 
@@ -121,26 +149,26 @@ jobs:
 
               cat /tmp/issue-body.txt
 
+            **Important — stop early if the fix is ambiguous:** If you cannot determine
+            the correct fix purely from the codebase (e.g. the required value is an
+            external secret, account ID, variant ID, API key, or a business decision),
+            do NOT guess. Instead:
+            1. Post a comment on the issue explaining what specific information is needed.
+            2. Close the issue with: `gh issue close ${{ github.event.issue.number }} --comment "⚠️ Manual fix required: <one sentence explaining what information is needed>" --repo ${{ github.repository }}`
+            3. Stop — do not attempt to commit or push.
+
             ### Step 2 — Prepare the working branch
 
-            **If PR state is `OPEN`:**
-
-                git fetch origin ${{ steps.pr_state.outputs.head }} && \
-                  git checkout ${{ steps.pr_state.outputs.head }}
+            **If PR state is `OPEN`:** you are already on branch `${{ steps.pr_state.outputs.head }}` — skip to Step 3.
 
             **If PR state is `CLOSED` or `MERGED`:**
 
-                git fetch origin ${{ steps.parse.outputs.base_branch }}
-                git checkout ${{ steps.parse.outputs.base_branch }}
-                git pull origin ${{ steps.parse.outputs.base_branch }}
                 # Slugify the issue title: lowercase, spaces/slashes → hyphens, max 40 chars
                 git checkout -b fix/issue-${{ github.event.issue.number }}-<slug>
 
             ### Step 3 — Fix the problem
 
             Read the relevant source files and make the minimal change described in the issue.
-            Before committing, run `npm ci` if `node_modules/` is absent (required by the
-            pre-commit build hook which runs `npm run build` on every commit to `src/`).
 
             Commit:
 
@@ -183,4 +211,24 @@ jobs:
             - Do NOT bump version numbers, modify `composer.lock`, or change `package-lock.json`.
             - Do NOT open more than one PR per issue.
 
-          claude_args: "--max-turns 20 --allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"
+          claude_args: "--max-turns 25 --allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"
+
+      # Surface the actual failure reason when Claude hits max turns or errors out.
+      # The action's default error chain ("Execution failed: Action failed with error:
+      # Claude execution failed: Process completed with exit code 1") loses the
+      # meaningful subtype. We parse the execution log and post a clear issue comment.
+      - name: Report execution failure
+        if: failure() && steps.claude.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          LOG="/home/runner/work/_temp/claude-execution-output.json"
+          MSG="❌ Auto-fix failed for issue #${{ github.event.issue.number }}. Please fix manually."
+          if [[ -f "$LOG" ]] && grep -q 'error_max_turns' "$LOG"; then
+            TURNS=$(grep -oP '"num_turns":\s*\K\d+' "$LOG" | tail -1)
+            COST=$(grep -oP '"total_cost_usd":\s*\K[0-9.]+' "$LOG" | tail -1)
+            MSG="❌ Auto-fix hit the turn limit (${TURNS} turns used, cost: \$${COST}). The fix may be too complex or require information not available in the codebase. Please fix manually."
+          fi
+          gh issue comment ${{ github.event.issue.number }} \
+            --body "$MSG" \
+            --repo ${{ github.repository }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -105,8 +105,12 @@ jobs:
 
             Do NOT apply the `auto-fix` label yourself. A subsequent workflow step applies
             it via a PAT outside this action, which guarantees the `issues: labeled` webhook
-            fires correctly and triggers the auto-fix workflow. Just append each created
-            issue number (one per line) to /tmp/auto-fix-issues.txt.
+            fires correctly and triggers the auto-fix workflow. Only append an issue number
+            to /tmp/auto-fix-issues.txt if the fix is **self-contained** — i.e. Claude can
+            determine the correct fix purely from the codebase, without needing external
+            values such as API keys, account IDs, variant IDs, secrets, or business
+            decisions. Issues requiring such information must be fixed manually: create the
+            issue but do NOT write its number to /tmp/auto-fix-issues.txt.
 
             Capture the URL returned by each `gh issue create` call.
 

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 namespace WP_AI_Mind\Core;
 
 use WP_AI_Mind\DB\Schema;
+use WP_AI_Mind\Proxy\NJ_Site_Registration;
 
 class Plugin {
 
@@ -40,13 +41,15 @@ class Plugin {
 
 	private function init_hooks(): void {
 		add_action( 'init', [ $this, 'load_textdomain' ] );
+		add_action( 'init', [ NJ_Site_Registration::class, 'maybe_register' ] );
 		add_action( 'admin_menu', [ $this, 'register_admin_menu' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
 		add_action( 'wp_ai_mind_trial_check', [ \WP_AI_Mind\Tiers\NJ_Tier_Manager::class, 'maybe_demote_expired_trials' ] );
 		add_action( 'wp_ai_mind_register_menu', [ \WP_AI_Mind\Admin\AdminMenu::class, 'register' ] );
 		add_action( 'wp_ai_mind_register_rest_routes', [ \WP_AI_Mind\Admin\OnboardingRestController::class, 'register_routes' ] );
 		add_action( 'wp_ai_mind_register_rest_routes', [ \WP_AI_Mind\Admin\TestKeyRestController::class, 'register_routes' ] );
-		add_action( 'wp_ai_mind_register_rest_routes', [ \WP_AI_Mind\Payments\NJ_LemonSqueezy_Webhook::class, 'register_routes' ] );
+		// Deprecated in Phase 2.1: LemonSqueezy webhook is now handled by the Cloudflare Worker.
+		// add_action( 'wp_ai_mind_register_rest_routes', [ \WP_AI_Mind\Payments\NJ_LemonSqueezy_Webhook::class, 'register_routes' ] );
 		\WP_AI_Mind\Admin\NJ_Tier_Status_Page::register_hooks();
 		\WP_AI_Mind\Admin\NJ_Api_Key_Settings::register_hooks();
 		\WP_AI_Mind\Admin\ActivationNotice::register();

--- a/includes/Providers/AbstractProvider.php
+++ b/includes/Providers/AbstractProvider.php
@@ -88,7 +88,7 @@ abstract class AbstractProvider implements ProviderInterface {
 
 	// ── Usage logging ─────────────────────────────────────────────────────────
 
-	private function maybe_log( CompletionRequest $request, CompletionResponse $response ): void {
+	protected function maybe_log( CompletionRequest $request, CompletionResponse $response ): void {
 		NJ_Usage_Tracker::log_usage( $response->total_tokens );
 	}
 }

--- a/includes/Providers/ClaudeProvider.php
+++ b/includes/Providers/ClaudeProvider.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
 use WP_AI_Mind\Proxy\NJ_Proxy_Client;
+use WP_AI_Mind\Proxy\NJ_Site_Registration;
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 
 class ClaudeProvider extends AbstractProvider {
@@ -46,7 +47,13 @@ class ClaudeProvider extends AbstractProvider {
 	public function get_default_model(): string {
 		return self::DEFAULT_MODEL; }
 	public function is_available(): bool {
-		return '' !== $this->api_key; }
+		if ( '' !== $this->api_key ) {
+			return true;
+		}
+		$tier = NJ_Tier_Manager::get_user_tier( get_current_user_id() );
+		return in_array( $tier, [ 'free', 'trial', 'pro_managed' ], true )
+			&& NJ_Site_Registration::is_registered();
+	}
 
 	/**
 	 * Route completion by tier:

--- a/includes/Providers/ClaudeProvider.php
+++ b/includes/Providers/ClaudeProvider.php
@@ -3,6 +3,9 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
+use WP_AI_Mind\Proxy\NJ_Proxy_Client;
+use WP_AI_Mind\Tiers\NJ_Tier_Manager;
+
 class ClaudeProvider extends AbstractProvider {
 
 	private const API_BASE      = 'https://api.anthropic.com/v1';
@@ -31,6 +34,9 @@ class ClaudeProvider extends AbstractProvider {
 		],
 	];
 
+	/** Tracks whether the proxy handled logging so maybe_log() can skip double-logging. */
+	private bool $proxy_logged = false;
+
 	public function __construct( private readonly string $api_key ) {}
 
 	public function get_slug(): string {
@@ -42,10 +48,59 @@ class ClaudeProvider extends AbstractProvider {
 	public function is_available(): bool {
 		return '' !== $this->api_key; }
 
+	/**
+	 * Route completion by tier:
+	 *   - free / trial / pro_managed → proxy (NJ_Proxy_Client handles usage logging)
+	 *   - pro_byok                   → direct Anthropic API call (AbstractProvider logs usage)
+	 */
 	protected function do_complete( CompletionRequest $request ): CompletionResponse {
-		$body = $this->build_body( $request );
-		$raw  = $this->post( '/messages', $body );
+		$tier = NJ_Tier_Manager::get_user_tier( get_current_user_id() );
+
+		if ( in_array( $tier, [ 'free', 'trial', 'pro_managed' ], true ) ) {
+			return $this->complete_via_proxy( $request );
+		}
+
+		// pro_byok — direct Anthropic API call; AbstractProvider::complete() will log usage.
+		$this->proxy_logged = false;
+		$body               = $this->build_body( $request );
+		$raw                = $this->post( '/messages', $body );
 		return $this->parse_response( $raw, $request );
+	}
+
+	/**
+	 * Suppress AbstractProvider usage logging when the proxy already logged it.
+	 *
+	 * @param CompletionRequest  $request
+	 * @param CompletionResponse $response
+	 */
+	protected function maybe_log( CompletionRequest $request, CompletionResponse $response ): void {
+		if ( $this->proxy_logged ) {
+			$this->proxy_logged = false; // Reset for re-use.
+			return;
+		}
+		parent::maybe_log( $request, $response );
+	}
+
+	private function complete_via_proxy( CompletionRequest $request ): CompletionResponse {
+		$result = NJ_Proxy_Client::chat(
+			$request->messages,
+			array_filter(
+				[
+					'model'      => ! empty( $request->model ) ? $request->model : null,
+					'max_tokens' => $request->max_tokens,
+					'system'     => '' !== $request->system ? $request->system : null,
+				],
+				fn( $v ) => null !== $v
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			throw new ProviderException( $result->get_error_message(), 'claude' ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		// NJ_Proxy_Client::chat() already called NJ_Usage_Tracker::log_usage() — flag to suppress parent logging.
+		$this->proxy_logged = true;
+		return $this->parse_response( $result, $request );
 	}
 
 	protected function do_stream( CompletionRequest $request, callable $on_chunk ): CompletionResponse {
@@ -113,7 +168,7 @@ class ClaudeProvider extends AbstractProvider {
 		return $data;
 	}
 
-	private function parse_response( array $data, CompletionRequest $request ): CompletionResponse {
+	protected function parse_response( array $data, CompletionRequest $request ): CompletionResponse {
 		$model      = $data['model'] ?? ( ! empty( $request->model ) ? $request->model : self::DEFAULT_MODEL );
 		$in_tokens  = (int) ( $data['usage']['input_tokens'] ?? 0 );
 		$out_tokens = (int) ( $data['usage']['output_tokens'] ?? 0 );

--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace WP_AI_Mind\Proxy;
 
 use WP_Error;
+use WP_AI_Mind\Tiers\NJ_Tier_Config;
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 use WP_AI_Mind\Tiers\NJ_Usage_Tracker;
 
@@ -12,58 +13,60 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Sends signed requests to the Cloudflare Worker proxy for Free/Trial/Pro Managed users.
- * Pro BYOK tier bypasses this class entirely and routes directly through ClaudeProvider.
+ * Sends Bearer-token-authenticated requests to the Cloudflare Worker proxy.
+ *
+ * Free/Trial/Pro Managed users are routed through this class.
+ * Pro BYOK tier bypasses this class entirely and routes via ClaudeProvider.
  */
 class NJ_Proxy_Client {
-
-	private static function get_proxy_url(): string {
-		if ( defined( 'WP_AI_MIND_PROXY_URL' ) && '' !== WP_AI_MIND_PROXY_URL ) {
-			return WP_AI_MIND_PROXY_URL;
-		}
-		return (string) get_option( 'wp_ai_mind_proxy_url', '' );
-	}
 
 	/**
 	 * Send a chat request through the Cloudflare proxy.
 	 *
 	 * @param array<array{role: string, content: string}> $messages
-	 * @param array<string, mixed>                        $options  Supports 'model', 'max_tokens'.
+	 * @param array<string, mixed>                        $options  Supports 'model', 'max_tokens', 'system'.
 	 * @return array<string, mixed>|WP_Error
 	 */
 	public static function chat( array $messages, array $options = [] ): array|WP_Error {
-		$url = self::get_proxy_url();
-		if ( empty( $url ) ) {
-			return new WP_Error( 'proxy_not_configured', __( 'Proxy URL not configured.', 'wp-ai-mind' ) );
+		$token = NJ_Site_Registration::get_site_token();
+		if ( empty( $token ) ) {
+			return new WP_Error( 'not_registered', __( 'Site not registered with AI proxy.', 'wp-ai-mind' ) );
 		}
 
 		$user_id = get_current_user_id();
-		$tier    = NJ_Tier_Manager::get_user_tier( $user_id );
 
-		// Fail-fast pre-check using local meta. Cloudflare KV is the authoritative limit.
+		// Fail-fast pre-check (WordPress meta). Cloudflare KV is authoritative for enforcement.
 		if ( ! NJ_Usage_Tracker::check_limit( $user_id ) ) {
 			return new WP_Error( 'rate_limit_exceeded', __( 'Monthly usage limit reached.', 'wp-ai-mind' ) );
 		}
 
 		$payload = [
-			'user_id'    => $user_id,
-			'tier'       => $tier,
-			'messages'   => $messages,
-			'model'      => $options['model'] ?? null,
-			'max_tokens' => $options['max_tokens'] ?? null,
+			'user_id'  => $user_id,
+			'tier'     => NJ_Tier_Manager::get_user_tier( $user_id ),
+			'messages' => $messages,
 		];
 
-		$body_json = wp_json_encode( $payload );
+		if ( isset( $options['model'] ) ) {
+			$payload['model'] = $options['model'];
+		}
+		if ( isset( $options['max_tokens'] ) ) {
+			$payload['max_tokens'] = $options['max_tokens'];
+		}
+		if ( isset( $options['system'] ) ) {
+			$payload['system'] = $options['system'];
+		}
+
+			$body_json = wp_json_encode( $payload );
 		if ( false === $body_json ) {
 			return new WP_Error( 'json_encode_failed', __( 'Failed to encode request payload.', 'wp-ai-mind' ) );
 		}
 
 		$response = wp_remote_post(
-			trailingslashit( $url ) . 'v1/chat',
+			NJ_Tier_Config::PROXY_URL . '/v1/chat',
 			[
 				'headers' => [
-					'Content-Type'   => 'application/json',
-					'X-WP-Signature' => self::sign( $body_json ),
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Bearer ' . $token,
 				],
 				'body'    => $body_json,
 				'timeout' => 60,
@@ -81,6 +84,12 @@ class NJ_Proxy_Client {
 			return new WP_Error( 'rate_limit_exceeded', __( 'Monthly usage limit reached.', 'wp-ai-mind' ) );
 		}
 
+		if ( 401 === $code ) {
+			// Token may be stale — clear it so maybe_register() re-issues on next init.
+			delete_option( 'wp_ai_mind_site_token' );
+			return new WP_Error( 'proxy_auth_failed', __( 'Proxy authentication failed. Please try again.', 'wp-ai-mind' ) );
+		}
+
 		if ( $code < 200 || $code >= 300 ) {
 			return new WP_Error( 'proxy_error', $body['error'] ?? sprintf( 'Proxy returned HTTP %d', $code ) );
 		}
@@ -92,14 +101,5 @@ class NJ_Proxy_Client {
 		}
 
 		return $body;
-	}
-
-	private static function sign( string $body ): string {
-		if ( ! defined( 'WP_AI_MIND_PROXY_SECRET' ) || '' === WP_AI_MIND_PROXY_SECRET ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( '[WP AI Mind] WP_AI_MIND_PROXY_SECRET is not defined in wp-config.php' );
-			return ''; // Worker will reject the request with 401 — misconfiguration is visible in logs.
-		}
-		return hash_hmac( 'sha256', $body, WP_AI_MIND_PROXY_SECRET );
 	}
 }

--- a/includes/Proxy/NJ_Site_Registration.php
+++ b/includes/Proxy/NJ_Site_Registration.php
@@ -41,13 +41,20 @@ class NJ_Site_Registration {
 	 * Idempotent — skips silently if a token is already stored.
 	 * Hooked to `init` in Plugin.php.
 	 */
+	private const TRANSIENT_BACKOFF = 'wp_ai_mind_reg_backoff';
+
 	public static function maybe_register(): void {
 		if ( self::is_registered() ) {
 			return;
 		}
 
+		if ( get_transient( self::TRANSIENT_BACKOFF ) ) {
+			return;
+		}
+
 		$result = self::register();
 		if ( is_wp_error( $result ) ) {
+			set_transient( self::TRANSIENT_BACKOFF, 1, 5 * MINUTE_IN_SECONDS );
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( '[WP AI Mind] Site registration failed: ' . $result->get_error_message() );
 		}

--- a/includes/Proxy/NJ_Site_Registration.php
+++ b/includes/Proxy/NJ_Site_Registration.php
@@ -1,0 +1,103 @@
+<?php
+declare( strict_types=1 );
+
+namespace WP_AI_Mind\Proxy;
+
+use WP_Error;
+use WP_AI_Mind\Tiers\NJ_Tier_Config;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles auto-registration of this site with the Cloudflare Worker proxy.
+ *
+ * On first activation the site sends its home URL to the /register endpoint
+ * and stores the returned token in wp_options. Subsequent requests use
+ * this token for Bearer authentication.
+ */
+class NJ_Site_Registration {
+
+	private const OPTION_TOKEN = 'wp_ai_mind_site_token';
+
+	/**
+	 * Return the stored site token, or an empty string if not yet registered.
+	 */
+	public static function get_site_token(): string {
+		return (string) get_option( self::OPTION_TOKEN, '' );
+	}
+
+	/**
+	 * Return true when a site token is present.
+	 */
+	public static function is_registered(): bool {
+		return '' !== self::get_site_token();
+	}
+
+	/**
+	 * Register with the proxy Worker if not already registered.
+	 *
+	 * Idempotent — skips silently if a token is already stored.
+	 * Hooked to `init` in Plugin.php.
+	 */
+	public static function maybe_register(): void {
+		if ( self::is_registered() ) {
+			return;
+		}
+
+		$result = self::register();
+		if ( is_wp_error( $result ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( '[WP AI Mind] Site registration failed: ' . $result->get_error_message() );
+		}
+	}
+
+	/**
+	 * Send a registration request to the proxy Worker.
+	 *
+	 * @return string|WP_Error The stored site token on success, or a WP_Error on failure.
+	 */
+	public static function register(): string|WP_Error {
+		$response = wp_remote_post(
+			NJ_Tier_Config::PROXY_URL . '/register',
+			[
+				'headers' => [ 'Content-Type' => 'application/json' ],
+				'body'    => wp_json_encode( [ 'site_url' => home_url() ] ),
+				'timeout' => 15,
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+		$body = json_decode( wp_remote_retrieve_body( $response ), true ) ?? [];
+
+		if ( ( 200 !== $code && 201 !== $code ) || empty( $body['token'] ) ) {
+			return new WP_Error( 'registration_failed', "Proxy registration returned HTTP {$code}" );
+		}
+
+		update_option( self::OPTION_TOKEN, sanitize_text_field( $body['token'] ) );
+		return $body['token'];
+	}
+
+	/**
+	 * Build a LemonSqueezy checkout URL for the given variant ID.
+	 *
+	 * Embeds the site token as a custom checkout field so the Worker can
+	 * associate the purchase with this installation automatically.
+	 *
+	 * @param string $variant_id The LemonSqueezy product variant ID.
+	 * @return string The fully-formed checkout URL.
+	 */
+	public static function checkout_url( string $variant_id ): string {
+		$token = self::get_site_token();
+		$url   = 'https://wp-ai-mind.lemonsqueezy.com/checkout/buy/' . rawurlencode( $variant_id );
+		if ( $token ) {
+			$url .= '?checkout[custom][site_token]=' . rawurlencode( $token );
+		}
+		return $url;
+	}
+}

--- a/includes/Tiers/NJ_Tier_Config.php
+++ b/includes/Tiers/NJ_Tier_Config.php
@@ -43,7 +43,7 @@ class NJ_Tier_Config {
 		'pro_byok'    => null,
 	];
 
-	const TRIAL_DAYS = 7;
+	const TRIAL_DAYS = 30;
 
 	public static function get_valid_tiers(): array {
 		return self::TIERS;

--- a/includes/Tiers/NJ_Tier_Config.php
+++ b/includes/Tiers/NJ_Tier_Config.php
@@ -45,6 +45,8 @@ class NJ_Tier_Config {
 
 	const TRIAL_DAYS = 30;
 
+	const PROXY_URL = 'https://wp-ai-mind-proxy.wp-ai-mind.workers.dev';
+
 	public static function get_valid_tiers(): array {
 		return self::TIERS;
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13561,9 +13561,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,13 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="tests/bootstrap.php"
-         colors="true"
-         testdox="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true" testdox="true">
   <testsuites>
     <testsuite name="Unit">
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <coverage>
+  <source>
     <include>
       <directory suffix=".php">includes</directory>
     </include>
-  </coverage>
+  </source>
 </phpunit>

--- a/tests/Unit/Providers/ClaudeProviderTest.php
+++ b/tests/Unit/Providers/ClaudeProviderTest.php
@@ -36,6 +36,9 @@ class ClaudeProviderTest extends TestCase {
 	}
 
 	public function test_is_available_false_without_key(): void {
+		// No API key and user is pro_byok (not proxy-routed) → unavailable.
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
 		$provider = new ClaudeProvider( '' );
 		$this->assertFalse( $provider->is_available() );
 	}
@@ -43,6 +46,24 @@ class ClaudeProviderTest extends TestCase {
 	public function test_is_available_true_with_key(): void {
 		$provider = new ClaudeProvider( 'sk-ant-test' );
 		$this->assertTrue( $provider->is_available() );
+	}
+
+	public function test_is_available_true_for_proxy_tier_with_registered_site(): void {
+		// No API key, free tier, site registered → proxy-routed users are available.
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'free' );
+		Functions\when( 'get_option' )->justReturn( 'some-token' );
+		$provider = new ClaudeProvider( '' );
+		$this->assertTrue( $provider->is_available() );
+	}
+
+	public function test_is_available_false_for_proxy_tier_without_registration(): void {
+		// No API key, free tier, but site not registered → unavailable.
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'free' );
+		Functions\when( 'get_option' )->justReturn( '' );
+		$provider = new ClaudeProvider( '' );
+		$this->assertFalse( $provider->is_available() );
 	}
 
 	public function test_complete_parses_response(): void {

--- a/tests/Unit/Providers/ClaudeProviderTest.php
+++ b/tests/Unit/Providers/ClaudeProviderTest.php
@@ -24,6 +24,8 @@ class ClaudeProviderTest extends TestCase {
 			public function query( string $sql ): int { return 1; }
 		};
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		// Return 'pro_byok' so routing goes direct — preserving existing test behaviour.
+		Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
 		Functions\when( 'sanitize_key' )->alias( fn($v) => $v );
 		Functions\when( 'sanitize_text_field' )->alias( fn($v) => $v );
 	}
@@ -67,6 +69,10 @@ class ClaudeProviderTest extends TestCase {
 	}
 
 	public function test_complete_throws_on_api_error(): void {
+		// Stub tier resolution so routing goes direct (pro_byok path).
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
+
 		Functions\when( 'wp_remote_post' )->justReturn( [
 			'response' => [ 'code' => 401 ],
 			'body'     => json_encode( [ 'error' => [ 'message' => 'Unauthorised' ] ] ),
@@ -136,6 +142,73 @@ class ClaudeProviderTest extends TestCase {
 
 		$this->assertFalse( $response->is_tool_call() );
 		$this->assertNull( $response->tool_call );
+	}
+
+	public function test_complete_routes_free_tier_to_proxy_returns_error_when_not_registered(): void {
+		// Mock get_current_user_id — called by NJ_Tier_Manager::get_user_tier() and NJ_Proxy_Client::chat().
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+		// Mock get_user_meta to return 'free' tier (called by NJ_Tier_Manager::get_user_tier()).
+		Functions\when( 'get_user_meta' )
+			->justReturn( 'free' );
+
+		// Mock get_option to return empty token (site not registered — called by NJ_Site_Registration::get_site_token()).
+		Functions\when( 'get_option' )
+			->justReturn( '' );
+
+		// is_wp_error must return true when passed the WP_Error returned by NJ_Proxy_Client::chat().
+		Functions\when( 'is_wp_error' )->alias( fn( $v ) => $v instanceof \WP_Error );
+
+		// Stub translation functions used inside NJ_Proxy_Client::chat().
+		Functions\stubs( [ '__' => fn( $str ) => $str ] );
+
+		$provider = new ClaudeProvider( 'test-api-key' );
+		$request  = new CompletionRequest(
+			messages: [ [ 'role' => 'user', 'content' => 'Hi' ] ],
+			max_tokens: 100,
+		);
+
+		// For a free-tier user, do_complete() routes through NJ_Proxy_Client.
+		// NJ_Proxy_Client::chat() returns WP_Error('not_registered') when site token is missing.
+		// ClaudeProvider converts this WP_Error to a ProviderException.
+		$this->expectException( ProviderException::class );
+		$provider->complete( $request );
+	}
+
+	public function test_complete_routes_pro_byok_direct_not_via_proxy(): void {
+		// Mock get_current_user_id — called by NJ_Tier_Manager::get_user_tier().
+		Functions\when( 'get_current_user_id' )->justReturn( 2 );
+
+		// Mock get_user_meta to return 'pro_byok' tier.
+		Functions\when( 'get_user_meta' )
+			->justReturn( 'pro_byok' );
+
+		// pro_byok users route to parent::do_complete() which calls wp_remote_post directly.
+		// Stub wp_remote_post to return a valid response.
+		Functions\when( 'wp_remote_post' )->justReturn( [
+			'response' => [ 'code' => 200 ],
+			'body'     => json_encode( [
+				'content' => [ [ 'type' => 'text', 'text' => 'Direct API response' ] ],
+				'model'   => 'claude-sonnet-4-6',
+				'usage'   => [ 'input_tokens' => 10, 'output_tokens' => 5 ],
+			] ),
+		] );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->alias( fn( $r ) => $r['body'] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+		$this->mock_wpdb();
+
+		$provider = new ClaudeProvider( 'sk-ant-byok-key' );
+		$request  = new CompletionRequest(
+			messages: [ [ 'role' => 'user', 'content' => 'Hi' ] ],
+			max_tokens: 100,
+		);
+
+		$response = $provider->complete( $request );
+
+		// Verify it returned a direct API result (not a proxy result).
+		$this->assertSame( 'Direct API response', $response->content );
 	}
 
 	public function test_tools_injected_in_request_body(): void {

--- a/tests/Unit/Proxy/NJProxyClientTest.php
+++ b/tests/Unit/Proxy/NJProxyClientTest.php
@@ -1,0 +1,35 @@
+<?php
+declare( strict_types=1 );
+
+namespace WP_AI_Mind\Tests\Unit\Proxy;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_AI_Mind\Proxy\NJ_Proxy_Client;
+
+class NJProxyClientTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_chat_returns_error_when_not_registered(): void {
+		Functions\expect( 'get_option' )
+			->with( 'wp_ai_mind_site_token', '' )
+			->andReturn( '' );
+
+		Functions\when( '__' )->alias( fn( $s ) => $s );
+
+		$result = NJ_Proxy_Client::chat( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'not_registered', $result->code );
+	}
+}

--- a/tests/Unit/Proxy/NJSiteRegistrationTest.php
+++ b/tests/Unit/Proxy/NJSiteRegistrationTest.php
@@ -1,0 +1,65 @@
+<?php
+declare( strict_types=1 );
+
+namespace WP_AI_Mind\Tests\Unit\Proxy;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_AI_Mind\Proxy\NJ_Site_Registration;
+
+class NJSiteRegistrationTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function test_get_site_token_returns_stored_token(): void {
+		Functions\expect( 'get_option' )
+			->with( 'wp_ai_mind_site_token', '' )
+			->andReturn( 'abc123' );
+
+		$this->assertSame( 'abc123', NJ_Site_Registration::get_site_token() );
+	}
+
+	public function test_get_site_token_returns_empty_string_when_not_registered(): void {
+		Functions\expect( 'get_option' )
+			->with( 'wp_ai_mind_site_token', '' )
+			->andReturn( '' );
+
+		$this->assertSame( '', NJ_Site_Registration::get_site_token() );
+	}
+
+	public function test_is_registered_returns_true_when_token_exists(): void {
+		Functions\expect( 'get_option' )
+			->with( 'wp_ai_mind_site_token', '' )
+			->andReturn( 'some-token' );
+
+		$this->assertTrue( NJ_Site_Registration::is_registered() );
+	}
+
+	public function test_is_registered_returns_false_when_no_token(): void {
+		Functions\expect( 'get_option' )
+			->with( 'wp_ai_mind_site_token', '' )
+			->andReturn( '' );
+
+		$this->assertFalse( NJ_Site_Registration::is_registered() );
+	}
+
+	public function test_checkout_url_embeds_site_token(): void {
+		Functions\expect( 'get_option' )
+			->with( 'wp_ai_mind_site_token', '' )
+			->andReturn( 'mytoken' );
+
+		$url = NJ_Site_Registration::checkout_url( 'variant-abc' );
+
+		$this->assertStringContainsString( 'variant-abc', $url );
+		$this->assertStringContainsString( 'mytoken', $url );
+	}
+}

--- a/tests/Unit/Tiers/NJTierManagerTest.php
+++ b/tests/Unit/Tiers/NJTierManagerTest.php
@@ -113,12 +113,20 @@ class NJTierManagerTest extends TestCase {
 		$this->assertTrue( NJ_Tier_Manager::is_trial_active( 6 ) );
 	}
 
-	public function test_is_trial_active_returns_false_after_seven_days(): void {
-		$started = time() - ( 8 * DAY_IN_SECONDS );
+	public function test_is_trial_active_returns_false_after_thirty_days(): void {
+		$started = time() - ( 31 * DAY_IN_SECONDS );
 		Functions\expect( 'get_user_meta' )->once()->with( 6, 'wp_ai_mind_tier', true )->andReturn( 'trial' );
 		Functions\expect( 'get_user_meta' )->once()->with( 6, 'wp_ai_mind_trial_started', true )->andReturn( (string) $started );
 
 		$this->assertFalse( NJ_Tier_Manager::is_trial_active( 6 ) );
+	}
+
+	public function test_is_trial_active_returns_true_within_thirty_days(): void {
+		$started = time() - ( 29 * DAY_IN_SECONDS );
+		Functions\expect( 'get_user_meta' )->once()->with( 6, 'wp_ai_mind_tier', true )->andReturn( 'trial' );
+		Functions\expect( 'get_user_meta' )->once()->with( 6, 'wp_ai_mind_trial_started', true )->andReturn( (string) $started );
+
+		$this->assertTrue( NJ_Tier_Manager::is_trial_active( 6 ) );
 	}
 
 	public function test_tier_config_has_four_tiers(): void {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,6 +31,12 @@ if ( ! class_exists( 'WP_Error' ) ) {
 			$this->code    = $code;
 			$this->message = $message;
 		}
+		public function get_error_message(): string {
+			return $this->message;
+		}
+		public function get_error_code(): string {
+			return $this->code;
+		}
 	}
 }
 

--- a/wp-ai-mind-proxy/.gitignore
+++ b/wp-ai-mind-proxy/.gitignore
@@ -1,0 +1,1 @@
+.worktrees/

--- a/wp-ai-mind-proxy/.gitignore
+++ b/wp-ai-mind-proxy/.gitignore
@@ -1,1 +1,0 @@
-.worktrees/

--- a/wp-ai-mind-proxy/src/auth.ts
+++ b/wp-ai-mind-proxy/src/auth.ts
@@ -1,0 +1,45 @@
+// src/auth.ts
+
+import { Env, SiteRecord, ProxyTier } from './types';
+
+export interface AuthResult {
+  authenticated: boolean;
+  site_token?: string;
+  tier?: ProxyTier;
+  site_url?: string;
+}
+
+export async function authenticateRequest(
+  request: Request,
+  env: Env
+): Promise<AuthResult> {
+  const authHeader = request.headers.get('Authorization') ?? '';
+  if (!authHeader.startsWith('Bearer ')) {
+    return { authenticated: false };
+  }
+
+  const token = authHeader.slice(7).trim();
+  if (!token) {
+    return { authenticated: false };
+  }
+
+  const record = await env.USAGE_KV.get<SiteRecord>(`site:${token}`, 'json');
+  if (!record) {
+    return { authenticated: false };
+  }
+
+  return {
+    authenticated: true,
+    site_token: token,
+    tier: record.tier,
+    site_url: record.site_url,
+  };
+}
+
+export function generateToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/wp-ai-mind-proxy/src/index.ts
+++ b/wp-ai-mind-proxy/src/index.ts
@@ -1,158 +1,155 @@
-import type { Env, ProxyRequest, ProxyTier } from './types';
-import { verifySignature } from './signature';
+// src/index.ts
+
+import { Env, ProxyRequest, ProxyTier } from './types';
+import { authenticateRequest } from './auth';
+import { handleRegistration } from './registration';
+import { handleWebhook } from './webhook';
+
+const MAX_BODY_BYTES = 1_048_576; // 1 MB
 
 export default {
-	async fetch( request: Request, env: Env ): Promise<Response> {
-		if ( request.method !== 'POST' ) {
-			return jsonResponse( { error: 'Method not allowed' }, 405 );
-		}
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method !== 'POST') {
+      return jsonResponse({ error: 'Method not allowed' }, 405);
+    }
 
-		const url = new URL( request.url );
-		if ( url.pathname === '/v1/chat' ) {
-			return handleChatProxy( request, env );
-		}
+    const { pathname } = new URL(request.url);
 
-		return jsonResponse( { error: 'Not found' }, 404 );
-	},
+    if (pathname === '/register') return handleRegistration(request, env);
+    if (pathname === '/webhook')  return handleWebhook(request, env);
+    if (pathname === '/v1/chat')  return handleChatProxy(request, env);
+
+    return jsonResponse({ error: 'Not found' }, 404);
+  },
 };
 
-const MAX_BODY_BYTES = 1_048_576; // 1 MB — guards against oversized message arrays
+async function handleChatProxy(request: Request, env: Env): Promise<Response> {
+  try {
+    const auth = await authenticateRequest(request, env);
+    if (!auth.authenticated || !auth.site_token || !auth.tier) {
+      return jsonResponse({ error: 'Unauthorised' }, 401);
+    }
 
-async function handleChatProxy( request: Request, env: Env ): Promise<Response> {
-	try {
-		const contentLength = parseInt( request.headers.get( 'Content-Length' ) ?? '0', 10 );
-		if ( contentLength > MAX_BODY_BYTES ) {
-			return jsonResponse( { error: 'Request body too large' }, 413 );
-		}
+    const contentLength = Number(request.headers.get('Content-Length') ?? 0);
+    if (contentLength > MAX_BODY_BYTES) {
+      return jsonResponse({ error: 'Request too large' }, 413);
+    }
 
-		// Read raw body before parsing — signature covers the exact bytes WordPress sent.
-		const bodyText = await request.text();
-		const signature = request.headers.get( 'X-WP-Signature' ) ?? '';
+    const bodyText = await request.text();
+    if (new TextEncoder().encode(bodyText).length > MAX_BODY_BYTES) {
+      return jsonResponse({ error: 'Request too large' }, 413);
+    }
 
-		if ( ! signature || ! ( await verifySignature( bodyText, signature, env ) ) ) {
-			return jsonResponse( { error: 'Invalid signature' }, 401 );
-		}
+    const body = JSON.parse(bodyText) as ProxyRequest;
+    const { messages, model, max_tokens, system } = body;
+    const { site_token, tier } = auth;
 
-		const body = JSON.parse( bodyText ) as ProxyRequest;
-		const { user_id, tier, messages, model, max_tokens } = body;
+    const rateLimitCheck = await checkRateLimit(site_token, tier, env);
+    if (!rateLimitCheck.allowed) {
+      return jsonResponse({
+        error: 'Rate limit exceeded',
+        used: rateLimitCheck.used,
+        limit: rateLimitCheck.limit,
+      }, 429);
+    }
 
-		// Validate tier is one we proxy for.
-		const validTiers: ProxyTier[] = [ 'free', 'trial', 'pro_managed' ];
-		if ( ! validTiers.includes( tier ) ) {
-			return jsonResponse( { error: 'Invalid tier for proxy' }, 400 );
-		}
+    const selectedModel = getModelForTier(tier, model);
+    const maxTokens = Math.min(
+      max_tokens ?? (tier === 'free' ? 1000 : 4000),
+      MAX_TOKENS[tier]
+    );
 
-		// KV is the authoritative rate limit. WordPress pre-check is a fail-fast optimisation.
-		const limitCheck = await checkRateLimit( user_id, tier, env );
-		if ( ! limitCheck.allowed ) {
-			return jsonResponse(
-				{ error: 'Rate limit exceeded', used: limitCheck.used, limit: limitCheck.limit },
-				429,
-			);
-		}
+    const anthropicBody: Record<string, unknown> = {
+      model: selectedModel,
+      max_tokens: maxTokens,
+      messages,
+    };
+    if (system) anthropicBody['system'] = system;
 
-		// Enforce model selection per tier regardless of what WordPress requested.
-		const selectedModel = getModelForTier( tier, model );
+    const anthropicResponse = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(anthropicBody),
+    });
 
-		// Clamp max_tokens to a per-tier ceiling so a large client-supplied value
-		// cannot consume far more tokens than the per-response default allows.
-		const resolvedMaxTokens = Math.min( max_tokens ?? MAX_TOKENS[ tier ], MAX_TOKENS[ tier ] );
+    const result = await anthropicResponse.json() as Record<string, unknown>;
 
-		const anthropicResponse = await fetch( 'https://api.anthropic.com/v1/messages', {
-			method: 'POST',
-			headers: {
-				'x-api-key': env.ANTHROPIC_API_KEY,
-				'anthropic-version': '2023-06-01',
-				'content-type': 'application/json',
-			},
-			body: JSON.stringify( {
-				model: selectedModel,
-				max_tokens: resolvedMaxTokens,
-				messages,
-			} ),
-		} );
+    if (anthropicResponse.ok && result['usage']) {
+      const usage = result['usage'] as { input_tokens: number; output_tokens: number };
+      await updateUsage(site_token, usage.input_tokens + usage.output_tokens, env);
+    }
 
-		const result = await anthropicResponse.json() as Record<string, unknown>;
-
-		// Update KV usage counter after a successful Anthropic response.
-		// Pass limitCheck.used to avoid a second KV read (prevents under-counting under concurrent load).
-		if ( anthropicResponse.ok && result.usage ) {
-			const usage = result.usage as { input_tokens: number; output_tokens: number };
-			await updateUsage( user_id, usage.input_tokens + usage.output_tokens, limitCheck.used, env );
-		}
-
-		return new Response( JSON.stringify( result ), {
-			status: anthropicResponse.status,
-			headers: { 'Content-Type': 'application/json' },
-		} );
-
-	} catch ( error ) {
-		console.error( 'Proxy error:', error );
-		return jsonResponse( { error: 'Internal proxy error' }, 500 );
-	}
+    return new Response(JSON.stringify(result), {
+      status: anthropicResponse.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Proxy error:', error);
+    return jsonResponse({ error: 'Internal proxy error' }, 500);
+  }
 }
-
-// Per-tier ceiling for max_tokens forwarded to Anthropic.
-const MAX_TOKENS: Record<ProxyTier, number> = {
-	free:        1000,
-	trial:       2000,
-	pro_managed: 8000,
-};
 
 // Mirrors NJ_Tier_Config::MONTHLY_LIMITS (PHP). Keep in sync.
 const MONTHLY_LIMITS: Record<ProxyTier, number> = {
-	free:        50_000,
-	trial:       300_000,
-	pro_managed: 2_000_000,
+  free:        50_000,
+  trial:       300_000,
+  pro_managed: 2_000_000,
+};
+
+const MAX_TOKENS: Record<ProxyTier, number> = {
+  free:        1_000,
+  trial:       4_000,
+  pro_managed: 8_000,
 };
 
 async function checkRateLimit(
-	userId: number,
-	tier: ProxyTier,
-	env: Env,
+  siteToken: string, tier: ProxyTier, env: Env
 ): Promise<{ allowed: boolean; used: number; limit: number }> {
-	const limit = MONTHLY_LIMITS[ tier ];
-	const monthKey = `usage:${ userId }:${ getCurrentMonth() }`;
-	const currentUsage = parseInt( ( await env.USAGE_KV.get( monthKey ) ) ?? '0', 10 );
-	return { allowed: currentUsage < limit, used: currentUsage, limit };
+  const limit = MONTHLY_LIMITS[tier];
+  const key = `usage:${siteToken}:${getCurrentMonth()}`;
+  const used = parseInt(await env.USAGE_KV.get(key) ?? '0', 10);
+  return { allowed: used < limit, used, limit };
 }
 
-async function updateUsage( userId: number, tokens: number, knownUsage: number, env: Env ): Promise<void> {
-	const monthKey = `usage:${ userId }:${ getCurrentMonth() }`;
-	await env.USAGE_KV.put( monthKey, String( knownUsage + tokens ), {
-		expirationTtl: getSecondsUntilNextMonth(),
-	} );
+async function updateUsage(siteToken: string, tokens: number, env: Env): Promise<void> {
+  const key = `usage:${siteToken}:${getCurrentMonth()}`;
+  const current = parseInt(await env.USAGE_KV.get(key) ?? '0', 10);
+  await env.USAGE_KV.put(key, String(current + tokens), {
+    expirationTtl: getSecondsUntilNextMonth(),
+  });
 }
 
 // Mirrors ClaudeProvider::MODELS (PHP). Keep in sync.
 const TIER_MODELS: Record<ProxyTier, string[]> = {
-	free:        [ 'claude-haiku-4-5-20251001' ],
-	trial:       [ 'claude-haiku-4-5-20251001' ],
-	pro_managed: [ 'claude-haiku-4-5-20251001', 'claude-sonnet-4-6', 'claude-opus-4-6' ],
+  free:        ['claude-haiku-4-5-20251001'],
+  trial:       ['claude-haiku-4-5-20251001'],
+  pro_managed: ['claude-haiku-4-5-20251001', 'claude-sonnet-4-6', 'claude-opus-4-6'],
 };
 
-function getModelForTier( tier: ProxyTier, requestedModel?: string ): string {
-	const allowed = TIER_MODELS[ tier ];
-	if ( requestedModel && allowed.includes( requestedModel ) ) {
-		return requestedModel;
-	}
-	return allowed[ 0 ];
+function getModelForTier(tier: ProxyTier, requestedModel?: string): string {
+  const allowed = TIER_MODELS[tier];
+  if (requestedModel && allowed.includes(requestedModel)) return requestedModel;
+  return allowed[0];
 }
 
 function getCurrentMonth(): string {
-	const now = new Date();
-	return `${ now.getFullYear() }-${ String( now.getMonth() + 1 ).padStart( 2, '0' ) }`;
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
 }
 
 function getSecondsUntilNextMonth(): number {
-	const now = new Date();
-	const next = new Date( now.getFullYear(), now.getMonth() + 1, 1 );
-	return Math.floor( ( next.getTime() - now.getTime() ) / 1000 );
+  const now = new Date();
+  const next = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+  return Math.floor((next.getTime() - now.getTime()) / 1000);
 }
 
-function jsonResponse( data: unknown, status = 200 ): Response {
-	return new Response( JSON.stringify( data ), {
-		status,
-		headers: { 'Content-Type': 'application/json' },
-	} );
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }

--- a/wp-ai-mind-proxy/src/registration.ts
+++ b/wp-ai-mind-proxy/src/registration.ts
@@ -1,0 +1,66 @@
+// src/registration.ts
+
+import { Env, SiteRecord } from './types';
+import { generateToken } from './auth';
+
+export async function handleRegistration(
+  request: Request,
+  env: Env
+): Promise<Response> {
+  if (request.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405);
+  }
+
+  let body: { site_url?: string };
+  try {
+    body = await request.json() as { site_url?: string };
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON' }, 400);
+  }
+
+  const site_url = (body.site_url ?? '').trim();
+  if (!site_url || !isValidUrl(site_url)) {
+    return jsonResponse({ error: 'Invalid site_url' }, 400);
+  }
+
+  // Idempotent — return the existing token if already registered.
+  const urlHash = await sha256(site_url);
+  const existingToken = await env.USAGE_KV.get(`site_url:${urlHash}`);
+  if (existingToken) {
+    const record = await env.USAGE_KV.get<SiteRecord>(`site:${existingToken}`, 'json');
+    if (record) {
+      return jsonResponse({ token: existingToken, tier: record.tier });
+    }
+  }
+
+  const token = generateToken();
+  const record: SiteRecord = { site_url, tier: 'free', created_at: Date.now() };
+
+  await env.USAGE_KV.put(`site:${token}`, JSON.stringify(record));
+  await env.USAGE_KV.put(`site_url:${urlHash}`, token);
+
+  return jsonResponse({ token, tier: 'free' }, 201);
+}
+
+async function sha256(input: string): Promise<string> {
+  const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(bytes))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function isValidUrl(url: string): boolean {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/wp-ai-mind-proxy/src/registration.ts
+++ b/wp-ai-mind-proxy/src/registration.ts
@@ -3,6 +3,9 @@
 import { Env, SiteRecord } from './types';
 import { generateToken } from './auth';
 
+const REGISTRATION_RATE_LIMIT = 5;  // max new registrations per IP per hour
+const REGISTRATION_WINDOW_TTL = 3600; // seconds
+
 export async function handleRegistration(
   request: Request,
   env: Env
@@ -33,6 +36,17 @@ export async function handleRegistration(
     }
   }
 
+  // Rate-limit new registrations by IP to prevent KV exhaustion.
+  const ip = request.headers.get('CF-Connecting-IP') ?? 'unknown';
+  const rateLimitKey = `reg_ip:${ip}:${getCurrentHour()}`;
+  const attempts = parseInt(await env.USAGE_KV.get(rateLimitKey) ?? '0', 10);
+  if (attempts >= REGISTRATION_RATE_LIMIT) {
+    return jsonResponse({ error: 'Too many registration attempts. Try again later.' }, 429);
+  }
+  await env.USAGE_KV.put(rateLimitKey, String(attempts + 1), {
+    expirationTtl: REGISTRATION_WINDOW_TTL,
+  });
+
   const token = generateToken();
   const record: SiteRecord = { site_url, tier: 'free', created_at: Date.now() };
 
@@ -40,6 +54,11 @@ export async function handleRegistration(
   await env.USAGE_KV.put(`site_url:${urlHash}`, token);
 
   return jsonResponse({ token, tier: 'free' }, 201);
+}
+
+function getCurrentHour(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}-${String(now.getUTCHours()).padStart(2, '0')}`;
 }
 
 async function sha256(input: string): Promise<string> {

--- a/wp-ai-mind-proxy/src/signature.ts
+++ b/wp-ai-mind-proxy/src/signature.ts
@@ -1,39 +1,31 @@
-// Signs the raw request body bytes — avoids JSON key-ordering fragility.
-// crypto.subtle.verify() is constant-time (no timing oracle).
-import type { Env } from './types';
+// src/signature.ts
+// Verifies LemonSqueezy webhook signatures sent in the X-Signature header.
+// Uses constant-time comparison to prevent timing attacks.
 
-export async function verifySignature(
-	bodyText: string,
-	signature: string,
-	env: Env,
+import { Env } from './types';
+
+export async function verifyLsSignature(
+  bodyText: string,
+  signature: string,
+  env: Env
 ): Promise<boolean> {
-	try {
-		const key = await crypto.subtle.importKey(
-			'raw',
-			new TextEncoder().encode( env.PROXY_SIGNATURE_SECRET ),
-			{ name: 'HMAC', hash: 'SHA-256' },
-			false,
-			[ 'verify' ],
-		);
-		const sigBytes = hexToBytes( signature );
-		return await crypto.subtle.verify(
-			'HMAC',
-			key,
-			sigBytes,
-			new TextEncoder().encode( bodyText ),
-		);
-	} catch {
-		return false;
-	}
-}
-
-function hexToBytes( hex: string ): Uint8Array {
-	if ( hex.length % 2 !== 0 || ! /^[0-9a-f]+$/i.test( hex ) ) {
-		return new Uint8Array( 0 ); // crypto.subtle.verify will return false safely
-	}
-	const out = new Uint8Array( hex.length / 2 );
-	for ( let i = 0; i < hex.length; i += 2 ) {
-		out[ i / 2 ] = parseInt( hex.slice( i, i + 2 ), 16 );
-	}
-	return out;
+  try {
+    if (!signature || signature.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(signature)) {
+      return false;
+    }
+    const key = await crypto.subtle.importKey(
+      'raw',
+      new TextEncoder().encode(env.LS_WEBHOOK_SECRET),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['verify']
+    );
+    const sigBytes = new Uint8Array(signature.length / 2);
+    for (let i = 0; i < signature.length; i += 2) {
+      sigBytes[i / 2] = parseInt(signature.slice(i, i + 2), 16);
+    }
+    return await crypto.subtle.verify('HMAC', key, sigBytes, new TextEncoder().encode(bodyText));
+  } catch {
+    return false;
+  }
 }

--- a/wp-ai-mind-proxy/src/types.ts
+++ b/wp-ai-mind-proxy/src/types.ts
@@ -1,21 +1,37 @@
+// src/types.ts
+
 export interface Env {
-	USAGE_KV: KVNamespace;
-	ANTHROPIC_API_KEY: string;
-	PROXY_SIGNATURE_SECRET: string;
+  USAGE_KV: KVNamespace;
+  ANTHROPIC_API_KEY: string;
+  LS_WEBHOOK_SECRET: string;
+  // PROXY_SIGNATURE_SECRET intentionally removed — replaced by site token Bearer auth.
 }
 
-// Tiers routed through proxy. Mirrors NJ_Tier_Config::TIERS (excludes pro_byok).
 export type ProxyTier = 'free' | 'trial' | 'pro_managed';
 
+export interface SiteRecord {
+  site_url: string;
+  tier: ProxyTier;
+  created_at: number;
+  ls_licence_key?: string;
+}
+
+export interface LicenceRecord {
+  tier: ProxyTier;
+  site_token: string;
+  activated_at: number;
+}
+
 export interface ProxyRequest {
-	user_id: number;
-	tier: ProxyTier;
-	messages: MessageParam[];
-	model?: string;
-	max_tokens?: number;
+  user_id: number; // kept for logging only — rate limiting is per site token
+  tier: ProxyTier;
+  messages: MessageParam[];
+  model?: string;
+  max_tokens?: number;
+  system?: string;
 }
 
 export interface MessageParam {
-	role: 'user' | 'assistant';
-	content: string;
+  role: 'user' | 'assistant';
+  content: string;
 }

--- a/wp-ai-mind-proxy/src/types.ts
+++ b/wp-ai-mind-proxy/src/types.ts
@@ -4,6 +4,8 @@ export interface Env {
   USAGE_KV: KVNamespace;
   ANTHROPIC_API_KEY: string;
   LS_WEBHOOK_SECRET: string;
+  LS_PRO_MONTHLY_VARIANT_ID: string;
+  LS_PRO_ANNUAL_VARIANT_ID: string;
   // PROXY_SIGNATURE_SECRET intentionally removed — replaced by site token Bearer auth.
 }
 

--- a/wp-ai-mind-proxy/src/webhook.ts
+++ b/wp-ai-mind-proxy/src/webhook.ts
@@ -1,0 +1,134 @@
+// src/webhook.ts
+
+import { Env, SiteRecord, LicenceRecord, ProxyTier } from './types';
+import { verifyLsSignature } from './signature';
+
+// Map LemonSqueezy variant IDs → plugin tier.
+// Pro Monthly: 988108. Pro Annual: confirm ID in LS dashboard (Products → WP AI Mind Pro → Variants).
+// Pro BYOK (1550517) is not here — it bypasses the proxy; handled in Phase 3.
+const VARIANT_TIER_MAP: Record<string, ProxyTier> = {
+  '988108': 'pro_managed', // Pro Monthly
+  'CONFIRM_PRO_ANNUAL_VARIANT_ID': 'pro_managed', // Pro Annual — replace with actual ID
+};
+
+export async function handleWebhook(request: Request, env: Env): Promise<Response> {
+  if (request.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 });
+  }
+
+  const bodyText = await request.text();
+  const signature = request.headers.get('X-Signature') ?? '';
+
+  if (!(await verifyLsSignature(bodyText, signature, env))) {
+    return new Response('Invalid signature', { status: 401 });
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(bodyText) as Record<string, unknown>;
+  } catch {
+    return new Response('Invalid JSON', { status: 400 });
+  }
+
+  const meta = payload['meta'] as Record<string, unknown> | undefined;
+  const eventName = (meta?.['event_name'] as string | undefined) ?? '';
+
+  switch (eventName) {
+    case 'order_created':
+    case 'subscription_created':
+    case 'subscription_resumed':
+    case 'subscription_unpaused':
+      await handleActivation(payload, env);
+      break;
+
+    case 'subscription_cancelled':
+    case 'subscription_expired':
+    case 'subscription_paused':
+      await handleDeactivation(payload, env);
+      break;
+
+    case 'licence_key_created':
+    case 'licence_key_updated':
+      await handleLicenceKey(payload, env);
+      break;
+
+    default:
+      break;
+  }
+
+  return new Response('OK', { status: 200 });
+}
+
+async function handleActivation(payload: Record<string, unknown>, env: Env): Promise<void> {
+  const meta = payload['meta'] as Record<string, unknown> | undefined;
+  const customData = meta?.['custom_data'] as Record<string, string> | undefined;
+  const site_token = customData?.['site_token'];
+  if (!site_token) return;
+
+  const data = payload['data'] as Record<string, unknown> | undefined;
+  const attrs = data?.['attributes'] as Record<string, unknown> | undefined;
+  const variantId = String(
+    ((attrs?.['first_order_item'] ?? attrs?.['variant_id']) as unknown) ?? ''
+  );
+  const tier = VARIANT_TIER_MAP[variantId] ?? null;
+  if (!tier) return;
+
+  const licenceKey = (attrs?.['identifier'] as string | undefined) ?? '';
+  await upgradeSiteTier(site_token, tier, licenceKey, env);
+}
+
+async function handleDeactivation(payload: Record<string, unknown>, env: Env): Promise<void> {
+  const data = payload['data'] as Record<string, unknown> | undefined;
+  const attrs = data?.['attributes'] as Record<string, unknown> | undefined;
+  const licenceKey = (attrs?.['licence_key'] ?? attrs?.['identifier']) as string | undefined;
+  if (!licenceKey) return;
+
+  const record = await env.USAGE_KV.get<LicenceRecord>(`licence:${licenceKey}`, 'json');
+  if (record?.site_token) {
+    await downgradeSiteTier(record.site_token, env);
+  }
+}
+
+async function handleLicenceKey(payload: Record<string, unknown>, env: Env): Promise<void> {
+  const data = payload['data'] as Record<string, unknown> | undefined;
+  const attrs = data?.['attributes'] as Record<string, unknown> | undefined;
+  const key = (attrs?.['key'] as string | undefined) ?? '';
+  const status = (attrs?.['status'] as string | undefined) ?? '';
+  const meta = payload['meta'] as Record<string, unknown> | undefined;
+  const customData = meta?.['custom_data'] as Record<string, string> | undefined;
+  const site_token = customData?.['site_token'];
+
+  if (!key || !site_token) return;
+
+  if (status === 'active') {
+    const variantId = String((attrs?.['variant_id'] as unknown) ?? '');
+    const tier = VARIANT_TIER_MAP[variantId] ?? 'pro_managed';
+    const record: LicenceRecord = { tier, site_token, activated_at: Date.now() };
+    await env.USAGE_KV.put(`licence:${key}`, JSON.stringify(record));
+  } else if (status === 'disabled' || status === 'expired') {
+    const record = await env.USAGE_KV.get<LicenceRecord>(`licence:${key}`, 'json');
+    if (record) await downgradeSiteTier(record.site_token, env);
+    await env.USAGE_KV.delete(`licence:${key}`);
+  }
+}
+
+async function upgradeSiteTier(
+  token: string, tier: ProxyTier, licenceKey: string, env: Env
+): Promise<void> {
+  const existing = await env.USAGE_KV.get<SiteRecord>(`site:${token}`, 'json');
+  if (!existing) return;
+  const updated: SiteRecord = { ...existing, tier, ...(licenceKey ? { ls_licence_key: licenceKey } : {}) };
+  await env.USAGE_KV.put(`site:${token}`, JSON.stringify(updated));
+
+  if (licenceKey) {
+    const lr: LicenceRecord = { tier, site_token: token, activated_at: Date.now() };
+    await env.USAGE_KV.put(`licence:${licenceKey}`, JSON.stringify(lr));
+  }
+}
+
+async function downgradeSiteTier(token: string, env: Env): Promise<void> {
+  const existing = await env.USAGE_KV.get<SiteRecord>(`site:${token}`, 'json');
+  if (!existing) return;
+  const { ls_licence_key: _removed, ...rest } = existing;
+  await env.USAGE_KV.put(`site:${token}`, JSON.stringify({ ...rest, tier: 'free' }));
+}

--- a/wp-ai-mind-proxy/src/webhook.ts
+++ b/wp-ai-mind-proxy/src/webhook.ts
@@ -3,13 +3,14 @@
 import { Env, SiteRecord, LicenceRecord, ProxyTier } from './types';
 import { verifyLsSignature } from './signature';
 
-// Map LemonSqueezy variant IDs → plugin tier.
-// Pro Monthly: 988108. Pro Annual: confirm ID in LS dashboard (Products → WP AI Mind Pro → Variants).
+// Build LemonSqueezy variant ID → plugin tier map from environment variables.
 // Pro BYOK (1550517) is not here — it bypasses the proxy; handled in Phase 3.
-const VARIANT_TIER_MAP: Record<string, ProxyTier> = {
-  '988108': 'pro_managed', // Pro Monthly
-  'CONFIRM_PRO_ANNUAL_VARIANT_ID': 'pro_managed', // Pro Annual — replace with actual ID
-};
+function buildVariantTierMap(env: Env): Record<string, ProxyTier> {
+  const map: Record<string, ProxyTier> = {};
+  if (env.LS_PRO_MONTHLY_VARIANT_ID) map[env.LS_PRO_MONTHLY_VARIANT_ID] = 'pro_managed';
+  if (env.LS_PRO_ANNUAL_VARIANT_ID) map[env.LS_PRO_ANNUAL_VARIANT_ID] = 'pro_managed';
+  return map;
+}
 
 export async function handleWebhook(request: Request, env: Env): Promise<Response> {
   if (request.method !== 'POST') {
@@ -70,7 +71,7 @@ async function handleActivation(payload: Record<string, unknown>, env: Env): Pro
   const variantId = String(
     ((attrs?.['first_order_item'] ?? attrs?.['variant_id']) as unknown) ?? ''
   );
-  const tier = VARIANT_TIER_MAP[variantId] ?? null;
+  const tier = buildVariantTierMap(env)[variantId] ?? null;
   if (!tier) return;
 
   const licenceKey = (attrs?.['identifier'] as string | undefined) ?? '';
@@ -102,7 +103,7 @@ async function handleLicenceKey(payload: Record<string, unknown>, env: Env): Pro
 
   if (status === 'active') {
     const variantId = String((attrs?.['variant_id'] as unknown) ?? '');
-    const tier = VARIANT_TIER_MAP[variantId] ?? 'pro_managed';
+    const tier = buildVariantTierMap(env)[variantId] ?? 'pro_managed';
     const record: LicenceRecord = { tier, site_token, activated_at: Date.now() };
     await env.USAGE_KV.put(`licence:${key}`, JSON.stringify(record));
   } else if (status === 'disabled' || status === 'expired') {

--- a/wp-ai-mind-proxy/wrangler.toml
+++ b/wp-ai-mind-proxy/wrangler.toml
@@ -4,8 +4,8 @@ compatibility_date = "2025-01-01"
 
 [[kv_namespaces]]
 binding = "USAGE_KV"
-id = "REPLACE_AFTER_KV_CREATE"
-preview_id = "REPLACE_AFTER_KV_CREATE_PREVIEW"
+id = "71612d363b07408bb70eec49d5739b1c"
+preview_id = "38975852f1bc4c838da456ea9a21e789"
 
 # Secrets (set via CLI — never commit values):
 # wrangler secret put ANTHROPIC_API_KEY

--- a/wp-ai-mind-proxy/wrangler.toml
+++ b/wp-ai-mind-proxy/wrangler.toml
@@ -9,4 +9,6 @@ preview_id = "REPLACE_AFTER_KV_CREATE_PREVIEW"
 
 # Secrets (set via CLI — never commit values):
 # wrangler secret put ANTHROPIC_API_KEY
-# wrangler secret put PROXY_SIGNATURE_SECRET   ← must match WP_AI_MIND_PROXY_SECRET in wp-config.php
+# wrangler secret put LS_WEBHOOK_SECRET   ← must match LemonSqueezy webhook signing secret
+# PROXY_SIGNATURE_SECRET is no longer used — can be deleted:
+# wrangler secret delete PROXY_SIGNATURE_SECRET

--- a/wp-ai-mind-proxy/wrangler.toml
+++ b/wp-ai-mind-proxy/wrangler.toml
@@ -9,6 +9,8 @@ preview_id = "38975852f1bc4c838da456ea9a21e789"
 
 # Secrets (set via CLI — never commit values):
 # wrangler secret put ANTHROPIC_API_KEY
-# wrangler secret put LS_WEBHOOK_SECRET   ← must match LemonSqueezy webhook signing secret
+# wrangler secret put LS_WEBHOOK_SECRET            ← must match LemonSqueezy webhook signing secret
+# wrangler secret put LS_PRO_MONTHLY_VARIANT_ID    ← LemonSqueezy: Products → WP AI Mind Pro → Variants
+# wrangler secret put LS_PRO_ANNUAL_VARIANT_ID     ← LemonSqueezy: Products → WP AI Mind Pro → Variants
 # PROXY_SIGNATURE_SECRET is no longer used — can be deleted:
 # wrangler secret delete PROXY_SIGNATURE_SECRET


### PR DESCRIPTION
## Summary

- Replaces HMAC shared-secret auth with per-site Bearer tokens issued by the Cloudflare Worker, eliminating the need for any secrets in wp-config.php
- Adds `NJ_Site_Registration` — plugin auto-registers with the Worker on `init`, stores the site token in `wp_options`, and embeds it in LemonSqueezy checkout URLs so tier upgrades are fully automatic
- Routes free/trial/pro_managed tiers through the managed proxy; pro_byok falls through to the direct Anthropic API; prevents double usage-logging via `$proxy_logged` flag
- Adds `/register` and `/webhook` Worker endpoints; repurposes `signature.ts` for LemonSqueezy HMAC verification; deploys updated Worker to Cloudflare

## Test Plan

- [x] PHP unit tests pass: `./vendor/bin/phpunit tests/Unit/ --colors=always` (168 tests)
- [x] TypeScript compiles cleanly: `cd wp-ai-mind-proxy && npm run build`
- [x] Worker deployed and `/register` returns a 201 with `{ token, tier: 'free' }` for a new site URL
- [x] Subsequent `/register` calls with the same URL return 200 with the same token (idempotent)
- [x] `/v1/chat` with a valid Bearer token routes to Anthropic and returns a response
- [x] `/v1/chat` with an invalid token returns 401
- [ ] LemonSqueezy `order_created` webhook upgrades the site token tier in KV (manual curl test) — requires `LS_WEBHOOK_SECRET` to generate valid HMAC; endpoint verified live and correctly rejects invalid signatures (401)
- [ ] End-to-end Docker smoke test deferred to post-merge (Task 13 in Phase 2.1 plan)

## Notes

- `CONFIRM_PRO_ANNUAL_VARIANT_ID` placeholder in `webhook.ts` must be replaced with the real LemonSqueezy annual variant ID before going live
- LemonSqueezy button links currently set to 'placeholder' — needs real activation URL (future phase)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)