### PR TITLE
fix(settings): enforce own_api_key tier gate on REST API key save endpoints

### DIFF
--- a/includes/Admin/NJ_Api_Key_Settings.php
+++ b/includes/Admin/NJ_Api_Key_Settings.php
@@ -177,7 +177,7 @@ class NJ_Api_Key_Settings {
 	}
 
 	public static function decrypt( string $ciphertext ): string|false {
-		$key  = self::derive_key();
+		$key = self::derive_key();
 		if ( false === $key ) {
 			return false;
 		}

--- a/includes/Admin/OnboardingRestController.php
+++ b/includes/Admin/OnboardingRestController.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 namespace WP_AI_Mind\Admin;
 
 use WP_AI_Mind\Settings\ProviderSettings;
+use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -71,6 +72,16 @@ class OnboardingRestController {
 			update_option( 'wp_ai_mind_default_provider', sanitize_text_field( $provider ) );
 		}
 		if ( $api_keys && is_array( $api_keys ) ) {
+			if ( ! NJ_Tier_Manager::user_can( 'own_api_key' ) ) {
+				return new WP_REST_Response(
+					[
+						'code'    => 'rest_plan_required',
+						'message' => __( 'API key management requires the Pro BYOK plan.', 'wp-ai-mind' ),
+					],
+					403
+				);
+			}
+
 			$valid    = [ 'openai', 'claude', 'gemini' ];
 			$settings = static::make_provider_settings();
 			foreach ( $api_keys as $p => $key ) {

--- a/includes/Admin/OnboardingRestController.php
+++ b/includes/Admin/OnboardingRestController.php
@@ -72,9 +72,9 @@ class OnboardingRestController {
 	 *
 	 * @since 1.0.0
 	 * @param WP_REST_Request $request Incoming REST request.
-	 * @return WP_REST_Response 200 on success; 403 if tier gate fails.
+	 * @return WP_REST_Response|\WP_Error 200 on success; WP_Error 403 if tier gate fails.
 	 */
-	public static function save( WP_REST_Request $request ): WP_REST_Response {
+	public static function save( WP_REST_Request $request ): WP_REST_Response|\WP_Error {
 		$seen = $request->get_param( 'seen' );
 
 		if ( true === $seen ) {
@@ -90,12 +90,10 @@ class OnboardingRestController {
 		}
 		if ( $api_keys && is_array( $api_keys ) ) {
 			if ( ! NJ_Tier_Manager::user_can( 'own_api_key' ) ) {
-				return new WP_REST_Response(
-					[
-						'code'    => 'rest_plan_required',
-						'message' => __( 'API key management requires the Pro BYOK plan.', 'wp-ai-mind' ),
-					],
-					403
+				return new \WP_Error(
+					'rest_plan_required',
+					__( 'API key management requires the Pro BYOK plan.', 'wp-ai-mind' ),
+					[ 'status' => 403 ]
 				);
 			}
 

--- a/includes/Admin/OnboardingRestController.php
+++ b/includes/Admin/OnboardingRestController.php
@@ -14,6 +14,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class OnboardingRestController {
 
+	/**
+	 * Registers the onboarding REST route.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register_routes(): void {
 		register_rest_route(
 			'wp-ai-mind/v1',
@@ -57,6 +63,17 @@ class OnboardingRestController {
 		);
 	}
 
+	/**
+	 * Handles the onboarding POST endpoint.
+	 *
+	 * Saves provider, API keys, and onboarding-seen state from the request.
+	 * Returns 403 if the current user's tier does not include the own_api_key feature
+	 * and api_keys are present in the payload.
+	 *
+	 * @since 1.0.0
+	 * @param WP_REST_Request $request Incoming REST request.
+	 * @return WP_REST_Response 200 on success; 403 if tier gate fails.
+	 */
 	public static function save( WP_REST_Request $request ): WP_REST_Response {
 		$seen = $request->get_param( 'seen' );
 

--- a/includes/Modules/Chat/SettingsRestController.php
+++ b/includes/Modules/Chat/SettingsRestController.php
@@ -83,9 +83,9 @@ class SettingsRestController {
 	 * Saves plugin settings from the request body.
 	 *
 	 * @param \WP_REST_Request $request Incoming REST request.
-	 * @return \WP_REST_Response
+	 * @return \WP_REST_Response|\WP_Error
 	 */
-	public function save_settings( \WP_REST_Request $request ): \WP_REST_Response {
+	public function save_settings( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
 		$provider_settings = $this->make_provider_settings();
 		$json_params       = $request->get_json_params();
 		$params            = ! empty( $json_params ) ? $json_params : [];
@@ -127,6 +127,14 @@ class SettingsRestController {
 		// API keys — skip any that are the mask placeholder (i.e. unchanged).
 		$api_keys = $request->get_param( 'api_keys' );
 		if ( is_array( $api_keys ) ) {
+			if ( ! NJ_Tier_Manager::user_can( 'own_api_key' ) ) {
+				return new \WP_Error(
+					'rest_plan_required',
+					__( 'API key management requires the Pro BYOK plan.', 'wp-ai-mind' ),
+					[ 'status' => 403 ]
+				);
+			}
+
 			$provider_map = [ 'claude', 'openai', 'gemini' ];
 
 			foreach ( $provider_map as $provider ) {

--- a/tests/Unit/Admin/OnboardingRestControllerTest.php
+++ b/tests/Unit/Admin/OnboardingRestControllerTest.php
@@ -156,9 +156,9 @@ class OnboardingRestControllerTest extends TestCase {
 
 		$response = OnboardingRestController::save( $request );
 
-		$this->assertInstanceOf( \WP_REST_Response::class, $response );
-		$this->assertSame( 403, $response->get_status() );
-		$this->assertSame( 'rest_plan_required', $response->data['code'] );
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'rest_plan_required', $response->get_error_code() );
+		$this->assertSame( 403, $response->get_error_data( 'rest_plan_required' )['status'] );
 	}
 
 	// ── save() — response ────────────────────────────────────────────────────

--- a/tests/Unit/Admin/OnboardingRestControllerTest.php
+++ b/tests/Unit/Admin/OnboardingRestControllerTest.php
@@ -100,6 +100,9 @@ class OnboardingRestControllerTest extends TestCase {
 
 	public function test_save_stores_api_keys_per_provider(): void {
 		Functions\when( 'sanitize_text_field' )->alias( fn( $s ) => $s );
+		// Tier gate: NJ_Tier_Manager::user_can() needs these stubs.
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
 
 		$mock_settings = $this->createMock( ProviderSettings::class );
 		$mock_settings->expects( $this->once() )
@@ -121,6 +124,10 @@ class OnboardingRestControllerTest extends TestCase {
 	}
 
 	public function test_save_ignores_invalid_provider_in_api_keys(): void {
+		// Tier gate: NJ_Tier_Manager::user_can() needs these stubs.
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
+
 		$mock_settings = $this->createMock( ProviderSettings::class );
 		$mock_settings->expects( $this->never() )->method( 'set_api_key' );
 
@@ -136,6 +143,22 @@ class OnboardingRestControllerTest extends TestCase {
 		$request->set_param( 'api_keys', [ 'unknown' => 'some-key' ] );
 
 		$ctrl::save( $request );
+	}
+
+	public function test_save_api_keys_rejected_for_free_tier(): void {
+		Functions\when( '__' )->alias( fn( $s ) => $s );
+		// Tier gate: simulate a free-tier user.
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'free' );
+
+		$request = new \WP_REST_Request( 'POST' );
+		$request->set_param( 'api_keys', [ 'openai' => 'sk-test' ] );
+
+		$response = OnboardingRestController::save( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'rest_plan_required', $response->data['code'] );
 	}
 
 	// ── save() — response ────────────────────────────────────────────────────

--- a/tests/Unit/Admin/OnboardingRestControllerTest.php
+++ b/tests/Unit/Admin/OnboardingRestControllerTest.php
@@ -102,7 +102,7 @@ class OnboardingRestControllerTest extends TestCase {
 		Functions\when( 'sanitize_text_field' )->alias( fn( $s ) => $s );
 		// Tier gate: NJ_Tier_Manager::user_can() needs these stubs.
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
-		Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
+		Functions\when( 'get_user_meta' )->alias( fn( $uid, $key, $single ) => $key === 'wp_ai_mind_tier' ? 'pro_byok' : null );
 
 		$mock_settings = $this->createMock( ProviderSettings::class );
 		$mock_settings->expects( $this->once() )
@@ -126,7 +126,7 @@ class OnboardingRestControllerTest extends TestCase {
 	public function test_save_ignores_invalid_provider_in_api_keys(): void {
 		// Tier gate: NJ_Tier_Manager::user_can() needs these stubs.
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
-		Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
+		Functions\when( 'get_user_meta' )->alias( fn( $uid, $key, $single ) => $key === 'wp_ai_mind_tier' ? 'pro_byok' : null );
 
 		$mock_settings = $this->createMock( ProviderSettings::class );
 		$mock_settings->expects( $this->never() )->method( 'set_api_key' );
@@ -147,9 +147,9 @@ class OnboardingRestControllerTest extends TestCase {
 
 	public function test_save_api_keys_rejected_for_free_tier(): void {
 		Functions\when( '__' )->alias( fn( $s ) => $s );
-		// Tier gate: simulate a free-tier user.
+		// tier gate: simulate a free-tier user.
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
-		Functions\when( 'get_user_meta' )->justReturn( 'free' );
+		Functions\when( 'get_user_meta' )->alias( fn( $uid, $key, $single ) => $key === 'wp_ai_mind_tier' ? 'free' : null );
 
 		$request = new \WP_REST_Request( 'POST' );
 		$request->set_param( 'api_keys', [ 'openai' => 'sk-test' ] );

--- a/tests/Unit/Modules/Chat/SettingsRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/SettingsRestControllerTest.php
@@ -182,6 +182,10 @@ class SettingsRestControllerTest extends TestCase {
         Functions\when( 'esc_url_raw' )->alias( fn( $v ) => $v );
         // ModuleRegistry::__construct() calls get_option to load saved state.
         Functions\when( 'get_option' )->justReturn( [] );
+        // NJ_Tier_Manager::user_can() reads tier via get_current_user_id + get_user_meta.
+        // Use pro_byok so both model_selection and own_api_key gates pass.
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
 
         $api_key_calls = [];
         $controller = new class( $api_key_calls ) extends SettingsRestController {
@@ -440,6 +444,9 @@ class SettingsRestControllerTest extends TestCase {
     public function test_save_settings_skips_masked_api_keys(): void {
         Functions\when( 'update_option' )->justReturn( true );
         Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+        // Tier gate: NJ_Tier_Manager::user_can() needs these stubs.
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
 
         $api_key_calls = [];
         $controller = new class( $api_key_calls ) extends SettingsRestController {
@@ -471,5 +478,38 @@ class SettingsRestControllerTest extends TestCase {
 
         // No provider keys should be saved when all values are masked.
         $this->assertEmpty( $api_key_calls );
+    }
+
+    public function test_save_settings_rejects_api_keys_for_free_tier(): void {
+        Functions\when( 'update_option' )->justReturn( true );
+        Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+        Functions\when( '__' )->alias( fn( $s ) => $s );
+        // Tier gate: simulate a free-tier user.
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'get_user_meta' )->justReturn( 'free' );
+
+        $controller = new class extends SettingsRestController {
+            protected function make_provider_settings(): \WP_AI_Mind\Settings\ProviderSettings {
+                $stub = new class extends \WP_AI_Mind\Settings\ProviderSettings {
+                    public function __construct() {}
+                    public function set_api_key( string $provider, string $key ): void {}
+                };
+                return $stub;
+            }
+        };
+
+        $request = new \WP_REST_Request();
+        $request->set_body_params( [
+            'api_keys' => [
+                'claude' => 'sk-free-attempt',
+            ],
+        ] );
+
+        $response = $controller->save_settings( $request );
+
+        // Free-tier users must be rejected with 403 and the plan_required error code.
+        $this->assertInstanceOf( \WP_Error::class, $response );
+        $this->assertSame( 'rest_plan_required', $response->get_error_code() );
+        $this->assertSame( 403, $response->get_error_data()['status'] );
     }
 }

--- a/tests/Unit/Modules/Chat/SettingsRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/SettingsRestControllerTest.php
@@ -37,7 +37,7 @@ class SettingsRestControllerTest extends TestCase {
         Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
         Functions\when( 'get_post_types' )->justReturn( [] );
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
-        Functions\when( 'get_user_meta' )->justReturn( 'free' );
+        Functions\when( 'get_user_meta' )->alias( fn( $uid, $key, $single ) => $key === 'wp_ai_mind_tier' ? 'free' : null );
         Functions\when( 'get_option' )->alias( function( $key, $default = '' ) {
             $map = [
                 'wp_ai_mind_default_provider' => 'claude',
@@ -87,7 +87,7 @@ class SettingsRestControllerTest extends TestCase {
         Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
         Functions\when( 'get_post_types' )->justReturn( [] );
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
-        Functions\when( 'get_user_meta' )->justReturn( 'free' );
+        Functions\when( 'get_user_meta' )->alias( fn( $uid, $key, $single ) => $key === 'wp_ai_mind_tier' ? 'free' : null );
         Functions\when( 'get_option' )->justReturn( '' );
         Functions\when( 'wp_ai_mind_is_pro' )->justReturn( false );
 
@@ -185,7 +185,7 @@ class SettingsRestControllerTest extends TestCase {
         // NJ_Tier_Manager::user_can() reads tier via get_current_user_id + get_user_meta.
         // Use pro_byok so both model_selection and own_api_key gates pass.
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
-        Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
+        Functions\when( 'get_user_meta' )->alias( fn( $uid, $key, $single ) => $key === 'wp_ai_mind_tier' ? 'pro_byok' : null );
 
         $api_key_calls = [];
         $controller = new class( $api_key_calls ) extends SettingsRestController {
@@ -253,7 +253,7 @@ class SettingsRestControllerTest extends TestCase {
     public function test_get_settings_returns_allowed_post_types(): void {
         Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
-        Functions\when( 'get_user_meta' )->justReturn( 'free' );
+        Functions\when( 'get_user_meta' )->alias( fn( $uid, $key, $single ) => $key === 'wp_ai_mind_tier' ? 'free' : null );
         Functions\when( 'get_option' )->alias( function( $key, $default = '' ) {
             if ( 'wp_ai_mind_allowed_post_types' === $key ) {
                 return [ 'post' ];
@@ -285,7 +285,7 @@ class SettingsRestControllerTest extends TestCase {
     public function test_get_settings_returns_available_post_types(): void {
         Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
-        Functions\when( 'get_user_meta' )->justReturn( 'free' );
+        Functions\when( 'get_user_meta' )->alias( fn( $uid, $key, $single ) => $key === 'wp_ai_mind_tier' ? 'free' : null );
         Functions\when( 'get_option' )->alias( function( $key, $default = '' ) {
             return is_array( $default ) ? $default : '';
         } );
@@ -392,7 +392,7 @@ class SettingsRestControllerTest extends TestCase {
         Functions\when( 'get_post_types' )->justReturn( [] );
         Functions\when( 'get_option' )->justReturn( '' );
         Functions\when( 'get_current_user_id' )->justReturn( 2 );
-        Functions\when( 'get_user_meta' )->justReturn( 'pro_managed' );
+        Functions\when( 'get_user_meta' )->alias( fn( $uid, $key, $single ) => $key === 'wp_ai_mind_tier' ? 'pro_managed' : null );
 
         $controller = new class extends SettingsRestController {
             protected function make_provider_settings(): \WP_AI_Mind\Settings\ProviderSettings {
@@ -419,7 +419,7 @@ class SettingsRestControllerTest extends TestCase {
         Functions\when( 'get_post_types' )->justReturn( [] );
         Functions\when( 'get_option' )->justReturn( '' );
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
-        Functions\when( 'get_user_meta' )->justReturn( 'free' );
+        Functions\when( 'get_user_meta' )->alias( fn( $uid, $key, $single ) => $key === 'wp_ai_mind_tier' ? 'free' : null );
 
         $controller = new class extends SettingsRestController {
             protected function make_provider_settings(): \WP_AI_Mind\Settings\ProviderSettings {
@@ -446,7 +446,7 @@ class SettingsRestControllerTest extends TestCase {
         Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
         // Tier gate: NJ_Tier_Manager::user_can() needs these stubs.
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
-        Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
+        Functions\when( 'get_user_meta' )->alias( fn( $uid, $key, $single ) => $key === 'wp_ai_mind_tier' ? 'pro_byok' : null );
 
         $api_key_calls = [];
         $controller = new class( $api_key_calls ) extends SettingsRestController {
@@ -484,9 +484,9 @@ class SettingsRestControllerTest extends TestCase {
         Functions\when( 'update_option' )->justReturn( true );
         Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
         Functions\when( '__' )->alias( fn( $s ) => $s );
-        // Tier gate: simulate a free-tier user.
+        // tier gate: simulate a free-tier user.
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
-        Functions\when( 'get_user_meta' )->justReturn( 'free' );
+        Functions\when( 'get_user_meta' )->alias( fn( $uid, $key, $single ) => $key === 'wp_ai_mind_tier' ? 'free' : null );
 
         $controller = new class extends SettingsRestController {
             protected function make_provider_settings(): \WP_AI_Mind\Settings\ProviderSettings {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,15 +27,20 @@ if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		public string $code;
 		public string $message;
+		private mixed $data;
 		public function __construct( string $code = '', string $message = '', $data = null ) {
 			$this->code    = $code;
 			$this->message = $message;
+			$this->data    = $data;
 		}
 		public function get_error_message(): string {
 			return $this->message;
 		}
 		public function get_error_code(): string {
 			return $this->code;
+		}
+		public function get_error_data( string $code = '' ): mixed {
+			return $this->data;
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #241 (backend half) — `ProvidersTab.jsx` already gates the UI correctly; this PR enforces the same check server-side so a free/trial user cannot bypass the UI and POST API keys directly.

### Endpoints audited

| Endpoint | Before | After |
|---|---|---|
| `POST /wp-ai-mind/v1/onboarding` | ❌ No tier check | ✅ Returns 403 `rest_plan_required` for non-`own_api_key` tiers |
| `POST /wp-ai-mind/v1/settings` (api_keys field) | ❌ No tier check | ✅ Same gate added |
| `POST /wp-ai-mind/v1/user/api-key` | ✅ Already gated | No change |
| `POST /wp-ai-mind/v1/test-key` | n/a — validates only, never persists | No change needed |

### Tests
- `OnboardingRestControllerTest`: new `test_save_api_keys_rejected_for_free_tier` (expects 403).
- `SettingsRestControllerTest`: new `test_save_settings_rejects_api_keys_for_free_tier`.
- `tests/bootstrap.php`: adds missing `get_error_data()` to the `WP_Error` stub.

## Test plan

- [ ] `./vendor/bin/phpunit tests/Unit/ --colors=always` — all tests pass
- [ ] `./vendor/bin/phpcs includes/Admin/OnboardingRestController.php includes/Modules/Chat/SettingsRestController.php` — no violations

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1ryPHZ6gAPdpBoMm1CtkV)_