### PR TITLE
Extract admin widget styles to dedicated stylesheet

### DIFF
--- a/assets/admin/wpaim-admin-widgets.css
+++ b/assets/admin/wpaim-admin-widgets.css
@@ -1,0 +1,58 @@
+/*
+ * WP AI Mind — Admin widget and tier-status styles.
+ *
+ * Enqueued on relevant admin pages by NJ_Usage_Widget and NJ_Tier_Status_Page.
+ * Tokens match those defined in :root within assets/admin/index.css; hex
+ * fallbacks apply only when the main admin bundle is absent on a given page.
+ */
+
+/* ---- Progress bar ---- */
+
+.wpaim-progress-track {
+	background: var(--color-border-subtle, #e0e1e6);
+	border-radius: 5px;
+	height: 10px;
+	margin: 8px 0;
+	overflow: hidden;
+}
+
+.wpaim-progress-bar {
+	border-radius: 5px;
+	height: 100%;
+	transition: width 0.3s ease;
+}
+
+.wpaim-progress-bar--success { background: var(--color-success, #16a34a); }
+.wpaim-progress-bar--warning { background: var(--color-warning, #d97706); }
+.wpaim-progress-bar--danger  { background: var(--color-error,   #dc2626); }
+
+.wpaim-meta-text {
+	color: var(--color-text-muted, #787c82);
+	font-size: 12px;
+}
+
+/* ---- Proxy / subscription status indicator ---- */
+
+.wpaim-status--active  { color: var(--color-success, #16a34a); }
+.wpaim-status--expired { color: var(--color-error,   #dc2626); }
+
+/* ---- Usage meter (native progress element) ---- */
+
+.wpaim-usage-meter {
+	display: block;
+	width: 300px;
+}
+
+/* ---- Upgrade card ---- */
+
+.wpaim-upgrade-card {
+	margin-top: 1rem;
+	max-width: 600px;
+}
+
+.wpaim-upgrade-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: .5rem;
+	margin-top: .5rem;
+}

--- a/includes/Admin/NJ_Tier_Status_Page.php
+++ b/includes/Admin/NJ_Tier_Status_Page.php
@@ -15,6 +15,16 @@ class NJ_Tier_Status_Page {
 
 	public static function register_hooks(): void {
 		add_action( 'admin_menu', [ self::class, 'add_menu_page' ] );
+		add_action( 'admin_enqueue_scripts', [ self::class, 'enqueue_styles' ] );
+	}
+
+	public static function enqueue_styles(): void {
+		wp_enqueue_style(
+			'wpaim-admin-widgets',
+			WP_AI_MIND_URL . 'assets/admin/wpaim-admin-widgets.css',
+			[],
+			WP_AI_MIND_VERSION
+		);
 	}
 
 	public static function add_menu_page(): void {
@@ -52,9 +62,9 @@ class NJ_Tier_Status_Page {
 					<th scope="row"><?php esc_html_e( 'Proxy connection', 'wp-ai-mind' ); ?></th>
 					<td>
 						<?php if ( $registered ) : ?>
-							<span style="color:var(--color-success, #00a32a)">&#10003; <?php esc_html_e( 'Connected', 'wp-ai-mind' ); ?></span>
+							<span class="wpaim-status--active">&#10003; <?php esc_html_e( 'Connected', 'wp-ai-mind' ); ?></span>
 						<?php else : ?>
-							<span style="color:var(--color-error, #d63638)"><?php esc_html_e( 'Not connected — will auto-connect on next page load', 'wp-ai-mind' ); ?></span>
+							<span class="wpaim-status--expired"><?php esc_html_e( 'Not connected — will auto-connect on next page load', 'wp-ai-mind' ); ?></span>
 						<?php endif; ?>
 					</td>
 				</tr>
@@ -69,9 +79,9 @@ class NJ_Tier_Status_Page {
 						?>
 						<br>
 						<progress
+							class="wpaim-usage-meter"
 							max="<?php echo esc_attr( (string) $usage['limit'] ); ?>"
-							value="<?php echo esc_attr( (string) $usage['used'] ); ?>"
-							style="width:300px">
+							value="<?php echo esc_attr( (string) $usage['used'] ); ?>">
 						</progress>
 					</td>
 				</tr>
@@ -88,10 +98,10 @@ class NJ_Tier_Status_Page {
 			</table>
 
 			<?php if ( 'free' === $tier || 'trial' === $tier ) : ?>
-			<div class="card" style="max-width:600px;margin-top:1rem;">
+			<div class="card wpaim-upgrade-card">
 				<h2><?php esc_html_e( 'Upgrade your plan', 'wp-ai-mind' ); ?></h2>
 				<p><?php esc_html_e( 'Pro Managed gives you 2M tokens/month with model selection. Pro BYOK gives you unlimited usage with your own API key.', 'wp-ai-mind' ); ?></p>
-				<div style="display:flex;gap:.5rem;flex-wrap:wrap;margin-top:.5rem">
+				<div class="wpaim-upgrade-actions">
 					<a href="<?php echo esc_url( NJ_Site_Registration::checkout_url( NJ_Site_Registration::PLAN_PRO_MANAGED_MONTHLY ) ); ?>" class="button button-primary">
 						<?php esc_html_e( 'Pro Managed — Monthly', 'wp-ai-mind' ); ?>
 					</a>

--- a/includes/Admin/NJ_Usage_Widget.php
+++ b/includes/Admin/NJ_Usage_Widget.php
@@ -12,6 +12,16 @@ class NJ_Usage_Widget {
 
 	public static function register_hooks(): void {
 		add_action( 'wp_dashboard_setup', [ self::class, 'add_dashboard_widget' ] );
+		add_action( 'admin_enqueue_scripts', [ self::class, 'enqueue_styles' ] );
+	}
+
+	public static function enqueue_styles(): void {
+		wp_enqueue_style(
+			'wpaim-admin-widgets',
+			WP_AI_MIND_URL . 'assets/admin/wpaim-admin-widgets.css',
+			[],
+			WP_AI_MIND_VERSION
+		);
 	}
 
 	public static function add_dashboard_widget(): void {
@@ -42,23 +52,19 @@ class NJ_Usage_Widget {
 		echo '<p><strong>' . esc_html( $tier_label ) . ' ' . esc_html__( 'Plan', 'wp-ai-mind' ) . '</strong></p>';
 
 		if ( isset( $usage['limit'] ) && $usage['limit'] > 0 ) {
-			$color_danger   = 'var(--color-error, #d63638)';
-			$color_warning  = 'var(--color-warning, #dba617)';
-			$color_success  = 'var(--color-success, #00a32a)';
-			$color_track_bg = 'var(--color-border-subtle, #e0e0e0)';
-			$color_label    = 'var(--color-text-muted, #666)';
+			$pct = min( 100, (int) round( ( $usage['used'] / $usage['limit'] ) * 100 ) );
 
-			$pct   = min( 100, (int) round( ( $usage['used'] / $usage['limit'] ) * 100 ) );
-			$color = $pct > 80 ? $color_danger : ( $pct > 60 ? $color_warning : $color_success );
+			if ( $pct > 80 )     $bar_modifier = 'danger';
+			elseif ( $pct > 60 ) $bar_modifier = 'warning';
+			else                 $bar_modifier = 'success';
+
 			printf(
-				'<div style="background:%s;height:10px;border-radius:5px;margin:8px 0"><div style="width:%d%%;background:%s;height:100%%;border-radius:5px"></div></div>',
-				esc_attr( $color_track_bg ),
-				absint( $pct ),
-				esc_attr( $color )
+				'<div class="wpaim-progress-track"><div class="wpaim-progress-bar wpaim-progress-bar--%s" style="width:%d%%"></div></div>',
+				esc_attr( $bar_modifier ),
+				absint( $pct )
 			);
 			printf(
-				'<p style="font-size:12px;color:%s">%s / %s %s (%s %s)</p>',
-				esc_attr( $color_label ),
+				'<p class="wpaim-meta-text">%s / %s %s (%s %s)</p>',
 				esc_html( number_format_i18n( (int) $usage['used'] ) ),
 				esc_html( number_format_i18n( (int) $usage['limit'] ) ),
 				esc_html__( 'tokens', 'wp-ai-mind' ),

--- a/tests/Unit/Admin/NJ_Tier_Status_Page_Test.php
+++ b/tests/Unit/Admin/NJ_Tier_Status_Page_Test.php
@@ -94,7 +94,7 @@ class NJ_Tier_Status_Page_Test extends TestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'Not connected', $output );
-		$this->assertStringNotContainsString( '#00a32a', $output );
+		$this->assertStringNotContainsString( 'wpaim-status--active', $output );
 	}
 
 	// ── Upgrade section — checkout URLs ──────────────────────────────────────

--- a/tests/Unit/Admin/NJ_Usage_Widget_Test.php
+++ b/tests/Unit/Admin/NJ_Usage_Widget_Test.php
@@ -100,7 +100,7 @@ class NJ_Usage_Widget_Test extends TestCase {
 		$this->assertStringContainsString( 'Free', $output );
 		$this->assertStringContainsString( '25,000', $output );
 		$this->assertStringContainsString( '50,000', $output );
-		$this->assertStringContainsString( 'border-radius:5px', $output );
+		$this->assertStringContainsString( 'wpaim-progress-track', $output );
 	}
 
 	public function test_render_shows_upgrade_notice_when_above_80_percent(): void {
@@ -129,7 +129,7 @@ class NJ_Usage_Widget_Test extends TestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'Over 80%', $output );
-		$this->assertStringContainsString( '#d63638', $output ); // red progress bar
+		$this->assertStringContainsString( 'wpaim-progress-bar--danger', $output );
 	}
 
 	// ── render() — unlimited tier (pro_byok) ─────────────────────────────────
@@ -160,6 +160,6 @@ class NJ_Usage_Widget_Test extends TestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'Unlimited', $output );
-		$this->assertStringNotContainsString( 'border-radius:5px', $output );
+		$this->assertStringNotContainsString( 'wpaim-progress-track', $output );
 	}
 }


### PR DESCRIPTION
## Summary
Refactored inline styles from admin widgets into a dedicated CSS stylesheet (`wpaim-admin-widgets.css`), improving maintainability and consistency across the plugin's admin interface.

## Key Changes
- **New stylesheet**: Created `assets/admin/wpaim-admin-widgets.css` with reusable component classes for:
  - Progress bars (`.wpaim-progress-track`, `.wpaim-progress-bar`, `.wpaim-progress-bar--*`)
  - Status indicators (`.wpaim-status--active`, `.wpaim-status--expired`)
  - Usage meter (`.wpaim-usage-meter`)
  - Upgrade card (`.wpaim-upgrade-card`, `.wpaim-upgrade-actions`)
  - Meta text styling (`.wpaim-meta-text`)

- **Style enqueuing**: Added `enqueue_styles()` methods to both `NJ_Usage_Widget` and `NJ_Tier_Status_Page` classes to load the stylesheet on relevant admin pages

- **Markup refactoring**: 
  - Replaced inline `style` attributes with semantic CSS classes in `NJ_Usage_Widget::render()` and `NJ_Tier_Status_Page::render()`
  - Simplified progress bar logic by using BEM-style modifiers (`--success`, `--warning`, `--danger`)
  - Removed hardcoded color values in favor of CSS custom properties with fallbacks

- **Test updates**: Updated unit tests to assert on CSS class names instead of inline style values

## Implementation Details
- CSS uses CSS custom properties (e.g., `--color-success`, `--color-error`) that match tokens from the main admin bundle (`assets/admin/index.css`), with hex fallbacks for pages where the main bundle isn't loaded
- Progress bar color logic moved from PHP to CSS classes, reducing conditional complexity
- All color tokens standardized across both admin pages for consistency

https://claude.ai/code/session_01EUmho6AipfcWJnj8xrqRz5