### PR TITLE
feat(workflow): consolidate PR review nits into single issue

### DIFF
--- a/.github/workflows/auto-fix-review-issue.yml
+++ b/.github/workflows/auto-fix-review-issue.yml
@@ -157,6 +157,10 @@ jobs:
             2. Close the issue with: `gh issue close ${{ github.event.issue.number }} --comment "⚠️ Manual fix required: <one sentence explaining what information is needed>" --repo ${{ github.repository }}`
             3. Stop — do not attempt to commit or push.
 
+            **Note — consolidated nits issue:** If this issue has the "nits" label, it contains
+            a consolidated list of multiple style/minor improvements collected from the review.
+            Apply all of them in a single commit to keep the PR history clean.
+
             ### Step 2 — Prepare the working branch
 
             **If PR state is `OPEN`:** you are already on branch `${{ steps.pr_state.outputs.head }}` — skip to Step 3.
@@ -168,7 +172,9 @@ jobs:
 
             ### Step 3 — Fix the problem
 
-            Read the relevant source files and make the minimal change described in the issue.
+            Read the relevant source files and make the minimal changes described in the issue.
+
+            If this is a nits issue with multiple items, apply all of them in one commit.
 
             Commit:
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -79,17 +79,17 @@ jobs:
               gh label create "code-review" --color "#0075ca" --description "Found during code review" --repo ${{ github.repository }} 2>/dev/null || true
               gh label create "blocking"    --color "#b60205" --description "Blocking issue"            --repo ${{ github.repository }} 2>/dev/null || true
               gh label create "enhancement" --color "#a2eeef" --description "Improvement or suggestion"  --repo ${{ github.repository }} 2>/dev/null || true
+              gh label create "nits"        --color "#d4c5f9" --description "Style and minor nits"     --repo ${{ github.repository }} 2>/dev/null || true
               gh label create "auto-fix"    --color "#e4e669" --description "Claude will auto-fix this"  --repo ${{ github.repository }} 2>/dev/null || true
 
             ### Step 1 — Create issues for follow-up items (do this FIRST to capture URLs)
 
-            For any finding that warrants independent follow-up (bug, non-trivial improvement,
-            security concern, missing test coverage), create a GitHub issue.
+            For any finding that warrants independent follow-up, create a GitHub issue.
 
             Classify each finding:
-            - **blocking** (bug, security flaw, data loss risk) → labels: `code-review,blocking`
-            - **improvement** (non-trivial refactor, missing tests, performance) → labels: `code-review,enhancement`
-            - **nit/style** → no issue, PR comment only
+            - **blocking** (bug, security flaw, data loss risk) → labels: `code-review,blocking`, auto-fixable → add to /tmp/auto-fix-issues.txt
+            - **improvement** (non-trivial refactor, missing tests, performance) → labels: `code-review,enhancement`, auto-fixable → add to /tmp/auto-fix-issues.txt
+            - **nits/style** → collect in memory, create ONE consolidated issue at the end with labels: `code-review,nits`, auto-fixable → add to /tmp/auto-fix-issues.txt
 
             Example command for a blocking issue (use this exact body format — the auto-fix
             workflow parses it to find the PR number and base branch):
@@ -102,6 +102,17 @@ jobs:
                 --repo ${{ github.repository }})
               ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
               echo "$ISSUE_NUMBER" >> /tmp/auto-fix-issues.txt
+
+            **For nits:** Collect all nit findings in a single structured list (e.g. in memory or temp file),
+            then create ONE consolidated issue with all of them at the end of Step 1:
+
+              NITS_ISSUE=$(gh issue create \
+                --title "Review nits: style and minor improvements from PR #${{ github.event.pull_request.number }}" \
+                --body $'Found during review of PR #${{ github.event.pull_request.number }}\n\n**PR:** ${{ github.event.pull_request.html_url }}\n**Base branch:** ${{ github.event.pull_request.base.ref }}\n\n## Nits to address\n\n- [nit 1]\n- [nit 2]\n- [nit 3]' \
+                --label "code-review,nits" \
+                --repo ${{ github.repository }})
+              NITS_NUMBER=$(echo "$NITS_ISSUE" | grep -oE '[0-9]+$')
+              echo "$NITS_NUMBER" >> /tmp/auto-fix-issues.txt
 
             Do NOT apply the `auto-fix` label yourself. A subsequent workflow step applies
             it via a PAT outside this action, which guarantees the `issues: labeled` webhook
@@ -127,6 +138,10 @@ jobs:
             2. **Findings** — grouped by severity (bugs → improvements → nits). For any finding that
                has an associated issue, include the issue URL inline, e.g. "See #42 for tracking."
             3. **Verdict** — Approved / Needs changes / Needs discussion
+
+            **Note:** All nits are collected into a single consolidated issue (#N) to streamline
+            auto-fix and reduce issue clutter. Reference it in the PR comment like:
+            "See #42 for all nits to be auto-fixed."
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -135,13 +135,12 @@ jobs:
 
             Structure the comment as:
             1. **Summary** — 1–3 sentence overview of the PR
-            2. **Findings** — grouped by severity (bugs → improvements → nits). For any finding that
-               has an associated issue, include the issue URL inline, e.g. "See #42 for tracking."
+            2. **Findings** — grouped by severity (bugs → improvements → nits):
+               - For bugs and improvements: include the issue URL inline, e.g. "See #42 for tracking."
+               - **For nits:** Provide the **full verbose explanation** of each nit as you normally would.
+                 Then, at the end of the nits section, add: "All nits are tracked in #N for auto-fix."
+                 This keeps the detailed feedback visible in the PR while also referencing the consolidated issue.
             3. **Verdict** — Approved / Needs changes / Needs discussion
-
-            **Note:** All nits are collected into a single consolidated issue (#N) to streamline
-            auto-fix and reduce issue clutter. Reference it in the PR comment like:
-            "See #42 for all nits to be auto-fixed."
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options


### PR DESCRIPTION
## Summary
This PR enhances the Claude code review workflow to better handle style issues and minor improvements by consolidating them into a single GitHub issue, rather than creating individual PR comments for each nit. This keeps the PR cleaner while maintaining detailed feedback and enabling batch auto-fixes.

## Key Changes

- **Added "nits" label**: New GitHub label with purple color (#d4c5f9) for tracking style and minor improvements
- **Consolidated nits handling**: Changed workflow to collect all nit findings and create ONE consolidated issue at the end of Step 1, rather than handling them individually
- **Updated classification guidance**: Clarified that nits/style issues should be collected in memory and batched into a single issue with the `code-review,nits` labels
- **Enhanced PR comment structure**: Modified instructions to include full verbose explanations of nits in PR comments, then reference the consolidated tracking issue (e.g., "All nits are tracked in #N for auto-fix")
- **Improved auto-fix workflow**: Added note that consolidated nits issues should have all items applied in a single commit to keep PR history clean
- **Updated documentation**: Refined instructions to clarify that bugs and improvements get inline issue references, while nits get a consolidated issue with detailed feedback in the PR comment

## Implementation Details

The workflow now:
1. Creates a single consolidated nits issue with all style/minor findings collected during review
2. Appends the nits issue number to `/tmp/auto-fix-issues.txt` for auto-fix processing
3. Provides detailed nit explanations in the PR comment while referencing the consolidated issue
4. Ensures the auto-fix workflow applies all nits in one commit when processing the consolidated issue

https://claude.ai/code/session_01NJZor3gaJJ4pCPABZJG2Vr