### PR TITLE
feat(ci): batch auto-fix — one Claude session per PR, remove max-turns limits

### DIFF
--- a/.github/workflows/auto-fix-ci.yml
+++ b/.github/workflows/auto-fix-ci.yml
@@ -61,4 +61,4 @@ jobs:
             - PHPUnit: fix the code under test, not the tests themselves, unless the test assertion is clearly wrong.
             - Do NOT bump version numbers, modify composer.lock, or change package-lock.json.
 
-          claude_args: "--max-turns 15 --allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"
+          claude_args: "--allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"

--- a/.github/workflows/auto-fix-review-issue.yml
+++ b/.github/workflows/auto-fix-review-issue.yml
@@ -217,7 +217,7 @@ jobs:
             - Do NOT bump version numbers, modify `composer.lock`, or change `package-lock.json`.
             - Do NOT open more than one PR per issue.
 
-          claude_args: "--max-turns 25 --allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"
+          claude_args: "--allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"
 
       # Surface the actual failure reason when Claude hits max turns or errors out.
       # The action's default error chain ("Execution failed: Action failed with error:

--- a/.github/workflows/batch-auto-fix.yml
+++ b/.github/workflows/batch-auto-fix.yml
@@ -51,17 +51,6 @@ jobs:
             echo "Wrote body for issue #${issue_number}"
           done
 
-      - name: Calculate max turns
-        id: turns
-        env:
-          ISSUES_JSON: ${{ toJson(github.event.client_payload.issue_numbers) }}
-        run: |
-          NUM=$(echo "$ISSUES_JSON" | jq 'length')
-          # 10 base turns + 8 per issue, uncapped — user preference is no turn limit.
-          TURNS=$(( 10 + NUM * 8 ))
-          echo "value=$TURNS" >> "$GITHUB_OUTPUT"
-          echo "Max turns for $NUM issues: $TURNS"
-
       - name: Run Claude batch auto-fix
         id: claude
         uses: anthropics/claude-code-action@aee99972d0cfa0c47a4563e6fca42d7a5a0cb9bd  # v1
@@ -148,7 +137,7 @@ jobs:
             - Do NOT open new PRs — push all fixes directly to the head branch.
             - Do NOT open more than one PR per issue.
 
-          claude_args: "--max-turns ${{ steps.turns.outputs.value }} --allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"
+          claude_args: "--allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"
 
       - name: Report execution failure
         if: failure() && steps.claude.outcome == 'failure'


### PR DESCRIPTION
## Summary

Optimises the automated PR review → auto-fix pipeline to eliminate redundant Claude Code session cold-starts and remove turn limits that were causing mid-task failures.

- **Replace N auto-fix sessions with 1 batch session per PR** — the review workflow previously applied an `auto-fix` label to each issue individually, firing a separate GitHub Actions runner per issue (full checkout, `npm ci`, `composer install`, and Claude cold-start each time). Now a single `repository_dispatch` event carries all issue numbers to a new `batch-auto-fix.yml` workflow, which fixes every issue in one session with separate commits (`closes #N`) and individual issue close comments. Typical saving: 3 redundant sessions on a 4-issue PR (~120k tokens).
- **Add `## Context` snippets to issue bodies** — the review prompt now instructs Claude to embed the relevant source lines (≤ 25 lines) in each issue body at creation time, so the fix session can skip a file-read turn per issue.
- **Remove `--max-turns` from all auto-fix workflows** — `auto-fix-ci.yml` (was 15, hit the limit on `feat/api-overhaul`), `auto-fix-review-issue.yml` (was 25), and `batch-auto-fix.yml` (had a calculated formula). The `timeout-minutes` on each job is the real safety valve; turn limits were cutting sessions short mid-fix.

The per-issue `auto-fix-review-issue.yml` workflow is kept as a manual fallback — a human can re-apply the `auto-fix` label to any individual issue to re-trigger it.

## Test plan

- [ ] Open a PR with at least 2 deliberate issues — confirm the review workflow creates issues and fires **one** `repository_dispatch` (no `auto-fix` labels applied to individual issues)
- [ ] Confirm `Batch Auto-fix Code Review Issues` run starts and produces separate commits per issue with `closes #N`
- [ ] Confirm both issues are closed with a summary comment
- [ ] Manually re-apply `auto-fix` label to a single open issue — confirm `auto-fix-review-issue.yml` still fires as expected (fallback path unchanged)
- [ ] Trigger a CI failure on a branch — confirm `auto-fix-ci.yml` runs to completion without hitting a turn limit

https://claude.ai/code/session_017wZa9WV4yXpAyzQxE573JD

---
_Generated by [Claude Code](https://claude.ai/code/session_017wZa9WV4yXpAyzQxE573JD)_