### PR TITLE
fix(tiers): add missing content features to NJ_Tier_Config and fix isPro gates

### DIFF
--- a/includes/Admin/ChatPage.php
+++ b/includes/Admin/ChatPage.php
@@ -50,7 +50,7 @@ class ChatPage {
 				'nonce'             => wp_create_nonce( 'wp_rest' ),
 				'restUrl'           => esc_url_raw( rest_url( 'wp-ai-mind/v1' ) ),
 				'currentPostId'     => 0,
-				'isPro'             => NJ_Tier_Manager::user_can( 'generator' ),
+				'isPro'             => NJ_Tier_Manager::user_can( 'chat' ),
 				'siteTitle'         => get_bloginfo( 'name' ),
 				'defaultModelLabel' => esc_html( $default_model_label ),
 			]

--- a/includes/Admin/ChatPage.php
+++ b/includes/Admin/ChatPage.php
@@ -50,7 +50,7 @@ class ChatPage {
 				'nonce'             => wp_create_nonce( 'wp_rest' ),
 				'restUrl'           => esc_url_raw( rest_url( 'wp-ai-mind/v1' ) ),
 				'currentPostId'     => 0,
-				'isPro'             => NJ_Tier_Manager::user_can( 'chat' ),
+				'isPro'             => NJ_Tier_Manager::user_can( 'generator' ),
 				'siteTitle'         => get_bloginfo( 'name' ),
 				'defaultModelLabel' => esc_html( $default_model_label ),
 			]

--- a/includes/Admin/DashboardPage.php
+++ b/includes/Admin/DashboardPage.php
@@ -60,6 +60,10 @@ class DashboardPage {
 		$has_own_key       = $provider && $provider_settings->has_key( $provider );
 		$is_pro            = NJ_Tier_Manager::user_can( 'generator' );
 
+		// Suppress the upgrade banner when the user has generator access (pro_managed, pro_byok, or
+		// trial tiers all have generator = true) or when they supply their own API key. Trial users
+		// intentionally do not see the banner — they already have access and will receive a separate
+		// trial-expiry notice when their quota runs low.
 		if ( $is_pro || $has_own_key ) {
 			$banner_state = 'none';
 		} else {

--- a/includes/Admin/DashboardPage.php
+++ b/includes/Admin/DashboardPage.php
@@ -58,7 +58,7 @@ class DashboardPage {
 		$provider_settings = new ProviderSettings();
 		$provider          = (string) get_option( 'wp_ai_mind_default_provider', '' );
 		$has_own_key       = $provider && $provider_settings->has_key( $provider );
-		$is_pro            = NJ_Tier_Manager::user_can( 'chat' );
+		$is_pro            = NJ_Tier_Manager::user_can( 'generator' );
 
 		if ( $is_pro || $has_own_key ) {
 			$banner_state = 'none';

--- a/includes/Admin/GeneratorPage.php
+++ b/includes/Admin/GeneratorPage.php
@@ -42,7 +42,7 @@ class GeneratorPage {
 				'nonce'         => \wp_create_nonce( 'wp_rest' ),
 				'restUrl'       => \esc_url_raw( \rest_url( 'wp-ai-mind/v1' ) ),
 				'currentPostId' => 0,
-				'isPro'         => NJ_Tier_Manager::user_can( 'chat' ),
+				'isPro'         => NJ_Tier_Manager::user_can( 'generator' ),
 				'siteTitle'     => \get_bloginfo( 'name' ),
 			]
 		);

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -44,7 +44,7 @@ class SettingsPage {
 				'nonce'         => wp_create_nonce( 'wp_rest' ),
 				'restUrl'       => esc_url_raw( rest_url( 'wp-ai-mind/v1' ) ),
 				'currentPostId' => 0,
-				'isPro'         => NJ_Tier_Manager::user_can( 'chat' ),
+				'isPro'         => NJ_Tier_Manager::user_can( 'generator' ),
 				'siteTitle'     => get_bloginfo( 'name' ),
 			]
 		);

--- a/includes/Modules/Chat/SettingsRestController.php
+++ b/includes/Modules/Chat/SettingsRestController.php
@@ -66,6 +66,7 @@ class SettingsRestController {
 			'allowed_post_types'   => \get_option( 'wp_ai_mind_allowed_post_types', [ 'post', 'page' ] ),
 			'available_post_types' => $this->get_public_post_types(),
 			'enable_write_tools'   => (bool) \get_option( 'wp_ai_mind_enable_write_tools', false ),
+			// Note: intentionally snake_case to match WP REST convention; JS reads this as `settings.is_pro` (see FeaturesTab.jsx).
 			'is_pro'               => NJ_Tier_Manager::user_can( 'generator' ),
 		];
 
@@ -171,16 +172,6 @@ class SettingsRestController {
 	 */
 	private function mask_key( bool $has_key ): string {
 		return $has_key ? '••••••' : '';
-	}
-
-	/**
-	 * Mask a raw key string directly (used in the original spec signature).
-	 *
-	 * @param string $key The raw key value.
-	 * @return string
-	 */
-	private function mask( string $key ): string {
-		return '' !== $key ? '••••••' : '';
 	}
 
 	/**

--- a/includes/Modules/Chat/SettingsRestController.php
+++ b/includes/Modules/Chat/SettingsRestController.php
@@ -5,6 +5,7 @@ declare( strict_types=1 );
 namespace WP_AI_Mind\Modules\Chat;
 
 use WP_AI_Mind\Settings\ProviderSettings;
+use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 
 /**
  * REST controller for plugin settings.
@@ -65,6 +66,7 @@ class SettingsRestController {
 			'allowed_post_types'   => \get_option( 'wp_ai_mind_allowed_post_types', [ 'post', 'page' ] ),
 			'available_post_types' => $this->get_public_post_types(),
 			'enable_write_tools'   => (bool) \get_option( 'wp_ai_mind_enable_write_tools', false ),
+			'is_pro'               => NJ_Tier_Manager::user_can( 'generator' ),
 		];
 
 		return rest_ensure_response( $data );

--- a/includes/Modules/Editor/EditorModule.php
+++ b/includes/Modules/Editor/EditorModule.php
@@ -44,7 +44,7 @@ class EditorModule {
 				'nonce'         => \wp_create_nonce( 'wp_rest' ),
 				'restUrl'       => \esc_url_raw( \rest_url( 'wp-ai-mind/v1' ) ),
 				'currentPostId' => isset( $GLOBALS['post'] ) ? (int) $GLOBALS['post']->ID : ( isset( $_GET['post'] ) ? \absint( $_GET['post'] ) : 0 ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only post ID for editor sidebar; no form processing.
-				'isPro'         => NJ_Tier_Manager::user_can( 'chat' ),
+				'isPro'         => NJ_Tier_Manager::user_can( 'generator' ),
 				'siteTitle'     => \get_bloginfo( 'name' ),
 			]
 		);

--- a/includes/Modules/Frontend/FrontendWidgetModule.php
+++ b/includes/Modules/Frontend/FrontendWidgetModule.php
@@ -36,7 +36,7 @@ class FrontendWidgetModule {
 				'nonce'         => \wp_create_nonce( 'wp_rest' ),
 				'restUrl'       => \esc_url_raw( \rest_url( 'wp-ai-mind/v1' ) ),
 				'currentPostId' => \get_the_ID() ? \get_the_ID() : 0,
-				'isPro'         => NJ_Tier_Manager::user_can( 'chat' ),
+				'isPro'         => NJ_Tier_Manager::user_can( 'generator' ),
 				'siteTitle'     => \get_bloginfo( 'name' ),
 			]
 		);

--- a/includes/Modules/Generator/GeneratorModule.php
+++ b/includes/Modules/Generator/GeneratorModule.php
@@ -55,7 +55,10 @@ class GeneratorModule {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ self::class, 'handle_generate' ],
-				'permission_callback' => fn() => \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'generator' ) && NJ_Usage_Tracker::check_limit(),
+				'permission_callback' => function() {
+						$user_id = \get_current_user_id();
+						return \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'generator', $user_id ) && NJ_Usage_Tracker::check_limit( $user_id );
+					},
 				'args'                => [
 					'title'    => [
 						'type'              => 'string',

--- a/includes/Modules/Generator/GeneratorModule.php
+++ b/includes/Modules/Generator/GeneratorModule.php
@@ -42,7 +42,7 @@ class GeneratorModule {
 				'nonce'         => \wp_create_nonce( 'wp_rest' ),
 				'restUrl'       => \esc_url_raw( \rest_url( 'wp-ai-mind/v1' ) ),
 				'currentPostId' => 0,
-				'isPro'         => NJ_Tier_Manager::user_can( 'chat' ),
+				'isPro'         => NJ_Tier_Manager::user_can( 'generator' ),
 				'siteTitle'     => \get_bloginfo( 'name' ),
 			]
 		);
@@ -55,7 +55,7 @@ class GeneratorModule {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ self::class, 'handle_generate' ],
-				'permission_callback' => fn() => \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'chat' ) && NJ_Usage_Tracker::check_limit(),
+				'permission_callback' => fn() => \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'generator' ) && NJ_Usage_Tracker::check_limit(),
 				'args'                => [
 					'title'    => [
 						'type'              => 'string',

--- a/includes/Modules/Images/ImagesModule.php
+++ b/includes/Modules/Images/ImagesModule.php
@@ -64,7 +64,10 @@ class ImagesModule {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ self::class, 'handle_generate' ],
-				'permission_callback' => fn() => \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'images' ) && NJ_Usage_Tracker::check_limit(),
+				'permission_callback' => function() {
+						$user_id = \get_current_user_id();
+						return \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'images', $user_id ) && NJ_Usage_Tracker::check_limit( $user_id );
+					},
 				'args'                => [
 					'prompt'       => [
 						'required'          => true,

--- a/includes/Modules/Images/ImagesModule.php
+++ b/includes/Modules/Images/ImagesModule.php
@@ -44,7 +44,7 @@ class ImagesModule {
 			[
 				'nonce'    => \wp_create_nonce( 'wp_rest' ),
 				'restUrl'  => \esc_url_raw( \rest_url( 'wp-ai-mind/v1' ) ),
-				'isPro'    => NJ_Tier_Manager::user_can( 'chat' ),
+				'isPro'    => NJ_Tier_Manager::user_can( 'images' ),
 				'adminUrl' => \esc_url_raw( \admin_url() ),
 			]
 		);
@@ -64,7 +64,7 @@ class ImagesModule {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ self::class, 'handle_generate' ],
-				'permission_callback' => fn() => \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'chat' ) && NJ_Usage_Tracker::check_limit(),
+				'permission_callback' => fn() => \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'images' ) && NJ_Usage_Tracker::check_limit(),
 				'args'                => [
 					'prompt'       => [
 						'required'          => true,

--- a/includes/Modules/Seo/SeoModule.php
+++ b/includes/Modules/Seo/SeoModule.php
@@ -68,7 +68,10 @@ class SeoModule {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ self::class, 'handle_generate' ],
-				'permission_callback' => fn() => \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'seo' ) && NJ_Usage_Tracker::check_limit(),
+				'permission_callback' => function() {
+						$user_id = \get_current_user_id();
+						return \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'seo', $user_id ) && NJ_Usage_Tracker::check_limit( $user_id );
+					},
 				'args'                => [
 					'post_id' => [
 						'required'          => true,
@@ -85,7 +88,10 @@ class SeoModule {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ self::class, 'handle_apply' ],
-				'permission_callback' => fn() => \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'seo' ) && NJ_Usage_Tracker::check_limit(),
+				'permission_callback' => function() {
+						$user_id = \get_current_user_id();
+						return \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'seo', $user_id ) && NJ_Usage_Tracker::check_limit( $user_id );
+					},
 				'args'                => [
 					'post_id'        => [
 						'required'          => true,

--- a/includes/Modules/Seo/SeoModule.php
+++ b/includes/Modules/Seo/SeoModule.php
@@ -48,7 +48,7 @@ class SeoModule {
 			[
 				'nonce'    => \wp_create_nonce( 'wp_rest' ),
 				'restUrl'  => \esc_url_raw( \rest_url( 'wp-ai-mind/v1' ) ),
-				'isPro'    => NJ_Tier_Manager::user_can( 'chat' ),
+				'isPro'    => NJ_Tier_Manager::user_can( 'seo' ),
 				'adminUrl' => \esc_url_raw( \admin_url() ),
 			]
 		);
@@ -68,7 +68,7 @@ class SeoModule {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ self::class, 'handle_generate' ],
-				'permission_callback' => fn() => \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'chat' ) && NJ_Usage_Tracker::check_limit(),
+				'permission_callback' => fn() => \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'seo' ) && NJ_Usage_Tracker::check_limit(),
 				'args'                => [
 					'post_id' => [
 						'required'          => true,
@@ -85,7 +85,7 @@ class SeoModule {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ self::class, 'handle_apply' ],
-				'permission_callback' => fn() => \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'chat' ) && NJ_Usage_Tracker::check_limit(),
+				'permission_callback' => fn() => \current_user_can( 'edit_posts' ) && NJ_Tier_Manager::user_can( 'seo' ) && NJ_Usage_Tracker::check_limit(),
 				'args'                => [
 					'post_id'        => [
 						'required'          => true,

--- a/includes/Modules/Usage/UsageModule.php
+++ b/includes/Modules/Usage/UsageModule.php
@@ -45,7 +45,7 @@ class UsageModule {
 				'nonce'         => \wp_create_nonce( 'wp_rest' ),
 				'restUrl'       => \esc_url_raw( \rest_url( 'wp-ai-mind/v1' ) ),
 				'currentPostId' => 0,
-				'isPro'         => NJ_Tier_Manager::user_can( 'chat' ),
+				'isPro'         => NJ_Tier_Manager::user_can( 'generator' ),
 				'siteTitle'     => \get_bloginfo( 'name' ),
 			]
 		);

--- a/includes/Tiers/NJ_Tier_Config.php
+++ b/includes/Tiers/NJ_Tier_Config.php
@@ -15,21 +15,33 @@ class NJ_Tier_Config {
 	const FEATURES = [
 		'free'        => [
 			'chat'            => true,
+			'generator'       => false,
+			'seo'             => false,
+			'images'          => false,
 			'model_selection' => false,
 			'own_api_key'     => false,
 		],
 		'trial'       => [
 			'chat'            => true,
+			'generator'       => true,
+			'seo'             => true,
+			'images'          => true,
 			'model_selection' => false,
 			'own_api_key'     => false,
 		],
 		'pro_managed' => [
 			'chat'            => true,
+			'generator'       => true,
+			'seo'             => true,
+			'images'          => true,
 			'model_selection' => true,
 			'own_api_key'     => false,
 		],
 		'pro_byok'    => [
 			'chat'            => true,
+			'generator'       => true,
+			'seo'             => true,
+			'images'          => true,
 			'model_selection' => true,
 			'own_api_key'     => true,
 		],

--- a/tests/Unit/Modules/Chat/SettingsRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/SettingsRestControllerTest.php
@@ -36,6 +36,8 @@ class SettingsRestControllerTest extends TestCase {
     public function test_get_settings_returns_masked_keys_when_set(): void {
         Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
         Functions\when( 'get_post_types' )->justReturn( [] );
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'get_user_meta' )->justReturn( 'free' );
         Functions\when( 'get_option' )->alias( function( $key, $default = '' ) {
             $map = [
                 'wp_ai_mind_default_provider' => 'claude',
@@ -84,6 +86,8 @@ class SettingsRestControllerTest extends TestCase {
     public function test_get_settings_returns_empty_string_when_key_not_set(): void {
         Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
         Functions\when( 'get_post_types' )->justReturn( [] );
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'get_user_meta' )->justReturn( 'free' );
         Functions\when( 'get_option' )->justReturn( '' );
 
         $controller = new class extends SettingsRestController {
@@ -184,6 +188,8 @@ class SettingsRestControllerTest extends TestCase {
 
     public function test_get_settings_returns_allowed_post_types(): void {
         Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'get_user_meta' )->justReturn( 'free' );
         Functions\when( 'get_option' )->alias( function( $key, $default = '' ) {
             if ( 'wp_ai_mind_allowed_post_types' === $key ) {
                 return [ 'post' ];
@@ -213,6 +219,8 @@ class SettingsRestControllerTest extends TestCase {
 
     public function test_get_settings_returns_available_post_types(): void {
         Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'get_user_meta' )->justReturn( 'free' );
         Functions\when( 'get_option' )->alias( function( $key, $default = '' ) {
             return is_array( $default ) ? $default : '';
         } );
@@ -309,6 +317,62 @@ class SettingsRestControllerTest extends TestCase {
 
         $this->assertArrayHasKey( 'wp_ai_mind_enable_write_tools', $stored );
         $this->assertTrue( $stored['wp_ai_mind_enable_write_tools'] );
+    }
+
+    // ── GET /settings — is_pro field ─────────────────────────────────────────
+
+    public function test_get_settings_includes_is_pro_field(): void {
+        Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+        Functions\when( 'get_post_types' )->justReturn( [] );
+        Functions\when( 'get_option' )->justReturn( '' );
+        Functions\when( 'get_current_user_id' )->justReturn( 2 );
+        Functions\when( 'get_user_meta' )->justReturn( 'pro_managed' );
+
+        $controller = new class extends SettingsRestController {
+            protected function make_provider_settings(): \WP_AI_Mind\Settings\ProviderSettings {
+                $stub = new class extends \WP_AI_Mind\Settings\ProviderSettings {
+                    public function __construct() {}
+                    public function has_key( string $provider ): bool { return false; }
+                    public function get_api_key( string $provider ): string { return ''; }
+                };
+                return $stub;
+            }
+        };
+
+        $request  = new \WP_REST_Request();
+        $response = $controller->get_settings( $request );
+        $data     = $response->data;
+
+        $this->assertArrayHasKey( 'is_pro', $data );
+        $this->assertIsBool( $data['is_pro'] );
+        $this->assertTrue( $data['is_pro'] );
+    }
+
+    public function test_get_settings_is_pro_false_for_free_user(): void {
+        Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+        Functions\when( 'get_post_types' )->justReturn( [] );
+        Functions\when( 'get_option' )->justReturn( '' );
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'get_user_meta' )->justReturn( 'free' );
+
+        $controller = new class extends SettingsRestController {
+            protected function make_provider_settings(): \WP_AI_Mind\Settings\ProviderSettings {
+                $stub = new class extends \WP_AI_Mind\Settings\ProviderSettings {
+                    public function __construct() {}
+                    public function has_key( string $provider ): bool { return false; }
+                    public function get_api_key( string $provider ): string { return ''; }
+                };
+                return $stub;
+            }
+        };
+
+        $request  = new \WP_REST_Request();
+        $response = $controller->get_settings( $request );
+        $data     = $response->data;
+
+        $this->assertArrayHasKey( 'is_pro', $data );
+        $this->assertIsBool( $data['is_pro'] );
+        $this->assertFalse( $data['is_pro'] );
     }
 
     public function test_save_settings_skips_masked_api_keys(): void {

--- a/tests/Unit/Tiers/NJTierManagerTest.php
+++ b/tests/Unit/Tiers/NJTierManagerTest.php
@@ -72,12 +72,42 @@ class NJTierManagerTest extends TestCase {
 	}
 
 	public function test_pro_byok_user_can_all_features(): void {
-		Functions\expect( 'get_current_user_id' )->times( 3 )->andReturn( 7 );
-		Functions\expect( 'get_user_meta' )->times( 3 )->with( 7, 'wp_ai_mind_tier', true )->andReturn( 'pro_byok' );
+		Functions\expect( 'get_current_user_id' )->times( 6 )->andReturn( 7 );
+		Functions\expect( 'get_user_meta' )->times( 6 )->with( 7, 'wp_ai_mind_tier', true )->andReturn( 'pro_byok' );
 
 		$this->assertTrue( NJ_Tier_Manager::user_can( 'chat' ) );
 		$this->assertTrue( NJ_Tier_Manager::user_can( 'model_selection' ) );
 		$this->assertTrue( NJ_Tier_Manager::user_can( 'own_api_key' ) );
+		$this->assertTrue( NJ_Tier_Manager::user_can( 'generator' ) );
+		$this->assertTrue( NJ_Tier_Manager::user_can( 'seo' ) );
+		$this->assertTrue( NJ_Tier_Manager::user_can( 'images' ) );
+	}
+
+	public function test_free_user_cannot_use_content_features(): void {
+		Functions\expect( 'get_current_user_id' )->times( 3 )->andReturn( 1 );
+		Functions\expect( 'get_user_meta' )->times( 3 )->with( 1, 'wp_ai_mind_tier', true )->andReturn( 'free' );
+
+		$this->assertFalse( NJ_Tier_Manager::user_can( 'generator' ) );
+		$this->assertFalse( NJ_Tier_Manager::user_can( 'seo' ) );
+		$this->assertFalse( NJ_Tier_Manager::user_can( 'images' ) );
+	}
+
+	public function test_trial_user_can_use_content_features(): void {
+		Functions\expect( 'get_current_user_id' )->times( 3 )->andReturn( 10 );
+		Functions\expect( 'get_user_meta' )->times( 3 )->with( 10, 'wp_ai_mind_tier', true )->andReturn( 'trial' );
+
+		$this->assertTrue( NJ_Tier_Manager::user_can( 'generator' ) );
+		$this->assertTrue( NJ_Tier_Manager::user_can( 'seo' ) );
+		$this->assertTrue( NJ_Tier_Manager::user_can( 'images' ) );
+	}
+
+	public function test_pro_managed_user_can_use_content_features(): void {
+		Functions\expect( 'get_current_user_id' )->times( 3 )->andReturn( 2 );
+		Functions\expect( 'get_user_meta' )->times( 3 )->with( 2, 'wp_ai_mind_tier', true )->andReturn( 'pro_managed' );
+
+		$this->assertTrue( NJ_Tier_Manager::user_can( 'generator' ) );
+		$this->assertTrue( NJ_Tier_Manager::user_can( 'seo' ) );
+		$this->assertTrue( NJ_Tier_Manager::user_can( 'images' ) );
 	}
 
 	public function test_get_monthly_limit_returns_null_for_pro_byok(): void {


### PR DESCRIPTION
## Summary

`NJ_Tier_Config` was missing `generator`, `seo`, and `images` feature keys. As a result, every pro gate across the plugin fell back to `user_can('chat')`, which returns `true` for all tiers — silently exposing all pro features to free users.

## Root cause

`NJ_Tier_Config::FEATURES` only defined `chat`, `model_selection`, and `own_api_key`. The architecture requires content-module feature keys that distinguish free users from trial and paid users. Without them, every `isPro` field and every REST permission callback was effectively bypassed.

## Changes

### `includes/Tiers/NJ_Tier_Config.php`
Added `generator`, `seo`, and `images` to the feature matrix:

| Feature | free | trial | pro_managed | pro_byok |
|---------|------|-------|-------------|---------|
| `generator` | false | true | true | true |
| `seo` | false | true | true | true |
| `images` | false | true | true | true |

### Admin pages and modules — `isPro` localisation
Replaced `user_can('chat')` with semantically correct checks:
- `SettingsPage`, `ChatPage`, `DashboardPage`, `GeneratorPage`, `EditorModule`, `FrontendWidgetModule`, `UsageModule` → `user_can('generator')`
- `ImagesModule` → `user_can('images')`
- `SeoModule` → `user_can('seo')`

### REST permission callbacks
- `GeneratorModule /generate` → `user_can('generator')`
- `ImagesModule /images/generate` → `user_can('images')`
- `SeoModule /seo/generate` and `/seo/apply` → `user_can('seo')`

### `includes/Modules/Chat/SettingsRestController.php`
Added `is_pro => NJ_Tier_Manager::user_can('generator')` to the GET settings response so `FeaturesTab.jsx` reads the correct tier status instead of always defaulting to `false`.

## Related

- Resolves the underlying cause of #247
- Depends on #245 (NJ_Tier_Manager foundation)

## Test plan

- [ ] PHPUnit passes
- [ ] PHPCS passes
- [ ] Manual: free user — pro quick actions hidden; generator, SEO, and images REST endpoints return 403
- [ ] Manual: trial user — pro quick actions visible; REST endpoints accessible
- [ ] Manual: pro user — full access throughout
- [ ] Manual: Settings → Features tab — pro module toggles correctly locked/unlocked per tier

https://claude.ai/code/session_01GY9qv2Eer4G4nXmM31u2m1