### PR TITLE
docs(agents): add comprehensive code documentation standards

### DIFF
--- a/.claude/agents/wordpress-coder.md
+++ b/.claude/agents/wordpress-coder.md
@@ -151,6 +151,9 @@ If any match is found inside HTML content (not inside a `<!-- wp:... -->` commen
 - Escape ALL output: `esc_html()`, `esc_attr()`, `esc_url()`
 - Sanitize ALL input: `sanitize_text_field()`, `absint()`
 - Follow WordPress PHP Coding Standards
+- Write PHPDoc for ALL public PHP methods and classes (see documentation standards in `CLAUDE.md`)
+- Write JSDoc for ALL exported React components (see documentation standards in `CLAUDE.md`)
+- Add inline "why" comments only where the reason is non-obvious — never describe what the code does
 - Use proper WordPress hooks and filters
 - Ensure accessibility compliance
 - Write secure, performant code

--- a/.claude/agents/wordpress-planner.md
+++ b/.claude/agents/wordpress-planner.md
@@ -51,6 +51,7 @@ For every planning request, you will:
    - Security and performance considerations
    - Testing approach for each environment
    - Mobile-first layout strategy: define the mobile layout (single column, stacked, collapsed navigation, minimum 44×44px tap targets) BEFORE the desktop layout. All breakpoints must use `min-width`. State which theme.json spacing/typography presets apply at mobile without override.
+   - Documentation requirements: note any complex functions, non-obvious state shapes, or prop contracts that need PHPDoc/JSDoc summary lines explaining *why* the design was chosen — not just what it does
 
 4. **Risk Assessment**: Identify potential issues, conflicts with existing functionality, and mitigation strategies.
 

--- a/.claude/agents/wordpress-planner.md
+++ b/.claude/agents/wordpress-planner.md
@@ -51,7 +51,7 @@ For every planning request, you will:
    - Security and performance considerations
    - Testing approach for each environment
    - Mobile-first layout strategy: define the mobile layout (single column, stacked, collapsed navigation, minimum 44×44px tap targets) BEFORE the desktop layout. All breakpoints must use `min-width`. State which theme.json spacing/typography presets apply at mobile without override.
-   - Documentation requirements: note any complex functions, non-obvious state shapes, or prop contracts that need PHPDoc/JSDoc summary lines explaining *why* the design was chosen — not just what it does
+   - Documentation requirements: flag complex functions, non-obvious state shapes, and prop contracts that need PHPDoc/JSDoc summary lines explaining *why* the design was chosen.
 
 4. **Risk Assessment**: Identify potential issues, conflicts with existing functionality, and mitigation strategies.
 

--- a/.claude/agents/wordpress-reviewer.md
+++ b/.claude/agents/wordpress-reviewer.md
@@ -157,7 +157,7 @@ See `.agents/_shared/file-hygiene.md` for full conventions.
 - British English in all content
 - All newly added or modified public PHP methods and classes have PHPDoc (`@param`, `@return`, `@since`, `@throws` if raised)
 - All newly added or modified exported React components have JSDoc (`@param` per prop, `@returns`)
-- Inline comments explain "why" — flag any comment that merely restates what the code does
+- Inline comments explain `why` — flag any comment that merely restates what the code does
 - Correct hook usage and plugin compatibility
 - Database schema integrity
 - No hardcoded values; use constants, options, or WordPress functions/settings/REST API instead

--- a/.claude/agents/wordpress-reviewer.md
+++ b/.claude/agents/wordpress-reviewer.md
@@ -155,6 +155,9 @@ See `.agents/_shared/file-hygiene.md` for full conventions.
 - Adherence to WordPress PHP Coding Standards
 - Proper use of `nj_` function prefixes
 - British English in all content
+- All newly added or modified public PHP methods and classes have PHPDoc (`@param`, `@return`, `@since`, `@throws` if raised)
+- All newly added or modified exported React components have JSDoc (`@param` per prop, `@returns`)
+- Inline comments explain "why" — flag any comment that merely restates what the code does
 - Correct hook usage and plugin compatibility
 - Database schema integrity
 - No hardcoded values; use constants, options, or WordPress functions/settings/REST API instead

--- a/.claude/agents/wordpress-reviewer.md
+++ b/.claude/agents/wordpress-reviewer.md
@@ -156,7 +156,7 @@ See `.agents/_shared/file-hygiene.md` for full conventions.
 - Proper use of `nj_` function prefixes
 - British English in all content
 - All newly added or modified public PHP methods and classes have PHPDoc (`@param`, `@return`, `@since`, `@throws` if raised)
-- All newly added or modified exported React components have JSDoc (`@param` per prop, `@returns`)
+- All newly added or modified exported React components have JSDoc (`@param` per prop, `@returns`; shared/reusable components also require `@example`)
 - Inline comments explain `why` — flag any comment that merely restates what the code does
 - Correct hook usage and plugin compatibility
 - Database schema integrity

--- a/.claude/agents/wordpress-standards-validator.md
+++ b/.claude/agents/wordpress-standards-validator.md
@@ -88,7 +88,7 @@ This is a SEPARATE checklist from styling. Block validation errors are caused by
 - **Security:** Uses proper sanitisation, validation, and nonce verification
 - **Performance:** Efficient database queries, proper caching, per-block CSS loading
 - **Accessibility:** WCAG compliance and WordPress accessibility standards
-- **Maintainability:** Code is readable, well-documented, and follows conventions
+- **Maintainability:** Code is readable; all public PHP methods and classes have PHPDoc blocks (including `@since`, `@param`, `@return`); all exported React components have JSDoc; inline comments explain "why" not "what"
 - **WordPress Way:** Uses WordPress APIs instead of custom solutions when possible
 - **Backwards Compatibility:** Considers WordPress version requirements
 - **Scalability:** Solution can handle growth without major refactoring

--- a/.claude/agents/wordpress-standards-validator.md
+++ b/.claude/agents/wordpress-standards-validator.md
@@ -88,7 +88,7 @@ This is a SEPARATE checklist from styling. Block validation errors are caused by
 - **Security:** Uses proper sanitisation, validation, and nonce verification
 - **Performance:** Efficient database queries, proper caching, per-block CSS loading
 - **Accessibility:** WCAG compliance and WordPress accessibility standards
-- **Maintainability:** Code is readable; all public PHP methods and classes have PHPDoc blocks (including `@since`, `@param`, `@return`); all exported React components have JSDoc; inline comments explain "why" not "what"
+- **Maintainability:** Code is readable; all public PHP methods and classes have PHPDoc blocks (`@since`, `@param`, `@return`); all exported React components have JSDoc. Inline comments explain "why", not "what".
 - **WordPress Way:** Uses WordPress APIs instead of custom solutions when possible
 - **Backwards Compatibility:** Considers WordPress version requirements
 - **Scalability:** Solution can handle growth without major refactoring

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,57 @@ Use WordPress admin color variables in wp-admin UI.
 - Prefix globals if necessary.
 - Follow Block Editor `@wordpress/blocks` standards for custom Gutenberg blocks.
 
+## Code Documentation Standards
+
+### PHP (PHPDoc)
+- ALL public methods and class declarations MUST have a PHPDoc block (`/** ... */`).
+- Include `@since x.y.z` (WordPress convention — version the method was introduced).
+- Include `@param` for every parameter, `@return` for return type, `@throws` where relevant.
+- Describe *why* any non-obvious constraint applies in the block summary line — not what.
+
+```php
+/**
+ * Adds a message to a conversation thread.
+ *
+ * $role must be 'user' or 'assistant'. $model is empty for user turns.
+ *
+ * @since 1.0.0
+ * @param int    $conversation_id  The conversation record ID.
+ * @param string $role             Message author: 'user' or 'assistant'.
+ * @param string $content          Sanitised message text.
+ * @param string $model            Model slug (e.g. 'claude-opus-4-6'); empty for user turns.
+ * @param int    $tokens           Token count for usage tracking; 0 if unknown.
+ * @return int   Inserted message row ID.
+ */
+```
+
+### JavaScript/React (JSDoc)
+- ALL exported React components MUST have a JSDoc block above the function.
+- Use `@param {Object} props` with one `@param` sub-entry per prop (type + description).
+- Use `@returns {ReactElement}`.
+- Shared/reusable components MUST include a `@example`.
+
+```jsx
+/**
+ * Shared data table with tab filtering and pagination.
+ *
+ * @param {Object}   props
+ * @param {Array}    props.tabs      Tab definitions: `[{ id, label, filter }]`.
+ * @param {Function} props.WorkArea  Component rendered in the expanded row area.
+ * @param {Array}    props.columns   Column definitions: `[{ label, render, width? }]`.
+ * @returns {ReactElement}
+ *
+ * @example
+ * <PostListTable tabs={SEO_TABS} WorkArea={SeoWorkArea} columns={SEO_COLUMNS} />
+ */
+```
+
+### Inline comments — "why", never "what"
+- Only add an inline comment when the reason is non-obvious: a hidden constraint, a subtle
+  invariant, a non-obvious API quirk, or a deliberate workaround.
+- Never describe *what* the code does; well-named identifiers already do that.
+- British English. Single line where possible.
+
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ Use WordPress admin color variables in wp-admin UI.
 - ALL exported React components MUST have a JSDoc block above the function.
 - Use `@param {Object} props` with one `@param` sub-entry per prop (type + description).
 - Use `@returns {ReactElement}`.
+- Use `@throws {Error}` for async functions or hooks that can throw; omit for synchronous components that never throw.
 - Shared/reusable components MUST include a `@example`.
 
 ```jsx
@@ -168,7 +169,6 @@ Use WordPress admin color variables in wp-admin UI.
   invariant, a non-obvious API quirk, or a deliberate workaround.
 - Never describe *what* the code does; well-named identifiers already do that.
 - British English. Single line where possible.
-
 
 ---
 


### PR DESCRIPTION
## Summary
Establishes mandatory documentation standards for PHP and JavaScript/React code across the project, ensuring consistent, maintainable, and well-documented codebase.

## Key Changes

- **PHP Documentation (PHPDoc)**: Added requirement that ALL public methods and class declarations include PHPDoc blocks with `@since`, `@param`, `@return`, and `@throws` tags where applicable. Includes guidance to document *why* non-obvious constraints exist, not just what the code does.

- **JavaScript/React Documentation (JSDoc)**: Added requirement that ALL exported React components include JSDoc blocks with structured `@param` entries per prop, `@returns` type, and `@example` for shared/reusable components.

- **Inline Comments Policy**: Clarified that inline comments should only explain *why* code exists (hidden constraints, invariants, API quirks, workarounds) — never describe what the code does, as well-named identifiers already convey that.

- **Agent Guidelines Updated**: Propagated documentation standards across all agent files:
  - `wordpress-coder.md`: Added explicit reminders to write PHPDoc and JSDoc per standards
  - `wordpress-reviewer.md`: Added checklist items to verify PHPDoc/JSDoc compliance and inline comment quality
  - `wordpress-standards-validator.md`: Updated maintainability criteria to explicitly require PHPDoc blocks and JSDoc for exported components
  - `wordpress-planner.md`: Added documentation requirements to planning checklist for complex functions and non-obvious design decisions

## Implementation Details

- Provided concrete code examples for both PHP and React documentation patterns
- Specified British English for all inline comments
- Aligned with WordPress conventions (e.g., `@since` versioning)
- Emphasised documentation of constraints and design rationale, not just API signatures

https://claude.ai/code/session_01SgZVqVmRPP39pUUh57TjC7