### PR TITLE
docs(codebase): add PHPDoc and JSDoc to all sources, enforce with tooling

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,51 @@
 module.exports = {
-	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
+	extends: [
+		'plugin:@wordpress/eslint-plugin/recommended',
+		'plugin:jsdoc/recommended-error',
+	],
+	plugins: [ 'jsdoc' ],
+	settings: {
+		jsdoc: {
+			mode: 'typescript',
+			tagNamePreference: {
+				// Enforce @return over @returns.
+				returns: 'return',
+			},
+		},
+	},
 	rules: {
 		// @wordpress/* packages are provided by WordPress core at runtime and
 		// externalized by @wordpress/scripts webpack. They are not installed as
 		// npm packages, so the module resolver cannot find them.
 		'import/no-unresolved': [ 'error', { ignore: [ '^@wordpress/' ] } ],
+
+		// Relax jsdoc rules that conflict with the project's documentation style.
+		'jsdoc/require-jsdoc': [
+			'error',
+			{
+				// Only exported (public) functions need a JSDoc block;
+				// inner helpers and event handlers are exempt.
+				publicOnly: true,
+				require: {
+					FunctionDeclaration: true,
+					ArrowFunctionExpression: true,
+					FunctionExpression: false,
+					MethodDefinition: false,
+				},
+				checkConstructors: false,
+			},
+		],
+		// Allow @return without a description (the type is sufficient).
+		'jsdoc/require-returns-description': 'off',
+		// Allow @param without a description when the name is self-documenting.
+		'jsdoc/require-param-description': 'off',
+		// JSDoc tags are checked by @wordpress/eslint-plugin already.
+		'jsdoc/check-tag-names': [ 'error', { definedTags: [ 'throws' ] } ],
+		// ReactElement, JSX.Element, etc. are valid types not resolvable in this config.
+		'jsdoc/no-undefined-types': 'off',
+		// Allow Function type — more specific types can be added case by case.
+		'jsdoc/reject-function-type': 'off',
+		// Allow nested prop paths (e.g. @param {string} props.message.role).
+		'jsdoc/check-param-names': 'off',
 	},
 };

--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -1,9 +1,27 @@
 <?php
+/**
+ * Registers the WP AI Mind admin menu and sub-menu pages.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Admin;
 
+/**
+ * Registers the top-level WP AI Mind admin menu and all sub-menu pages.
+ *
+ * The 'Upgrade' sub-menu is conditionally added only for free and trial users;
+ * Pro users see a clean menu without the upsell entry.
+ */
 class AdminMenu {
 
+	/**
+	 * Register all admin menu and sub-menu pages via WordPress hooks.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register(): void {
 		add_menu_page(
 			__( 'WP AI Mind', 'wp-ai-mind' ),
@@ -38,7 +56,14 @@ class AdminMenu {
 		}
 	}
 
-	/** Inline SVG — Lucide `sparkles` icon, zinc-400 (#a1a1aa). */
+	/**
+	 * Build the base64-encoded SVG data URI used as the menu icon.
+	 *
+	 * Inline SVG — Lucide `sparkles` icon, zinc-400 (#a1a1aa).
+	 *
+	 * @since 1.0.0
+	 * @return string Data URI string suitable for the $icon_url parameter of add_menu_page().
+	 */
 	private static function get_menu_icon(): string {
 		return 'data:image/svg+xml;base64,' . base64_encode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encoding SVG menu icon for WordPress admin, not obfuscation.
 			'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#a1a1aa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/></svg>'

--- a/includes/Admin/ChatPage.php
+++ b/includes/Admin/ChatPage.php
@@ -1,5 +1,10 @@
 <?php
-// includes/Admin/ChatPage.php
+/**
+ * Admin page rendering the main AI chat interface.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Admin;
 
@@ -7,13 +12,34 @@ use WP_AI_Mind\Providers\ProviderFactory;
 use WP_AI_Mind\Settings\ProviderSettings;
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 
+/**
+ * Renders the WP AI Mind chat admin page.
+ *
+ * Outputs a React mount point and enqueues the shared admin bundle with
+ * localised data that includes the default model label for the UI header.
+ */
 class ChatPage {
 
+	/**
+	 * Output the page markup and enqueue all required assets.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function render(): void {
 		self::enqueue_assets();
 		echo '<div id="wp-ai-mind-chat" class="wp-ai-mind-page"></div>';
 	}
 
+	/**
+	 * Enqueue the admin script and stylesheet, and localise runtime data.
+	 *
+	 * Resolves the default model label by instantiating the configured provider;
+	 * falls back to 'AI' if the provider factory throws (e.g. no API key set).
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	private static function enqueue_assets(): void {
 		$asset_file = WP_AI_MIND_DIR . 'assets/admin/index.asset.php';
 		$asset      = file_exists( $asset_file )

--- a/includes/Admin/DashboardPage.php
+++ b/includes/Admin/DashboardPage.php
@@ -1,12 +1,30 @@
 <?php
+/**
+ * Admin page rendering the WP AI Mind dashboard.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Admin;
 
 use WP_AI_Mind\Settings\ProviderSettings;
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 
+/**
+ * Renders the WP AI Mind dashboard admin page.
+ *
+ * Also handles the "Run setup again" GET action, which clears the
+ * onboarding-seen flag and redirects back to the dashboard root.
+ */
 class DashboardPage {
 
+	/**
+	 * Handle the optional run-setup action, then output the page markup and enqueue assets.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function render(): void {
 		// Handle "Run setup again" — nonce-protected GET action.
 		if (
@@ -23,6 +41,12 @@ class DashboardPage {
 		echo '<div id="wp-ai-mind-dashboard" class="wp-ai-mind-page"></div>';
 	}
 
+	/**
+	 * Enqueue the admin script and stylesheet, and localise dashboard data.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	private static function enqueue_assets(): void {
 		$asset_file = WP_AI_MIND_DIR . 'assets/admin/index.asset.php';
 		$asset      = file_exists( $asset_file )
@@ -54,6 +78,15 @@ class DashboardPage {
 		);
 	}
 
+	/**
+	 * Assemble the data object passed to the dashboard React app.
+	 *
+	 * Determines the upgrade banner state: suppressed for Pro/BYOK users and
+	 * trial users (who already have access and receive a separate expiry notice).
+	 *
+	 * @since 1.0.0
+	 * @return array<string, mixed> Associative array of localised dashboard data.
+	 */
 	private static function get_dashboard_data(): array {
 		$provider_settings = new ProviderSettings();
 		$provider          = (string) get_option( 'wp_ai_mind_default_provider', '' );

--- a/includes/Admin/GeneratorPage.php
+++ b/includes/Admin/GeneratorPage.php
@@ -1,5 +1,10 @@
 <?php
-// includes/Admin/GeneratorPage.php
+/**
+ * Admin page rendering the AI post-generator wizard.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Admin;
@@ -13,11 +18,23 @@ use WP_AI_Mind\Tiers\NJ_Tier_Manager;
  */
 class GeneratorPage {
 
+	/**
+	 * Output the page markup and enqueue all required assets.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function render(): void {
 		self::enqueue_assets();
 		echo '<div id="wp-ai-mind-generator" class="wp-ai-mind-page"></div>';
 	}
 
+	/**
+	 * Enqueue the generator script and stylesheet, and localise runtime data.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function enqueue_assets(): void {
 		$asset_file = WP_AI_MIND_DIR . 'assets/generator/index.asset.php';
 		$asset      = file_exists( $asset_file )

--- a/includes/Admin/ImagesPage.php
+++ b/includes/Admin/ImagesPage.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Admin page rendering the AI image generation interface.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Admin;
@@ -7,8 +13,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Renders the WP AI Mind image-generation admin page.
+ *
+ * Outputs a React mount point; assets are enqueued by ImagesModule.
+ */
 class ImagesPage {
 
+	/**
+	 * Output the page markup.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function render(): void {
 		echo '<div id="wp-ai-mind-images" class="wp-ai-mind-page"></div>';
 	}

--- a/includes/Admin/NJ_Api_Key_Settings.php
+++ b/includes/Admin/NJ_Api_Key_Settings.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Pro BYOK: API key management settings page and REST handling.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Admin;
 
@@ -186,6 +192,13 @@ class NJ_Api_Key_Settings {
 		<?php
 	}
 
+	/**
+	 * Return a masked display string for the stored API key of a provider.
+	 *
+	 * @since 1.2.0
+	 * @param string $provider Provider slug (e.g. 'claude', 'openai').
+	 * @return string Bullet-character mask when a key is stored, or empty string otherwise.
+	 */
 	private static function get_masked_key( string $provider ): string {
 		$encrypted = get_user_meta( get_current_user_id(), "wp_ai_mind_api_key_{$provider}", true );
 		return $encrypted ? '••••••••••••••••••••' : '';

--- a/includes/Admin/NJ_Tier_Status_Page.php
+++ b/includes/Admin/NJ_Tier_Status_Page.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Admin page displaying the current user's licence tier and usage status.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Admin;
 

--- a/includes/Admin/NJ_Usage_Widget.php
+++ b/includes/Admin/NJ_Usage_Widget.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * WordPress admin dashboard widget showing current-user token usage.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Admin;
 
@@ -70,8 +76,8 @@ class NJ_Usage_Widget {
 	 */
 	public static function render(): void {
 		$user_id = get_current_user_id();
-		$usage = NJ_Usage_Tracker::get_usage( $user_id );
-		$tier  = $usage['tier'];
+		$usage   = NJ_Usage_Tracker::get_usage( $user_id );
+		$tier    = $usage['tier'];
 
 		$tier_labels = [
 			'free'        => __( 'Free', 'wp-ai-mind' ),

--- a/includes/Admin/OnboardingRestController.php
+++ b/includes/Admin/OnboardingRestController.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * REST controller for the onboarding wizard flow.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Admin;
 
@@ -12,6 +18,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * REST controller for the onboarding wizard — marks the wizard seen and saves initial API settings.
+ *
+ * @since 1.0.0
+ */
 class OnboardingRestController {
 
 	/**

--- a/includes/Admin/SeoPage.php
+++ b/includes/Admin/SeoPage.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Admin page rendering the AI SEO metadata manager.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Admin;
@@ -7,8 +13,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Renders the WP AI Mind SEO admin page.
+ *
+ * Outputs a React mount point; assets are enqueued by SeoModule.
+ */
 class SeoPage {
 
+	/**
+	 * Output the page markup.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function render(): void {
 		echo '<div id="wp-ai-mind-seo" class="wp-ai-mind-page"></div>';
 	}

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -1,5 +1,10 @@
 <?php
-// includes/Admin/SettingsPage.php
+/**
+ * Admin page rendering the plugin settings screen.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Admin;
@@ -15,11 +20,23 @@ use WP_AI_Mind\Tiers\NJ_Tier_Manager;
  */
 class SettingsPage {
 
+	/**
+	 * Output the page markup and enqueue all required assets.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function render(): void {
 		self::enqueue_assets();
 		echo '<div id="wp-ai-mind-settings" class="wp-ai-mind-page"></div>';
 	}
 
+	/**
+	 * Enqueue the admin script and stylesheet, and localise runtime data.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function enqueue_assets(): void {
 		$asset_file = WP_AI_MIND_DIR . 'assets/admin/index.asset.php';
 		$asset      = file_exists( $asset_file )

--- a/includes/Admin/TestKeyRestController.php
+++ b/includes/Admin/TestKeyRestController.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * REST controller for testing AI provider API key validity.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Admin;
 
@@ -10,8 +16,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * REST controller that validates an API key by making a minimal live call.
+ *
+ * Route: POST /wp-ai-mind/v1/test-key
+ * Requires the manage_options capability.
+ */
 class TestKeyRestController {
 
+	/**
+	 * Register the test-key REST route.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register_routes(): void {
 		register_rest_route(
 			'wp-ai-mind/v1',
@@ -37,9 +55,14 @@ class TestKeyRestController {
 	}
 
 	/**
-	 * Makes a minimal live API call to validate the given key.
+	 * Make a minimal live API call to validate the given key.
 	 *
-	 * @param WP_REST_Request $request
+	 * Returns 200 on a valid key, 400 on an invalid key, or 502 on a network
+	 * or provider error. The raw provider error message is forwarded to the
+	 * client so users can diagnose mistyped keys without leaving the settings UI.
+	 *
+	 * @since 1.0.0
+	 * @param WP_REST_Request $request Incoming REST request.
 	 * @return WP_REST_Response|\WP_Error
 	 */
 	public static function handle( WP_REST_Request $request ): WP_REST_Response|\WP_Error {
@@ -116,6 +139,9 @@ class TestKeyRestController {
 	}
 
 	/**
+	 * Check that the current user has the manage_options capability.
+	 *
+	 * @since 1.0.0
 	 * @return bool|\WP_Error
 	 */
 	public static function check_permission(): bool|\WP_Error {

--- a/includes/Admin/UsagePage.php
+++ b/includes/Admin/UsagePage.php
@@ -1,5 +1,10 @@
 <?php
-// includes/Admin/UsagePage.php
+/**
+ * Admin page rendering the token usage dashboard.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Admin;
@@ -11,6 +16,12 @@ namespace WP_AI_Mind\Admin;
  */
 class UsagePage {
 
+	/**
+	 * Output the page markup.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function render(): void {
 		echo '<div id="wp-ai-mind-usage" class="wp-ai-mind-page"></div>';
 	}

--- a/includes/Core/Autoloader.php
+++ b/includes/Core/Autoloader.php
@@ -1,12 +1,37 @@
 <?php
+/**
+ * PSR-4 autoloader for the WP_AI_Mind namespace, used as a Composer fallback.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Core;
 
+/**
+ * PSR-4 autoloader for the WP_AI_Mind namespace.
+ *
+ * Retained as a safety net for environments where the Composer vendor directory
+ * is absent. Composer's autoloader takes precedence when available.
+ *
+ * @since 1.0.0
+ */
 class Autoloader {
 
+	/**
+	 * Whether the autoloader has already been registered via spl_autoload_register.
+	 *
+	 * @var bool
+	 */
 	private static bool $registered = false;
 
+	/**
+	 * Register the autoloader with the SPL autoload stack.
+	 *
+	 * @since 1.0.0
+	 * @return bool True if registration succeeded or was already done.
+	 */
 	public static function register(): bool {
 		if ( self::$registered ) {
 			return true;
@@ -15,6 +40,13 @@ class Autoloader {
 		return (bool) self::$registered;
 	}
 
+	/**
+	 * Resolve a class name to its file path and require it.
+	 *
+	 * @since 1.0.0
+	 * @param string $class_name Fully-qualified class name to load.
+	 * @return void
+	 */
 	public static function load( string $class_name ): void {
 		$prefix = 'WP_AI_Mind\\';
 		if ( ! str_starts_with( $class_name, $prefix ) ) {

--- a/includes/Core/ModuleRegistry.php
+++ b/includes/Core/ModuleRegistry.php
@@ -1,7 +1,21 @@
 <?php
+/**
+ * Registry that tracks enabled/disabled state for all AI modules.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Core;
 
+/**
+ * Registry that tracks enabled/disabled state for all AI modules.
+ *
+ * State is persisted in the `wp_ai_mind_modules` option and merged with
+ * hard-coded defaults so new modules are on by default without a migration.
+ *
+ * @since 1.0.0
+ */
 class ModuleRegistry {
 
 	private const OPTION_KEY = 'wp_ai_mind_modules';
@@ -18,21 +32,52 @@ class ModuleRegistry {
 		'usage'           => true,
 	];
 
+	/**
+	 * Current module state merged from defaults and the saved option.
+	 *
+	 * @var array<string, bool>
+	 */
 	private array $state;
 
+	/**
+	 * Load saved module state from the database.
+	 *
+	 * @since 1.0.0
+	 */
 	public function __construct() {
 		$saved       = get_option( self::OPTION_KEY, [] );
 		$this->state = array_merge( self::DEFAULTS, (array) $saved );
 	}
 
+	/**
+	 * Check whether a module is currently enabled.
+	 *
+	 * @since 1.0.0
+	 * @param string $module Module slug (e.g. 'chat', 'seo').
+	 * @return bool
+	 */
 	public function is_enabled( string $module ): bool {
 		return (bool) ( $this->state[ $module ] ?? false );
 	}
 
+	/**
+	 * Return the full module state map.
+	 *
+	 * @since 1.0.0
+	 * @return array<string, bool>
+	 */
 	public function get_all(): array {
 		return $this->state;
 	}
 
+	/**
+	 * Enable or disable a module and persist the new state.
+	 *
+	 * @since 1.0.0
+	 * @param string $module  Module slug.
+	 * @param bool   $enabled Whether the module should be enabled.
+	 * @return void
+	 */
 	public function set( string $module, bool $enabled ): void {
 		$this->state[ $module ] = $enabled;
 		update_option( self::OPTION_KEY, $this->state );

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Plugin bootstrap singleton — wires all hooks and owns the module registry.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Core;
 
@@ -12,10 +18,25 @@ use WP_AI_Mind\Proxy\NJ_Site_Registration;
  */
 class Plugin {
 
+	/**
+	 * Singleton instance.
+	 *
+	 * @var self|null
+	 */
 	private static ?self $instance = null;
 
+	/**
+	 * Module enabled/disabled state registry.
+	 *
+	 * @var ModuleRegistry
+	 */
 	private ModuleRegistry $modules;
 
+	/**
+	 * Initialise module registry and wire WordPress hooks.
+	 *
+	 * @since 1.0.0
+	 */
 	private function __construct() {
 		$this->modules = new ModuleRegistry();
 		$this->init_hooks();
@@ -34,7 +55,11 @@ class Plugin {
 		return self::$instance;
 	}
 
-	// Prevent cloning/serialisation of singleton.
+	/**
+	 * Prevent cloning to enforce the singleton invariant.
+	 *
+	 * @since 1.0.0
+	 */
 	private function __clone() {}
 
 	/**
@@ -49,14 +74,22 @@ class Plugin {
 	}
 
 	/**
-	 * @internal For use in unit tests only — resets singleton so tests do not leak state.
+	 * Reset the singleton — for use in unit tests only so tests do not leak state.
+	 *
+	 * @internal
+	 * @since 1.0.0
+	 * @return void
 	 */
 	public static function reset_instance(): void {
 		self::$instance = null;
 	}
 
-	// ── Hooks ─────────────────────────────────────────────────────────────────
-
+	/**
+	 * Register all WordPress action hooks required by the plugin.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	private function init_hooks(): void {
 		add_action( 'init', [ $this, 'load_textdomain' ] );
 		add_action( 'admin_init', [ NJ_Site_Registration::class, 'maybe_register' ] );

--- a/includes/DB/ConversationStore.php
+++ b/includes/DB/ConversationStore.php
@@ -1,10 +1,29 @@
 <?php
-// includes/DB/ConversationStore.php
+/**
+ * Data-access layer for conversations and their messages.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\DB;
 
+/**
+ * Data-access layer for conversations and their messages.
+ *
+ * Authentication is not enforced here — callers (REST controllers) are
+ * responsible for ownership and permission checks before invoking these methods.
+ */
 class ConversationStore {
 
+	/**
+	 * Create a new conversation owned by the current logged-in user.
+	 *
+	 * @since 1.0.0
+	 * @param string   $title   Optional conversation title; sanitised before storage.
+	 * @param int|null $post_id Optional WordPress post ID to associate the conversation with.
+	 * @return int Inserted conversation row ID, or 0 on failure.
+	 */
 	public function create( string $title = '', ?int $post_id = null ): int {
 		global $wpdb;
 		$wpdb->insert(
@@ -19,6 +38,19 @@ class ConversationStore {
 		return (int) $wpdb->insert_id;
 	}
 
+	/**
+	 * Append a message to an existing conversation.
+	 *
+	 * $role must be 'user' or 'assistant'. $model is empty for user turns.
+	 *
+	 * @since 1.0.0
+	 * @param int    $conversation_id The conversation record ID.
+	 * @param string $role            Message author: 'user' or 'assistant'.
+	 * @param string $content         Message text; HTML-sanitised via wp_kses_post before storage.
+	 * @param string $model           Model slug (e.g. 'claude-opus-4-6'); empty for user turns.
+	 * @param int    $tokens          Token count for usage tracking; 0 if unknown.
+	 * @return int Inserted message row ID, or 0 on failure.
+	 */
 	public function add_message( int $conversation_id, string $role, string $content, string $model = '', int $tokens = 0 ): int {
 		global $wpdb;
 		$wpdb->insert(
@@ -35,6 +67,13 @@ class ConversationStore {
 		return (int) $wpdb->insert_id;
 	}
 
+	/**
+	 * Retrieve all messages for a conversation in ascending ID order.
+	 *
+	 * @since 1.0.0
+	 * @param int $conversation_id The conversation record ID.
+	 * @return array<int, array<string, mixed>> Rows from the messages table; empty array if none.
+	 */
 	public function get_messages( int $conversation_id ): array {
 		global $wpdb;
 		$table   = Schema::table( 'messages' );
@@ -45,6 +84,14 @@ class ConversationStore {
 		return ! empty( $results ) ? $results : [];
 	}
 
+	/**
+	 * List conversations belonging to a user, newest first.
+	 *
+	 * @since 1.0.0
+	 * @param int $user_id WordPress user ID.
+	 * @param int $limit   Maximum rows to return; defaults to 50.
+	 * @return array<int, array<string, mixed>> Conversation rows; empty array if none.
+	 */
 	public function list_for_user( int $user_id, int $limit = 50 ): array {
 		global $wpdb;
 		$table   = Schema::table( 'conversations' );
@@ -59,6 +106,13 @@ class ConversationStore {
 		return ! empty( $results ) ? $results : [];
 	}
 
+	/**
+	 * Fetch a single conversation row by ID.
+	 *
+	 * @since 1.0.0
+	 * @param int $conversation_id The conversation record ID.
+	 * @return array<string, mixed>|null Conversation row, or null if not found.
+	 */
 	public function get_conversation( int $conversation_id ): ?array {
 		global $wpdb;
 		$table = Schema::table( 'conversations' );
@@ -69,12 +123,30 @@ class ConversationStore {
 		return ! empty( $row ) ? $row : null;
 	}
 
+	/**
+	 * Delete a conversation and all its messages.
+	 *
+	 * Messages are deleted before the conversation row to respect the logical
+	 * foreign-key relationship (no DB constraint enforces this ordering).
+	 *
+	 * @since 1.0.0
+	 * @param int $conversation_id The conversation record ID.
+	 * @return void
+	 */
 	public function delete( int $conversation_id ): void {
 		global $wpdb;
 		$wpdb->delete( Schema::table( 'messages' ), [ 'conversation_id' => $conversation_id ], [ '%d' ] );
 		$wpdb->delete( Schema::table( 'conversations' ), [ 'id' => $conversation_id ], [ '%d' ] );
 	}
 
+	/**
+	 * Update the title of an existing conversation.
+	 *
+	 * @since 1.0.0
+	 * @param int    $conversation_id The conversation record ID.
+	 * @param string $title           New title text; sanitised before storage.
+	 * @return void
+	 */
 	public function update_title( int $conversation_id, string $title ): void {
 		global $wpdb;
 		$wpdb->update(

--- a/includes/DB/Schema.php
+++ b/includes/DB/Schema.php
@@ -1,7 +1,19 @@
 <?php
+/**
+ * Manages the plugin's custom database tables via dbDelta.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\DB;
 
+/**
+ * Manages the plugin's custom database tables.
+ *
+ * All table names are prefixed with $wpdb->prefix and the plugin-specific
+ * 'wpaim_' prefix to avoid collisions with other plugins.
+ */
 class Schema {
 
 	private const PREFIX = 'wpaim_';
@@ -11,6 +23,14 @@ class Schema {
 		'messages'      => 'messages',
 	];
 
+	/**
+	 * Resolve a logical table name to its fully-qualified database table name.
+	 *
+	 * @since 1.0.0
+	 * @param string $name Logical name: 'conversations' or 'messages'.
+	 * @throws \InvalidArgumentException If $name is not a known table identifier.
+	 * @return string Fully-qualified table name including WordPress and plugin prefixes.
+	 */
 	public static function table( string $name ): string {
 		global $wpdb;
 		if ( ! isset( self::TABLES[ $name ] ) ) {
@@ -21,6 +41,9 @@ class Schema {
 
 	/**
 	 * Run on plugin activation via dbDelta().
+	 *
+	 * @since 1.0.0
+	 * @return void
 	 */
 	public static function create_tables(): void {
 		global $wpdb;
@@ -57,6 +80,14 @@ class Schema {
 		);
 	}
 
+	/**
+	 * Drop all plugin tables.
+	 *
+	 * Called on plugin uninstall from uninstall.php.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function drop_tables(): void {
 		global $wpdb;
 		foreach ( array_keys( self::TABLES ) as $name ) {

--- a/includes/Modules/Chat/ChatModule.php
+++ b/includes/Modules/Chat/ChatModule.php
@@ -1,12 +1,27 @@
 <?php
-// includes/Modules/Chat/ChatModule.php
+/**
+ * Chat module bootstrap — registers assets and REST routes for the chat feature.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Modules\Chat;
 
 use WP_AI_Mind\Tools\ToolRegistry;
 use WP_AI_Mind\Tools\ToolExecutor;
 
+/**
+ * Bootstraps the Chat module by registering its REST routes on rest_api_init.
+ */
 class ChatModule {
+
+	/**
+	 * Register the rest_api_init hook that wires up both REST controllers.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register(): void {
 		add_action(
 			'rest_api_init',

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -1,5 +1,10 @@
 <?php
-// includes/Modules/Chat/ChatRestController.php
+/**
+ * REST controller handling conversation and message endpoints for the chat feature.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Modules\Chat;
 
@@ -13,15 +18,43 @@ use WP_AI_Mind\Tools\ToolRegistry;
 use WP_AI_Mind\Tools\ToolExecutor;
 use WP_AI_Mind\Voice\VoiceInjector;
 
+/**
+ * REST controller for chat conversations, providers, and post search.
+ *
+ * Routes:
+ *   GET  /wp-ai-mind/v1/conversations               — list conversations
+ *   POST /wp-ai-mind/v1/conversations               — create conversation
+ *   GET  /wp-ai-mind/v1/conversations/{id}/messages — get messages
+ *   POST /wp-ai-mind/v1/conversations/{id}/messages — send message (AI turn)
+ *   DELETE /wp-ai-mind/v1/conversations/{id}        — delete conversation
+ *   GET  /wp-ai-mind/v1/providers                   — list available providers
+ *   GET  /wp-ai-mind/v1/search-posts                — search posts
+ *
+ * All routes require the edit_posts capability except delete, which also
+ * allows manage_options to delete any conversation.
+ */
 class ChatRestController {
 
 	private const NAMESPACE = 'wp-ai-mind/v1';
 
+	/**
+	 * Inject the tool registry and executor used during AI tool-call loops.
+	 *
+	 * @since 1.0.0
+	 * @param ToolRegistry $tool_registry Registry of available tools.
+	 * @param ToolExecutor $tool_executor Executor that dispatches tool calls.
+	 */
 	public function __construct(
 		private readonly ToolRegistry $tool_registry,
 		private readonly ToolExecutor $tool_executor,
 	) {}
 
+	/**
+	 * Register all chat REST routes.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public function register_routes(): void {
 
 		register_rest_route(
@@ -125,6 +158,13 @@ class ChatRestController {
 		);
 	}
 
+	/**
+	 * Return all conversations for the current user.
+	 *
+	 * @since 1.0.0
+	 * @param \WP_REST_Request $request Incoming REST request (unused).
+	 * @return \WP_REST_Response
+	 */
 	public function list_conversations( \WP_REST_Request $request ): \WP_REST_Response { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by WP_REST_Server callback signature.
 		$store         = $this->make_store();
 		$conversations = $store->list_for_user( get_current_user_id() );
@@ -139,6 +179,13 @@ class ChatRestController {
 		return rest_ensure_response( $response );
 	}
 
+	/**
+	 * Create a new conversation for the current user.
+	 *
+	 * @since 1.0.0
+	 * @param \WP_REST_Request $request Incoming REST request.
+	 * @return \WP_REST_Response 201 on success; 500 if the row could not be inserted.
+	 */
 	public function create_conversation( \WP_REST_Request $request ): \WP_REST_Response {
 		$store         = $this->make_store();
 		$post_id_param = $request->get_param( 'post_id' );
@@ -163,11 +210,29 @@ class ChatRestController {
 		);
 	}
 
+	/**
+	 * Return all messages for the given conversation.
+	 *
+	 * @since 1.0.0
+	 * @param \WP_REST_Request $request Incoming REST request; must contain 'id' route parameter.
+	 * @return \WP_REST_Response
+	 */
 	public function get_messages( \WP_REST_Request $request ): \WP_REST_Response {
 		$store = $this->make_store();
 		return rest_ensure_response( $store->get_messages( (int) $request->get_param( 'id' ) ) );
 	}
 
+	/**
+	 * Append a user message and run an AI completion turn, including tool-call loops.
+	 *
+	 * Handles multi-step tool-call agentic loops up to 5 iterations.
+	 * Provider 401/403 errors are mapped to 502 so the client cannot distinguish
+	 * a plugin auth failure from a provider auth failure.
+	 *
+	 * @since 1.0.0
+	 * @param \WP_REST_Request $request Incoming REST request.
+	 * @return \WP_REST_Response
+	 */
 	public function send_message( \WP_REST_Request $request ): \WP_REST_Response {
 		$conv_id        = (int) $request->get_param( 'id' );
 		$content        = $request->get_param( 'content' );
@@ -215,7 +280,7 @@ class ChatRestController {
 				return new \WP_REST_Response(
 					[
 						'message' => sprintf(
-																/* translators: %s: provider slug */
+												/* translators: %s: provider slug */
 							__( 'No API key configured for "%s". Please add one in WP AI Mind → Settings.', 'wp-ai-mind' ),
 							$provider_slug
 						),
@@ -322,6 +387,13 @@ class ChatRestController {
 		}
 	}
 
+	/**
+	 * Delete a conversation owned by the current user (or any conversation for admins).
+	 *
+	 * @since 1.0.0
+	 * @param \WP_REST_Request $request Incoming REST request; must contain 'id' route parameter.
+	 * @return \WP_REST_Response|\WP_Error 200 on success; 404 if not found; 403 if forbidden.
+	 */
 	public function delete_conversation( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
 		$store   = $this->make_store();
 		$conv_id = (int) $request->get_param( 'id' );
@@ -338,6 +410,13 @@ class ChatRestController {
 		return rest_ensure_response( [ 'deleted' => true ] );
 	}
 
+	/**
+	 * Return all configured providers with their models and availability status.
+	 *
+	 * @since 1.0.0
+	 * @param \WP_REST_Request $request Incoming REST request (unused).
+	 * @return \WP_REST_Response
+	 */
 	public function list_providers( \WP_REST_Request $request ): \WP_REST_Response { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by WP_REST_Server callback signature.
 		$factory = $this->make_provider_factory();
 		$all     = $factory->get_all();
@@ -352,6 +431,13 @@ class ChatRestController {
 		return rest_ensure_response( $data );
 	}
 
+	/**
+	 * Search published posts and pages by keyword.
+	 *
+	 * @since 1.0.0
+	 * @param \WP_REST_Request $request Incoming REST request; accepts 'q' parameter.
+	 * @return \WP_REST_Response
+	 */
 	public function search_posts( \WP_REST_Request $request ): \WP_REST_Response {
 		$q            = trim( (string) $request->get_param( 'q' ) );
 		$post_types   = array_values(
@@ -385,6 +471,12 @@ class ChatRestController {
 		return rest_ensure_response( $data );
 	}
 
+	/**
+	 * Check that the current user has the edit_posts capability.
+	 *
+	 * @since 1.0.0
+	 * @return bool|\WP_Error
+	 */
 	public function check_permission(): bool|\WP_Error {
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			return new \WP_Error( 'rest_forbidden', __( 'Insufficient permissions.', 'wp-ai-mind' ), [ 'status' => 403 ] );
@@ -394,14 +486,32 @@ class ChatRestController {
 
 	// ── Overridable factory methods (for testing) ─────────────────────────────
 
+	/**
+	 * Factory method for ConversationStore — overridable in tests.
+	 *
+	 * @since 1.0.0
+	 * @return ConversationStore
+	 */
 	protected function make_store(): ConversationStore {
 		return new ConversationStore();
 	}
 
+	/**
+	 * Factory method for ProviderFactory — overridable in tests.
+	 *
+	 * @since 1.0.0
+	 * @return ProviderFactory
+	 */
 	protected function make_provider_factory(): ProviderFactory {
 		return new ProviderFactory( new ProviderSettings() );
 	}
 
+	/**
+	 * Factory method for VoiceInjector — overridable in tests.
+	 *
+	 * @since 1.0.0
+	 * @return VoiceInjector
+	 */
 	protected function make_voice_injector(): VoiceInjector {
 		return new VoiceInjector();
 	}
@@ -411,10 +521,10 @@ class ChatRestController {
 	/**
 	 * Append a complete tool exchange (assistant tool call + user tool result) to the message history.
 	 *
-	 * @param array             $messages      Existing message history.
-	 * @param string            $provider_slug Provider identifier.
+	 * @param array              $messages      Existing message history.
+	 * @param string             $provider_slug Provider identifier.
 	 * @param CompletionResponse $tool_response The provider response that triggered tool execution.
-	 * @param array             $tool_results  Tool results keyed by tool_use/call id.
+	 * @param array              $tool_results  Tool results keyed by tool_use/call id.
 	 * @return array Updated message history.
 	 */
 	private function append_tool_exchange(

--- a/includes/Modules/Chat/SettingsRestController.php
+++ b/includes/Modules/Chat/SettingsRestController.php
@@ -1,5 +1,10 @@
 <?php
-// includes/Modules/Chat/SettingsRestController.php
+/**
+ * REST controller for reading and updating plugin settings.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Modules\Chat;
@@ -20,8 +25,12 @@ class SettingsRestController {
 
 	private const NAMESPACE = 'wp-ai-mind/v1';
 
-	// ── Route registration ────────────────────────────────────────────────────
-
+	/**
+	 * Register the /settings REST routes.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public function register_routes(): void {
 		register_rest_route(
 			self::NAMESPACE,

--- a/includes/Modules/Editor/EditorModule.php
+++ b/includes/Modules/Editor/EditorModule.php
@@ -1,5 +1,10 @@
 <?php
-// includes/Modules/Editor/EditorModule.php
+/**
+ * Editor module bootstrap — enqueues the Block Editor plugin sidebar assets.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Modules\Editor;
 

--- a/includes/Modules/Frontend/FrontendWidgetModule.php
+++ b/includes/Modules/Frontend/FrontendWidgetModule.php
@@ -1,17 +1,39 @@
 <?php
-// includes/Modules/Frontend/FrontendWidgetModule.php
+/**
+ * Frontend widget module — registers the public-facing AI chat shortcode.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Modules\Frontend;
 
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 
+/**
+ * Registers the front-end chat widget as a shortcode and enqueues its assets.
+ *
+ * The widget is mounted on any page that contains the [wp_ai_mind_chat] shortcode.
+ */
 class FrontendWidgetModule {
 
+	/**
+	 * Register WordPress hooks for this module.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register(): void {
 		\add_action( 'wp_enqueue_scripts', [ self::class, 'enqueue_assets' ] );
 		\add_shortcode( 'wp_ai_mind_chat', [ self::class, 'render_shortcode' ] );
 	}
 
+	/**
+	 * Enqueue the widget script and stylesheet on the front end.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function enqueue_assets(): void {
 		$asset_file = WP_AI_MIND_DIR . 'assets/frontend/widget.asset.php';
 		$asset      = file_exists( $asset_file )
@@ -49,6 +71,13 @@ class FrontendWidgetModule {
 		);
 	}
 
+	/**
+	 * Render the shortcode mount point for the front-end widget.
+	 *
+	 * @since 1.0.0
+	 * @param array $atts Shortcode attributes; accepts 'title' (unused by the React app).
+	 * @return string HTML div that the React widget mounts into.
+	 */
 	public static function render_shortcode( array $atts ): string {
 		$atts = \shortcode_atts( [ 'title' => '' ], $atts, 'wp_ai_mind_chat' );
 		$id   = 'wp-ai-mind-widget-' . \absint( \get_the_ID() );

--- a/includes/Modules/Generator/GeneratorModule.php
+++ b/includes/Modules/Generator/GeneratorModule.php
@@ -1,20 +1,41 @@
 <?php
-// includes/Modules/Generator/GeneratorModule.php
+/**
+ * Generator module — REST routes and asset enqueuing for the post-generation wizard.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Modules\Generator;
 
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 use WP_AI_Mind\Tiers\NJ_Usage_Tracker;
 
+/**
+ * Registers the post-generator admin assets and REST route.
+ */
 class GeneratorModule {
 
+	/**
+	 * Register WordPress hooks for this module.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register(): void {
 		\add_action( 'admin_enqueue_scripts', [ self::class, 'enqueue_assets' ] );
 		\add_action( 'rest_api_init', [ self::class, 'register_routes' ] );
 	}
 
+	/**
+	 * Enqueue generator assets on the generator admin page only.
+	 *
+	 * @since 1.0.0
+	 * @param string $hook Current admin page hook suffix (unused; page detection uses $_GET).
+	 * @return void
+	 */
 	public static function enqueue_assets( string $hook ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by admin_enqueue_scripts hook signature.
-		// Only load on the generator admin page
+		// Only load on the generator admin page.
 		if ( ! isset( $_GET['page'] ) || 'wp-ai-mind-generator' !== $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
@@ -48,6 +69,12 @@ class GeneratorModule {
 		);
 	}
 
+	/**
+	 * Register the /wp-ai-mind/v1/generate REST route.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register_routes(): void {
 		\register_rest_route(
 			'wp-ai-mind/v1',
@@ -89,6 +116,13 @@ class GeneratorModule {
 		);
 	}
 
+	/**
+	 * Generate a draft post from the request parameters using the default AI provider.
+	 *
+	 * @since 1.0.0
+	 * @param \WP_REST_Request $request Incoming REST request.
+	 * @return \WP_REST_Response 201 on success with post_id, edit_url, content, tokens_used; 500 on error.
+	 */
 	public static function handle_generate( \WP_REST_Request $request ): \WP_REST_Response {
 		$title    = $request->get_param( 'title' );
 		$keywords = $request->get_param( 'keywords' );
@@ -136,7 +170,7 @@ class GeneratorModule {
 			NJ_Usage_Tracker::log_usage( $response->total_tokens );
 			$content = $response->content;
 
-			// Create a draft post
+			// Create a draft post.
 			$post_id = \wp_insert_post(
 				[
 					'post_title'   => \sanitize_text_field( $title ),

--- a/includes/Modules/Images/ImagesModule.php
+++ b/includes/Modules/Images/ImagesModule.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Images module — REST routes and asset enqueuing for AI image generation.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Modules\Images;
 
@@ -8,13 +14,32 @@ use WP_AI_Mind\Settings\ProviderSettings;
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 use WP_AI_Mind\Tiers\NJ_Usage_Tracker;
 
+/**
+ * Registers the image-generation admin assets and REST route.
+ *
+ * Multiple images are generated in a loop; partial failures are reported
+ * via a 207 Multi-Status response rather than aborting the entire request.
+ */
 class ImagesModule {
 
+	/**
+	 * Register WordPress hooks for this module.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register(): void {
 		\add_action( 'admin_enqueue_scripts', [ self::class, 'enqueue_assets' ] );
 		\add_action( 'rest_api_init', [ self::class, 'register_routes' ] );
 	}
 
+	/**
+	 * Enqueue image-module assets on the images admin page only.
+	 *
+	 * @since 1.0.0
+	 * @param string $hook Current admin page hook suffix (unused; page detection uses $_GET).
+	 * @return void
+	 */
 	public static function enqueue_assets( string $hook ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by admin_enqueue_scripts hook signature.
 		// Only load on the images admin page.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only page detection, never output.
@@ -57,6 +82,12 @@ class ImagesModule {
 		);
 	}
 
+	/**
+	 * Register the /wp-ai-mind/v1/images/generate REST route.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register_routes(): void {
 		\register_rest_route(
 			'wp-ai-mind/v1',
@@ -92,6 +123,16 @@ class ImagesModule {
 		);
 	}
 
+	/**
+	 * Generate one or more images and save them to the WordPress media library.
+	 *
+	 * Returns 201 when all images succeed, 207 when at least one fails but at
+	 * least one succeeds, and 500 when all fail.
+	 *
+	 * @since 1.0.0
+	 * @param \WP_REST_Request $request Incoming REST request.
+	 * @return \WP_REST_Response
+	 */
 	public static function handle_generate( \WP_REST_Request $request ): \WP_REST_Response {
 		$prompt       = $request->get_param( 'prompt' );
 		$aspect_ratio = $request->get_param( 'aspect_ratio' );

--- a/includes/Modules/Seo/SeoModule.php
+++ b/includes/Modules/Seo/SeoModule.php
@@ -1,5 +1,10 @@
 <?php
-// includes/Modules/Seo/SeoModule.php
+/**
+ * SEO module — REST routes and asset enqueuing for the AI SEO admin page.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Modules\Seo;
@@ -11,14 +16,33 @@ use WP_AI_Mind\Settings\ProviderSettings;
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 use WP_AI_Mind\Tiers\NJ_Usage_Tracker;
 
+/**
+ * Registers the SEO module admin assets, REST routes, and the wpaim_seo_status REST field.
+ *
+ * The wpaim_seo_status field is registered with context ['edit'] so it only
+ * appears when the REST request uses context=edit (e.g. PostListTable).
+ */
 class SeoModule {
 
+	/**
+	 * Register WordPress hooks for this module.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register(): void {
 		\add_action( 'admin_enqueue_scripts', [ self::class, 'enqueue_assets' ] );
 		\add_action( 'rest_api_init', [ self::class, 'register_routes' ] );
 		\add_action( 'rest_api_init', [ self::class, 'register_seo_status_field' ] );
 	}
 
+	/**
+	 * Enqueue SEO module assets on the SEO admin page only.
+	 *
+	 * @since 1.0.0
+	 * @param string $hook Current admin page hook suffix (unused; page detection uses $_GET).
+	 * @return void
+	 */
 	public static function enqueue_assets( string $hook ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by admin_enqueue_scripts hook signature.
 		// Only load on the SEO admin page.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only page detection, never output.
@@ -61,6 +85,12 @@ class SeoModule {
 		);
 	}
 
+	/**
+	 * Register the /wp-ai-mind/v1/seo/generate and /wp-ai-mind/v1/seo/apply REST routes.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register_routes(): void {
 		\register_rest_route(
 			'wp-ai-mind/v1',
@@ -123,6 +153,13 @@ class SeoModule {
 		);
 	}
 
+	/**
+	 * Generate SEO metadata for a post using the default AI provider.
+	 *
+	 * @since 1.0.0
+	 * @param \WP_REST_Request $request Incoming REST request.
+	 * @return \WP_REST_Response
+	 */
 	public static function handle_generate( \WP_REST_Request $request ): \WP_REST_Response {
 		$post_id = $request->get_param( 'post_id' );
 		$post    = \get_post( $post_id );
@@ -206,6 +243,16 @@ class SeoModule {
 		);
 	}
 
+	/**
+	 * Apply SEO metadata fields to a post and its featured image.
+	 *
+	 * Writes to both Yoast and Rank Math meta keys so the values are picked
+	 * up regardless of which SEO plugin is active.
+	 *
+	 * @since 1.0.0
+	 * @param \WP_REST_Request $request Incoming REST request.
+	 * @return \WP_REST_Response
+	 */
 	public static function handle_apply( \WP_REST_Request $request ): \WP_REST_Response {
 		$post_id = $request->get_param( 'post_id' );
 		$post    = \get_post( $post_id );
@@ -263,6 +310,12 @@ class SeoModule {
 		);
 	}
 
+	/**
+	 * Register the wpaim_seo_status REST field on all configured post types.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register_seo_status_field(): void {
 		$post_types = (array) \apply_filters( 'wp_ai_mind_seo_post_types', [ 'post', 'page' ] );
 		foreach ( $post_types as $post_type ) {
@@ -299,6 +352,13 @@ class SeoModule {
 		}
 	}
 
+	/**
+	 * REST field callback: return the SEO fill status for each tracked field.
+	 *
+	 * @since 1.0.0
+	 * @param array<string, mixed> $post_data Associative REST post data array.
+	 * @return array<string, string> Map of field names to 'filled' or 'empty'.
+	 */
 	public static function get_seo_status( array $post_data ): array {
 		$post_id = $post_data['id'];
 

--- a/includes/Modules/Usage/UsageModule.php
+++ b/includes/Modules/Usage/UsageModule.php
@@ -1,5 +1,10 @@
 <?php
-// includes/Modules/Usage/UsageModule.php
+/**
+ * Usage module — REST routes and asset enqueuing for the usage dashboard.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Modules\Usage;
@@ -12,11 +17,24 @@ use WP_AI_Mind\Tiers\NJ_Usage_Tracker;
  */
 class UsageModule {
 
+	/**
+	 * Register WordPress hooks for this module.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register(): void {
 		add_action( 'admin_enqueue_scripts', [ self::class, 'enqueue_assets' ] );
 		add_action( 'rest_api_init', [ self::class, 'register_routes' ] );
 	}
 
+	/**
+	 * Enqueue usage-module assets on the usage admin page only.
+	 *
+	 * @since 1.0.0
+	 * @param string $hook Current admin page hook suffix (unused; page detection uses $_GET).
+	 * @return void
+	 */
 	public static function enqueue_assets( string $hook ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by admin_enqueue_scripts hook signature.
 		if ( ! isset( $_GET['page'] ) || 'wp-ai-mind-usage' !== $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
@@ -58,6 +76,12 @@ class UsageModule {
 		);
 	}
 
+	/**
+	 * Register the /wp-ai-mind/v1/usage REST route.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	public static function register_routes(): void {
 		\register_rest_route(
 			'wp-ai-mind/v1',
@@ -70,6 +94,13 @@ class UsageModule {
 		);
 	}
 
+	/**
+	 * Return the current user's token usage summary.
+	 *
+	 * @since 1.0.0
+	 * @param \WP_REST_Request $request Incoming REST request (unused).
+	 * @return \WP_REST_Response
+	 */
 	public static function get_usage( \WP_REST_Request $request ): \WP_REST_Response { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by WP_REST_Server callback signature.
 		$usage = NJ_Usage_Tracker::get_usage();
 

--- a/includes/Payments/NJ_Webhook_Verifier.php
+++ b/includes/Payments/NJ_Webhook_Verifier.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Verifies Freemius webhook signatures for licence lifecycle events.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Payments;
 

--- a/includes/Providers/AbstractProvider.php
+++ b/includes/Providers/AbstractProvider.php
@@ -1,23 +1,51 @@
 <?php
-// includes/Providers/AbstractProvider.php
+/**
+ * Base class shared by all AI completion providers.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
 use WP_AI_Mind\Tiers\NJ_Usage_Tracker;
 
+/**
+ * Provides retry logic, usage logging, and media-library image saving for concrete providers.
+ *
+ * Concrete providers implement do_complete() and do_stream(); the public complete() and
+ * stream() methods add automatic exponential-back-off retry around those.
+ *
+ * @since 1.0.0
+ */
 abstract class AbstractProvider implements ProviderInterface {
 
 	private const MAX_RETRIES   = 3;
-	private const RETRY_BASE_MS = 500; // milliseconds
+	private const RETRY_BASE_MS = 500; // Milliseconds.
 
-	// ── Public API (implements interface) ─────────────────────────────────────
-
+	/**
+	 * Run a completion request with automatic retry on retryable errors.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request The completion request.
+	 * @return CompletionResponse
+	 * @throws ProviderException On non-retryable error or exhausted retries.
+	 */
 	final public function complete( CompletionRequest $request ): CompletionResponse {
 		$response = $this->with_retry( fn() => $this->do_complete( $request ) );
 		$this->maybe_log( $request, $response );
 		return $response;
 	}
 
+	/**
+	 * Run a streaming completion request with automatic retry on retryable errors.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request  The completion request.
+	 * @param callable          $on_chunk Callback invoked with each text delta string.
+	 * @return CompletionResponse
+	 * @throws ProviderException On non-retryable error or exhausted retries.
+	 */
 	final public function stream( CompletionRequest $request, callable $on_chunk ): CompletionResponse {
 		$response = $this->with_retry( fn() => $this->do_stream( $request, $on_chunk ) );
 		$this->maybe_log( $request, $response );
@@ -34,13 +62,35 @@ abstract class AbstractProvider implements ProviderInterface {
 		return true;
 	}
 
-	// ── Abstract — each provider implements these ─────────────────────────────
-
+	/**
+	 * Perform the actual completion API call (no retry wrapper).
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request The completion request.
+	 * @return CompletionResponse
+	 */
 	abstract protected function do_complete( CompletionRequest $request ): CompletionResponse;
+
+	/**
+	 * Perform the actual streaming API call (no retry wrapper).
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request  The completion request.
+	 * @param callable          $on_chunk Callback invoked with each text delta string.
+	 * @return CompletionResponse
+	 */
 	abstract protected function do_stream( CompletionRequest $request, callable $on_chunk ): CompletionResponse;
 
-	// ── Shared: image save to media library ──────────────────────────────────
-
+	/**
+	 * Download an image URL into the WP media library and return its attachment ID.
+	 *
+	 * @since 1.0.0
+	 * @param string $image_url Remote image URL to download.
+	 * @param string $filename  Base filename (without extension) for the attachment.
+	 * @param string $prompt    Prompt used to generate the image; stored as post meta.
+	 * @return int Attachment ID.
+	 * @throws ProviderException On download or sideload failure.
+	 */
 	protected function save_image_to_media_library( string $image_url, string $filename, string $prompt ): int {
 		require_once ABSPATH . 'wp-admin/includes/media.php';
 		require_once ABSPATH . 'wp-admin/includes/file.php';
@@ -67,8 +117,14 @@ abstract class AbstractProvider implements ProviderInterface {
 		return $attachment_id;
 	}
 
-	// ── Retry logic ───────────────────────────────────────────────────────────
-
+	/**
+	 * Wrap a provider call with exponential back-off retry (max 3 attempts).
+	 *
+	 * @since 1.0.0
+	 * @param callable $callback Provider call to retry.
+	 * @return CompletionResponse
+	 * @throws ProviderException When all retries are exhausted or the error is not retryable.
+	 */
 	private function with_retry( callable $callback ): CompletionResponse {
 		$last_exception = null;
 		for ( $attempt = 0; $attempt <= self::MAX_RETRIES; $attempt++ ) {
@@ -86,8 +142,14 @@ abstract class AbstractProvider implements ProviderInterface {
 		throw $last_exception; // @phpstan-ignore-line
 	}
 
-	// ── Usage logging ─────────────────────────────────────────────────────────
-
+	/**
+	 * Log token usage for the current user if the response contains a token count.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest  $request  The originating request (unused here, available to subclasses).
+	 * @param CompletionResponse $response The completed response.
+	 * @return void
+	 */
 	protected function maybe_log( CompletionRequest $request, CompletionResponse $response ): void {
 		NJ_Usage_Tracker::log_usage( $response->total_tokens );
 	}

--- a/includes/Providers/ClaudeProvider.php
+++ b/includes/Providers/ClaudeProvider.php
@@ -1,5 +1,10 @@
 <?php
-// includes/Providers/ClaudeProvider.php
+/**
+ * AI provider implementation for the Anthropic Claude API.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
@@ -7,6 +12,14 @@ use WP_AI_Mind\Proxy\NJ_Proxy_Client;
 use WP_AI_Mind\Proxy\NJ_Site_Registration;
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 
+/**
+ * Handles completions, streaming, and tier-aware routing for Anthropic Claude.
+ *
+ * Free, trial, and pro_managed tiers route through the NJ proxy client so that
+ * usage is logged centrally. The pro_byok tier calls the Anthropic API directly.
+ *
+ * @since 1.0.0
+ */
 class ClaudeProvider extends AbstractProvider {
 
 	private const API_BASE      = 'https://api.anthropic.com/v1';
@@ -36,23 +49,60 @@ class ClaudeProvider extends AbstractProvider {
 		],
 	];
 
-	/** Tracks whether the proxy handled logging so maybe_log() can skip double-logging. */
+	/**
+	 * Tracks whether the proxy handled logging so maybe_log() can skip double-logging.
+	 *
+	 * @var bool
+	 */
 	private bool $proxy_logged = false;
 
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.0.0
+	 * @param string $api_key Anthropic API key; empty string for proxy-routed tiers.
+	 */
 	public function __construct( private readonly string $api_key ) {}
 
+	/**
+	 * Return the provider slug used throughout the plugin.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
 	public function get_slug(): string {
 		return 'claude';
 	}
 
+	/**
+	 * Return the available model identifiers keyed by model ID.
+	 *
+	 * @since 1.0.0
+	 * @return array<string, string>
+	 */
 	public function get_models(): array {
 		return self::MODELS;
 	}
 
-
+	/**
+	 * Return the default model identifier.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
 	public function get_default_model(): string {
 		return self::DEFAULT_MODEL;
 	}
+
+	/**
+	 * Return true if the provider can handle requests for the current user.
+	 *
+	 * Available when an API key is set, or when the site is registered and the
+	 * user's tier is eligible for proxy routing.
+	 *
+	 * @since 1.0.0
+	 * @return bool
+	 */
 	public function is_available(): bool {
 		if ( '' !== $this->api_key ) {
 			return true;
@@ -66,6 +116,11 @@ class ClaudeProvider extends AbstractProvider {
 	 * Route completion by tier:
 	 *   - free / trial / pro_managed → proxy (NJ_Proxy_Client handles usage logging)
 	 *   - pro_byok                   → direct Anthropic API call (AbstractProvider logs usage)
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request The completion request.
+	 * @return CompletionResponse
+	 * @throws ProviderException On API or proxy failure.
 	 */
 	protected function do_complete( CompletionRequest $request ): CompletionResponse {
 		$tier = NJ_Tier_Manager::get_user_tier( get_current_user_id() );
@@ -84,8 +139,10 @@ class ClaudeProvider extends AbstractProvider {
 	/**
 	 * Suppress AbstractProvider usage logging when the proxy already logged it.
 	 *
-	 * @param CompletionRequest  $request
-	 * @param CompletionResponse $response
+	 * @since 1.0.0
+	 * @param CompletionRequest  $request  The original completion request.
+	 * @param CompletionResponse $response The completed response.
+	 * @return void
 	 */
 	protected function maybe_log( CompletionRequest $request, CompletionResponse $response ): void {
 		if ( $this->proxy_logged ) {
@@ -95,6 +152,14 @@ class ClaudeProvider extends AbstractProvider {
 		parent::maybe_log( $request, $response );
 	}
 
+	/**
+	 * Send the completion request through the NJ proxy client.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request The completion request.
+	 * @return CompletionResponse
+	 * @throws ProviderException When the proxy returns a WP_Error.
+	 */
 	private function complete_via_proxy( CompletionRequest $request ): CompletionResponse {
 		$result = NJ_Proxy_Client::chat(
 			$request->messages,
@@ -117,9 +182,19 @@ class ClaudeProvider extends AbstractProvider {
 		return $this->parse_response( $result, $request );
 	}
 
+	/**
+	 * Simulate streaming by word-chunking a non-streaming completion.
+	 *
+	 * The WP HTTP API does not support SSE natively, so a full completion is
+	 * fetched and the response is word-split to simulate incremental delivery.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request  The completion request.
+	 * @param callable          $on_chunk Callback invoked with each word token.
+	 * @return CompletionResponse
+	 * @throws ProviderException On API or proxy failure.
+	 */
 	protected function do_stream( CompletionRequest $request, callable $on_chunk ): CompletionResponse {
-		// Claude supports SSE; WP HTTP API doesn't support streaming natively,
-		// so we fall back to non-streaming and simulate chunking.
 		$response = $this->do_complete( $request );
 		$words    = explode( ' ', $response->content );
 		foreach ( $words as $i => $word ) {
@@ -128,7 +203,15 @@ class ClaudeProvider extends AbstractProvider {
 		return $response;
 	}
 
-	public function generate_image( string $prompt, array $options = [] ): int {
+	/**
+	 * Image generation is not supported by Claude.
+	 *
+	 * @since 1.0.0
+	 * @param string $prompt  Image generation prompt.
+	 * @param array  $options Optional generation options.
+	 * @throws ProviderException Always — Claude does not support image generation.
+	 */
+	public function generate_image( string $prompt, array $options = [] ): never {
 		throw new ProviderException(
 			'Claude does not support image generation. Use Gemini or OpenAI.',
 			'claude',
@@ -138,6 +221,13 @@ class ClaudeProvider extends AbstractProvider {
 
 	// ── Private helpers ───────────────────────────────────────────────────────
 
+	/**
+	 * Build the Anthropic API request body from a completion request.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request The completion request.
+	 * @return array
+	 */
 	private function build_body( CompletionRequest $request ): array {
 		$body = [
 			'model'      => ! empty( $request->model ) ? $request->model : self::DEFAULT_MODEL,
@@ -148,11 +238,20 @@ class ClaudeProvider extends AbstractProvider {
 			$body['system'] = $request->system;
 		}
 		if ( ! empty( $request->tools ) ) {
-			$body['tools'] = $request->tools; // already in Claude wire format from ToolRegistry
+			$body['tools'] = $request->tools; // Already in Claude wire format from ToolRegistry.
 		}
 		return $body;
 	}
 
+	/**
+	 * POST a JSON body to the Anthropic API and return the decoded response.
+	 *
+	 * @since 1.0.0
+	 * @param string $path API endpoint path (e.g. '/messages').
+	 * @param array  $body Request payload.
+	 * @return array
+	 * @throws ProviderException On HTTP failure or non-2xx status.
+	 */
 	private function post( string $path, array $body ): array {
 		$response = wp_remote_post(
 			self::API_BASE . $path,
@@ -182,6 +281,17 @@ class ClaudeProvider extends AbstractProvider {
 		return $data;
 	}
 
+	/**
+	 * Parse a raw Anthropic API response into a CompletionResponse value object.
+	 *
+	 * Detects tool_use content blocks and populates tool_call on the response
+	 * when the model has invoked a function.
+	 *
+	 * @since 1.0.0
+	 * @param array             $data    Decoded API response body.
+	 * @param CompletionRequest $request The originating request (used for model fallback).
+	 * @return CompletionResponse
+	 */
 	protected function parse_response( array $data, CompletionRequest $request ): CompletionResponse {
 		$model      = $data['model'] ?? ( ! empty( $request->model ) ? $request->model : self::DEFAULT_MODEL );
 		$in_tokens  = (int) ( $data['usage']['input_tokens'] ?? 0 );

--- a/includes/Providers/CompletionRequest.php
+++ b/includes/Providers/CompletionRequest.php
@@ -1,14 +1,24 @@
 <?php
-// includes/Providers/CompletionRequest.php
+/**
+ * Immutable value object representing an AI completion request.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Providers;
 
+/**
+ * Captures all parameters required to make an AI completion request.
+ *
+ * @since 1.0.0
+ */
 final class CompletionRequest {
 	/**
 	 * Constructor.
 	 *
-	 * @param array  $messages      Message history: [['role'=>'user','content'=>'...']]
+	 * @param array  $messages      Message history: [['role'=>'user','content'=>'...']].
 	 * @param string $system        System prompt.
 	 * @param string $model         Model ID (empty = use provider default).
 	 * @param float  $temperature   Sampling temperature.

--- a/includes/Providers/CompletionResponse.php
+++ b/includes/Providers/CompletionResponse.php
@@ -1,10 +1,25 @@
 <?php
-// includes/Providers/CompletionResponse.php
+/**
+ * Immutable value object representing an AI completion response.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Providers;
 
+/**
+ * Captures content, token counts, cost, and optional tool-call data from a provider response.
+ *
+ * @since 1.0.0
+ */
 final class CompletionResponse {
+	/**
+	 * Sum of prompt and completion token counts.
+	 *
+	 * @var int
+	 */
 	public readonly int $total_tokens;
 
 	/**

--- a/includes/Providers/GeminiProvider.php
+++ b/includes/Providers/GeminiProvider.php
@@ -1,8 +1,21 @@
 <?php
-// includes/Providers/GeminiProvider.php
+/**
+ * AI provider implementation for the Google Gemini API.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
+/**
+ * Handles completions, streaming, and image generation for Google Gemini models.
+ *
+ * Image generation uses the Imagen 3 model, decoding the base64-encoded response
+ * directly to a temp file to avoid a second HTTP round trip.
+ *
+ * @since 1.0.0
+ */
 class GeminiProvider extends AbstractProvider {
 
 	private const API_BASE      = 'https://generativelanguage.googleapis.com/v1beta';
@@ -30,17 +43,62 @@ class GeminiProvider extends AbstractProvider {
 		],
 	];
 
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.0.0
+	 * @param string $api_key Google AI Studio API key.
+	 */
 	public function __construct( private readonly string $api_key ) {}
 
+	/**
+	 * Return the provider slug used throughout the plugin.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
 	public function get_slug(): string {
-		return 'gemini'; }
-	public function get_models(): array {
-		return self::MODELS; }
-	public function get_default_model(): string {
-		return self::DEFAULT_MODEL; }
-	public function is_available(): bool {
-		return '' !== $this->api_key; }
+		return 'gemini';
+	}
 
+	/**
+	 * Return the available model identifiers keyed by model ID.
+	 *
+	 * @since 1.0.0
+	 * @return array<string, string>
+	 */
+	public function get_models(): array {
+		return self::MODELS;
+	}
+
+	/**
+	 * Return the default model identifier.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_default_model(): string {
+		return self::DEFAULT_MODEL;
+	}
+
+	/**
+	 * Return true when an API key is configured.
+	 *
+	 * @since 1.0.0
+	 * @return bool
+	 */
+	public function is_available(): bool {
+		return '' !== $this->api_key;
+	}
+
+	/**
+	 * Send a completion request to the Gemini generateContent endpoint.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request The completion request.
+	 * @return CompletionResponse
+	 * @throws ProviderException On HTTP failure or non-2xx status.
+	 */
 	protected function do_complete( CompletionRequest $request ): CompletionResponse {
 		$model    = ! empty( $request->model ) ? $request->model : self::DEFAULT_MODEL;
 		$contents = $this->messages_to_contents( $request->messages );
@@ -49,12 +107,21 @@ class GeminiProvider extends AbstractProvider {
 			$body['systemInstruction'] = [ 'parts' => [ [ 'text' => $request->system ] ] ];
 		}
 		if ( ! empty( $request->tools ) ) {
-			$body['tools'] = $request->tools; // already in Gemini wire format (functionDeclarations)
+			$body['tools'] = $request->tools; // Already in Gemini wire format (functionDeclarations).
 		}
 		$raw = $this->post( "/models/{$model}:generateContent", $body );
 		return $this->parse_response( $raw, $model );
 	}
 
+	/**
+	 * Simulate streaming by word-chunking a non-streaming completion.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request  The completion request.
+	 * @param callable          $on_chunk Callback invoked with each word token.
+	 * @return CompletionResponse
+	 * @throws ProviderException On HTTP failure or non-2xx status.
+	 */
 	protected function do_stream( CompletionRequest $request, callable $on_chunk ): CompletionResponse {
 		$response = $this->do_complete( $request );
 		foreach ( explode( ' ', $response->content ) as $i => $word ) {
@@ -63,6 +130,18 @@ class GeminiProvider extends AbstractProvider {
 		return $response;
 	}
 
+	/**
+	 * Generate an image using the Imagen 3 model.
+	 *
+	 * The base64-encoded image is decoded directly to a temp file to avoid a
+	 * second HTTP request, then handed off to media_handle_sideload.
+	 *
+	 * @since 1.0.0
+	 * @param string $prompt  Image generation prompt.
+	 * @param array  $options Optional overrides: 'aspect_ratio'.
+	 * @return int WordPress attachment ID.
+	 * @throws ProviderException When the API returns no image data or sideload fails.
+	 */
 	public function generate_image( string $prompt, array $options = [] ): int {
 		$body = [
 			'instances'  => [ [ 'prompt' => $prompt ] ],
@@ -111,6 +190,13 @@ class GeminiProvider extends AbstractProvider {
 		return $attachment_id;
 	}
 
+	/**
+	 * Convert OpenAI-style message array to Gemini contents format.
+	 *
+	 * @since 1.0.0
+	 * @param array $messages Array of messages with 'role' and 'content' keys.
+	 * @return array
+	 */
 	private function messages_to_contents( array $messages ): array {
 		return array_map(
 			fn( $m ) => [
@@ -121,6 +207,15 @@ class GeminiProvider extends AbstractProvider {
 		);
 	}
 
+	/**
+	 * POST a JSON body to the Gemini API and return the decoded response.
+	 *
+	 * @since 1.0.0
+	 * @param string $path API endpoint path (e.g. '/models/gemini-2.5-pro:generateContent').
+	 * @param array  $body Request payload.
+	 * @return array
+	 * @throws ProviderException On HTTP failure or non-2xx status.
+	 */
 	private function post( string $path, array $body ): array {
 		$url      = self::API_BASE . $path . '?key=' . rawurlencode( $this->api_key );
 		$response = wp_remote_post(
@@ -146,6 +241,18 @@ class GeminiProvider extends AbstractProvider {
 		return $data;
 	}
 
+	/**
+	 * Parse a raw Gemini API response into a CompletionResponse value object.
+	 *
+	 * Detects functionCall parts and populates tool_call on the response when the
+	 * model has invoked a function. Gemini does not always return a stable call ID,
+	 * so one is generated locally when absent.
+	 *
+	 * @since 1.0.0
+	 * @param array  $data  Decoded API response body.
+	 * @param string $model Model identifier used for pricing lookup.
+	 * @return CompletionResponse
+	 */
 	private function parse_response( array $data, string $model ): CompletionResponse {
 		$meta       = $data['usageMetadata'] ?? [];
 		$in_tokens  = (int) ( $meta['promptTokenCount'] ?? 0 );
@@ -169,7 +276,7 @@ class GeminiProvider extends AbstractProvider {
 					raw: [
 						'data'    => $data,
 						'call_id' => $call_id,
-					], // preserve generated call_id for history reconstruction
+					], // Preserve generated call_id for history reconstruction.
 					tool_call: [
 						'id'        => $call_id,
 						'name'      => $fc['name'],

--- a/includes/Providers/OllamaProvider.php
+++ b/includes/Providers/OllamaProvider.php
@@ -1,35 +1,95 @@
 <?php
-// includes/Providers/OllamaProvider.php
+/**
+ * AI provider implementation for locally-hosted Ollama models.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
+/**
+ * Handles completions via a local Ollama instance.
+ *
+ * Ollama does not support function/tool calling in the plugin's tool-use
+ * protocol, so tool definitions are never forwarded to this provider.
+ *
+ * @since 1.0.0
+ */
 class OllamaProvider extends AbstractProvider {
 
 	private const DEFAULT_MODEL = 'llama3.2';
 
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.0.0
+	 * @param string $base_url      Base URL of the Ollama HTTP server.
+	 * @param string $default_model Default model tag to use when none is specified.
+	 */
 	public function __construct(
 		private readonly string $base_url = 'http://localhost:11434',
 		private readonly string $default_model = self::DEFAULT_MODEL,
 	) {}
 
+	/**
+	 * Return the provider slug used throughout the plugin.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
 	public function get_slug(): string {
-		return 'ollama'; }
+		return 'ollama';
+	}
+
+	/**
+	 * Return the available model identifiers keyed by model tag.
+	 *
+	 * @since 1.0.0
+	 * @return array<string, string>
+	 */
 	public function get_models(): array {
-		return [ $this->default_model => $this->default_model ]; }
+		return [ $this->default_model => $this->default_model ];
+	}
+
+	/**
+	 * Return the default model identifier.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
 	public function get_default_model(): string {
-		return $this->default_model; }
+		return $this->default_model;
+	}
+
+	/**
+	 * Return true when a base URL is configured.
+	 *
+	 * @since 1.0.0
+	 * @return bool
+	 */
 	public function is_available(): bool {
-		return '' !== $this->base_url; }
+		return '' !== $this->base_url;
+	}
 
 	/**
 	 * Ollama does not support function/tool calling in the plugin's tool-use protocol.
 	 *
+	 * @since 1.0.0
 	 * @return bool
 	 */
 	public function supports_tools(): bool {
 		return false;
 	}
 
+	/**
+	 * Send a completion request to Ollama and return the response.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request The completion request.
+	 * @return CompletionResponse
+	 * @throws ProviderException On HTTP failure or non-2xx status.
+	 */
 	protected function do_complete( CompletionRequest $request ): CompletionResponse {
 		$messages = $request->messages;
 		if ( '' !== $request->system ) {
@@ -58,11 +118,20 @@ class OllamaProvider extends AbstractProvider {
 			$raw['model'] ?? $this->default_model,
 			$in_tokens,
 			$out_tokens,
-			0.0, // local inference — no cost
+			0.0, // Local inference — no cost.
 			$raw
 		);
 	}
 
+	/**
+	 * Simulate streaming by word-chunking a non-streaming completion.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request  The completion request.
+	 * @param callable          $on_chunk Callback invoked with each word token.
+	 * @return CompletionResponse
+	 * @throws ProviderException On HTTP failure or non-2xx status.
+	 */
 	protected function do_stream( CompletionRequest $request, callable $on_chunk ): CompletionResponse {
 		$response = $this->do_complete( $request );
 		foreach ( explode( ' ', $response->content ) as $i => $word ) {
@@ -71,7 +140,15 @@ class OllamaProvider extends AbstractProvider {
 		return $response;
 	}
 
-	public function generate_image( string $prompt, array $options = [] ): int {
+	/**
+	 * Image generation is not supported by Ollama.
+	 *
+	 * @since 1.0.0
+	 * @param string $prompt  Image generation prompt.
+	 * @param array  $options Optional generation options.
+	 * @throws ProviderException Always — Ollama does not support image generation.
+	 */
+	public function generate_image( string $prompt, array $options = [] ): never {
 		throw new ProviderException(
 			'Ollama does not support image generation. Use Gemini or OpenAI.',
 			'ollama',
@@ -79,11 +156,20 @@ class OllamaProvider extends AbstractProvider {
 		);
 	}
 
+	/**
+	 * POST a JSON body to the Ollama API and return the decoded response.
+	 *
+	 * @since 1.0.0
+	 * @param string $path API endpoint path (e.g. '/api/chat').
+	 * @param array  $body Request payload.
+	 * @return array
+	 * @throws ProviderException On HTTP failure or non-2xx status.
+	 */
 	private function post( string $path, array $body ): array {
 		$response = wp_remote_post(
 			rtrim( $this->base_url, '/' ) . $path,
 			[
-				'timeout' => 120, // Ollama can be slow on first run
+				'timeout' => 120, // Ollama can be slow on first run.
 				'headers' => [ 'Content-Type' => 'application/json' ],
 				'body'    => wp_json_encode( $body ),
 			]

--- a/includes/Providers/OpenAIProvider.php
+++ b/includes/Providers/OpenAIProvider.php
@@ -1,8 +1,18 @@
 <?php
-// includes/Providers/OpenAIProvider.php
+/**
+ * AI provider implementation for the OpenAI API.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
+/**
+ * Handles completions, streaming, and image generation for OpenAI models.
+ *
+ * @since 1.0.0
+ */
 class OpenAIProvider extends AbstractProvider {
 
 	private const API_BASE      = 'https://api.openai.com/v1';
@@ -34,17 +44,62 @@ class OpenAIProvider extends AbstractProvider {
 		],
 	];
 
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.0.0
+	 * @param string $api_key OpenAI API key.
+	 */
 	public function __construct( private readonly string $api_key ) {}
 
+	/**
+	 * Return the provider slug used throughout the plugin.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
 	public function get_slug(): string {
-		return 'openai'; }
-	public function get_models(): array {
-		return self::MODELS; }
-	public function get_default_model(): string {
-		return self::DEFAULT_MODEL; }
-	public function is_available(): bool {
-		return '' !== $this->api_key; }
+		return 'openai';
+	}
 
+	/**
+	 * Return the available model identifiers keyed by model ID.
+	 *
+	 * @since 1.0.0
+	 * @return array<string, string>
+	 */
+	public function get_models(): array {
+		return self::MODELS;
+	}
+
+	/**
+	 * Return the default model identifier.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_default_model(): string {
+		return self::DEFAULT_MODEL;
+	}
+
+	/**
+	 * Return true when an API key is configured.
+	 *
+	 * @since 1.0.0
+	 * @return bool
+	 */
+	public function is_available(): bool {
+		return '' !== $this->api_key;
+	}
+
+	/**
+	 * Send a completion request to the OpenAI Chat Completions endpoint.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request The completion request.
+	 * @return CompletionResponse
+	 * @throws ProviderException On HTTP failure or non-2xx status.
+	 */
 	protected function do_complete( CompletionRequest $request ): CompletionResponse {
 		$messages = $request->messages;
 		if ( '' !== $request->system ) {
@@ -64,13 +119,22 @@ class OpenAIProvider extends AbstractProvider {
 			'temperature' => $request->temperature,
 		];
 		if ( ! empty( $request->tools ) ) {
-			$body['tools']       = $request->tools; // already in OpenAI wire format from ToolRegistry
+			$body['tools']       = $request->tools; // Already in OpenAI wire format from ToolRegistry.
 			$body['tool_choice'] = 'auto';
 		}
 		$raw = $this->post( '/chat/completions', $body );
 		return $this->parse_response( $raw, $model );
 	}
 
+	/**
+	 * Simulate streaming by word-chunking a non-streaming completion.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request  The completion request.
+	 * @param callable          $on_chunk Callback invoked with each word token.
+	 * @return CompletionResponse
+	 * @throws ProviderException On HTTP failure or non-2xx status.
+	 */
 	protected function do_stream( CompletionRequest $request, callable $on_chunk ): CompletionResponse {
 		$response = $this->do_complete( $request );
 		$words    = explode( ' ', $response->content );
@@ -80,6 +144,15 @@ class OpenAIProvider extends AbstractProvider {
 		return $response;
 	}
 
+	/**
+	 * Generate an image using the DALL-E 3 model.
+	 *
+	 * @since 1.0.0
+	 * @param string $prompt  Image generation prompt.
+	 * @param array  $options Optional overrides: 'size' and 'quality'.
+	 * @return int WordPress attachment ID.
+	 * @throws ProviderException When the API returns no image URL.
+	 */
 	public function generate_image( string $prompt, array $options = [] ): int {
 		$body = [
 			'model'   => 'dall-e-3',
@@ -96,6 +169,15 @@ class OpenAIProvider extends AbstractProvider {
 		return $this->save_image_to_media_library( $url, 'dalle-' . time(), $prompt );
 	}
 
+	/**
+	 * POST a JSON body to the OpenAI API and return the decoded response.
+	 *
+	 * @since 1.0.0
+	 * @param string $path API endpoint path (e.g. '/chat/completions').
+	 * @param array  $body Request payload.
+	 * @return array
+	 * @throws ProviderException On HTTP failure or non-2xx status.
+	 */
 	private function post( string $path, array $body ): array {
 		$response = wp_remote_post(
 			self::API_BASE . $path,
@@ -124,6 +206,17 @@ class OpenAIProvider extends AbstractProvider {
 		return $data;
 	}
 
+	/**
+	 * Parse a raw OpenAI API response into a CompletionResponse value object.
+	 *
+	 * Detects tool_calls finish reason and populates tool_call on the response
+	 * when the model has invoked a function.
+	 *
+	 * @since 1.0.0
+	 * @param array  $data  Decoded API response body.
+	 * @param string $model Model identifier used for pricing lookup.
+	 * @return CompletionResponse
+	 */
 	private function parse_response( array $data, string $model ): CompletionResponse {
 		$in_tokens  = (int) ( $data['usage']['prompt_tokens'] ?? 0 );
 		$out_tokens = (int) ( $data['usage']['completion_tokens'] ?? 0 );

--- a/includes/Providers/ProviderException.php
+++ b/includes/Providers/ProviderException.php
@@ -1,9 +1,19 @@
 <?php
-// includes/Providers/ProviderException.php
+/**
+ * Exception thrown by AI providers on API errors, timeouts, or invalid responses.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Providers;
 
+/**
+ * Carries HTTP status, provider slug, and raw response alongside the error message.
+ *
+ * @since 1.0.0
+ */
 class ProviderException extends \RuntimeException {
 
 	/**

--- a/includes/Providers/ProviderFactory.php
+++ b/includes/Providers/ProviderFactory.php
@@ -1,14 +1,38 @@
 <?php
-// includes/Providers/ProviderFactory.php
+/**
+ * Factory for instantiating AI provider instances.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
 use WP_AI_Mind\Settings\ProviderSettings;
 
+/**
+ * Creates concrete provider instances from a slug and decrypted API keys.
+ *
+ * @since 1.0.0
+ */
 class ProviderFactory {
 
+	/**
+	 * Inject the provider settings to supply decrypted API keys.
+	 *
+	 * @since 1.0.0
+	 * @param ProviderSettings $settings Provider settings holding encrypted API keys.
+	 */
 	public function __construct( private readonly ProviderSettings $settings ) {}
 
+	/**
+	 * Instantiate a provider by slug.
+	 *
+	 * @since 1.0.0
+	 * @param string $slug Provider slug: 'claude', 'openai', 'gemini', or 'ollama'.
+	 * @return ProviderInterface
+	 * @throws \InvalidArgumentException For unknown slugs.
+	 */
 	public function make( string $slug ): ProviderInterface {
 		return match ( $slug ) {
 			'claude' => new ClaudeProvider( $this->settings->get_api_key( 'claude' ) ),
@@ -22,19 +46,34 @@ class ProviderFactory {
 		};
 	}
 
-	/** Returns the active provider for text completions (from settings). */
+	/**
+	 * Return the active provider for text completions (resolved from plugin settings).
+	 *
+	 * @since 1.0.0
+	 * @return ProviderInterface
+	 */
 	public function make_default(): ProviderInterface {
 		$slug = get_option( 'wp_ai_mind_default_provider', 'claude' );
 		return $this->make( ! empty( $slug ) ? $slug : 'claude' );
 	}
 
-	/** Returns the active provider for image generation. */
+	/**
+	 * Return the active provider for image generation (resolved from plugin settings).
+	 *
+	 * @since 1.0.0
+	 * @return ProviderInterface
+	 */
 	public function make_image_provider(): ProviderInterface {
 		$slug = get_option( 'wp_ai_mind_image_provider', 'gemini' );
 		return $this->make( ! empty( $slug ) ? $slug : 'gemini' );
 	}
 
-	/** Returns all configured (available) providers. */
+	/**
+	 * Return all providers that have a valid API key configured.
+	 *
+	 * @since 1.0.0
+	 * @return ProviderInterface[]
+	 */
 	public function get_available(): array {
 		return array_values(
 			array_filter(
@@ -44,7 +83,12 @@ class ProviderFactory {
 		);
 	}
 
-	/** Returns all providers unconditionally (regardless of API key). */
+	/**
+	 * Return all supported providers unconditionally, regardless of API key status.
+	 *
+	 * @since 1.0.0
+	 * @return ProviderInterface[]
+	 */
 	public function get_all(): array {
 		return array_map( fn( $s ) => $this->make( $s ), [ 'claude', 'openai', 'gemini', 'ollama' ] );
 	}

--- a/includes/Providers/ProviderInterface.php
+++ b/includes/Providers/ProviderInterface.php
@@ -1,5 +1,10 @@
 <?php
-// includes/Providers/ProviderInterface.php
+/**
+ * Common contract for all AI completion providers.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Providers;
@@ -12,7 +17,7 @@ interface ProviderInterface {
 	 * @param CompletionRequest $request The completion request.
 	 * @return CompletionResponse
 	 *
-	 * @throws ProviderException on API error or timeout.
+	 * @throws ProviderException On API error or timeout.
 	 */
 	public function complete( CompletionRequest $request ): CompletionResponse;
 
@@ -24,7 +29,7 @@ interface ProviderInterface {
 	 * @param callable          $on_chunk Callback for each chunk.
 	 * @return CompletionResponse
 	 *
-	 * @throws ProviderException
+	 * @throws ProviderException On API error or timeout.
 	 */
 	public function stream( CompletionRequest $request, callable $on_chunk ): CompletionResponse;
 
@@ -36,7 +41,7 @@ interface ProviderInterface {
 	 * @param array  $options Image generation options.
 	 * @return int Attachment ID.
 	 *
-	 * @throws ProviderException
+	 * @throws ProviderException On generation failure or unsupported provider.
 	 */
 	public function generate_image( string $prompt, array $options = [] ): int;
 

--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Sends authenticated requests to the Cloudflare Worker AI proxy.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Proxy;
@@ -22,7 +28,7 @@ class NJ_Proxy_Client {
 	/**
 	 * Send a chat request through the Cloudflare proxy.
 	 *
-	 * @param array<array{role: string, content: string}> $messages
+	 * @param array<array{role: string, content: string}> $messages Chat message history.
 	 * @param array<string, mixed>                        $options  Supports 'model', 'max_tokens', 'system'.
 	 * @return array<string, mixed>|WP_Error
 	 */

--- a/includes/Proxy/NJ_Site_Registration.php
+++ b/includes/Proxy/NJ_Site_Registration.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Handles site registration with the Cloudflare Worker AI proxy.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Proxy;

--- a/includes/Settings/ProviderSettings.php
+++ b/includes/Settings/ProviderSettings.php
@@ -1,7 +1,20 @@
 <?php
+/**
+ * Encrypted storage and retrieval of AI provider API keys.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Settings;
 
+/**
+ * Stores and retrieves encrypted API keys for AI providers.
+ *
+ * Keys are AES-256-CBC encrypted using WordPress's AUTH_KEY and
+ * SECURE_AUTH_KEY constants as the secret. If a matching environment
+ * variable is set, it takes precedence over the database-stored key.
+ */
 class ProviderSettings {
 
 	private const OPTION_KEY      = 'wp_ai_mind_provider_keys';
@@ -13,13 +26,33 @@ class ProviderSettings {
 		'gemini' => 'GEMINI_API_KEY',
 	];
 
+	/**
+	 * Decrypted API keys keyed by provider slug.
+	 *
+	 * @var array<string, string>
+	 */
 	private array $keys;
 
+	/**
+	 * Load stored encrypted keys from the database on construction.
+	 *
+	 * @since 1.0.0
+	 */
 	public function __construct() {
 		$raw        = get_option( self::OPTION_KEY, [] );
 		$this->keys = is_array( $raw ) ? $raw : [];
 	}
 
+	/**
+	 * Return the plaintext API key for a provider.
+	 *
+	 * Environment variable takes precedence over the database value so
+	 * server-level secrets can override per-site settings without touching the DB.
+	 *
+	 * @since 1.0.0
+	 * @param string $provider Provider slug: 'claude', 'openai', 'gemini', or 'ollama'.
+	 * @return string Decrypted API key, or empty string if none is set.
+	 */
 	public function get_api_key( string $provider ): string {
 		$env_var = self::ENV_VARS[ $provider ] ?? null;
 		if ( $env_var ) {
@@ -35,6 +68,16 @@ class ProviderSettings {
 		return self::decrypt( $this->keys[ $provider ] );
 	}
 
+	/**
+	 * Encrypt and persist an API key for a provider.
+	 *
+	 * Silently ignores unknown provider slugs.
+	 *
+	 * @since 1.0.0
+	 * @param string $provider Provider slug.
+	 * @param string $key      Plaintext API key to store.
+	 * @return void
+	 */
 	public function set_api_key( string $provider, string $key ): void {
 		if ( ! in_array( $provider, self::VALID_PROVIDERS, true ) ) {
 			return;
@@ -43,22 +86,49 @@ class ProviderSettings {
 		update_option( self::OPTION_KEY, $this->keys );
 	}
 
+	/**
+	 * Check whether a non-empty key is available for a provider.
+	 *
+	 * @since 1.0.0
+	 * @param string $provider Provider slug.
+	 * @return bool True if a key is set via environment variable or database.
+	 */
 	public function has_key( string $provider ): bool {
 		return '' !== $this->get_api_key( $provider );
 	}
 
 	// ── Encryption helpers ─────────────────────────────────────────────────────
 
+	/**
+	 * Derive the 256-bit encryption secret from WordPress salt constants.
+	 *
+	 * @since 1.0.0
+	 * @return string Binary 32-byte key.
+	 */
 	private static function secret(): string {
 		return hash( 'sha256', AUTH_KEY . SECURE_AUTH_KEY, true );
 	}
 
+	/**
+	 * Encrypt a plaintext string with AES-256-CBC and base64-encode the result.
+	 *
+	 * @since 1.0.0
+	 * @param string $plain Plaintext to encrypt.
+	 * @return string Base64-encoded "IV::ciphertext" string.
+	 */
 	private static function encrypt( string $plain ): string {
 		$iv         = random_bytes( openssl_cipher_iv_length( self::CIPHER ) );
 		$ciphertext = openssl_encrypt( $plain, self::CIPHER, self::secret(), 0, $iv );
 		return base64_encode( $iv . '::' . $ciphertext ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encoding encrypted API key, not obfuscation.
 	}
 
+	/**
+	 * Decrypt a base64-encoded "IV::ciphertext" string.
+	 *
+	 * @since 1.0.0
+	 * @param string $encoded Base64-encoded encrypted value.
+	 * @return string Decrypted plaintext, or empty string on failure.
+	 */
 	private static function decrypt( string $encoded ): string {
 		$decoded = base64_decode( $encoded, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding encrypted API key, not obfuscation.
 		if ( false === $decoded || ! str_contains( $decoded, '::' ) ) {

--- a/includes/Tiers/NJ_Tier_Config.php
+++ b/includes/Tiers/NJ_Tier_Config.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Static configuration for tier capabilities and monthly request limits.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Tiers;

--- a/includes/Tiers/NJ_Tier_Manager.php
+++ b/includes/Tiers/NJ_Tier_Manager.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Manages user licence tiers (Free, Trial, Pro Managed, Pro BYOK).
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Tiers;

--- a/includes/Tiers/NJ_Usage_Tracker.php
+++ b/includes/Tiers/NJ_Usage_Tracker.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Tracks per-user monthly API request consumption against tier limits.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Tiers;

--- a/includes/Tools/ToolDefinition.php
+++ b/includes/Tools/ToolDefinition.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Immutable value object describing a single AI tool definition.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Tools;
@@ -8,10 +14,20 @@ namespace WP_AI_Mind\Tools;
  */
 final class ToolDefinition {
 
+	/**
+	 * Create a tool definition.
+	 *
+	 * @since 1.0.0
+	 * @param string $name                Tool name used by the AI provider (snake_case).
+	 * @param string $description         Human-readable description sent to the provider.
+	 * @param array  $parameters          JSON Schema object describing the tool's parameters.
+	 * @param string $capability          WordPress capability required to call this tool.
+	 * @param bool   $requires_write_tools Whether the tool requires the write-tools setting to be enabled.
+	 */
 	public function __construct(
 		public readonly string $name,
 		public readonly string $description,
-		public readonly array $parameters,        // JSON Schema object for the tool's params.
+		public readonly array $parameters,
 		public readonly string $capability = 'edit_posts',
 		public readonly bool $requires_write_tools = false,
 	) {}

--- a/includes/Tools/ToolExecutor.php
+++ b/includes/Tools/ToolExecutor.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Executes AI tool calls on behalf of authenticated WordPress users.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Tools;
@@ -12,6 +18,12 @@ namespace WP_AI_Mind\Tools;
  */
 class ToolExecutor {
 
+	/**
+	 * Inject the tool registry needed to validate allowed post types.
+	 *
+	 * @since 1.0.0
+	 * @param ToolRegistry $registry The tool registry instance.
+	 */
 	public function __construct( private ToolRegistry $registry ) {}
 
 	// -------------------------------------------------------------------------
@@ -50,6 +62,11 @@ class ToolExecutor {
 
 	/**
 	 * Retrieve a list of recent posts.
+	 *
+	 * @since 1.0.0
+	 * @param array $args    Tool arguments from the AI provider.
+	 * @param int   $user_id WordPress user ID performing the call.
+	 * @return array
 	 */
 	private function get_recent_posts( array $args, int $user_id ): array {
 		if ( ! \user_can( $user_id, 'edit_posts' ) ) {
@@ -91,6 +108,11 @@ class ToolExecutor {
 
 	/**
 	 * Retrieve the full content of a single post or page.
+	 *
+	 * @since 1.0.0
+	 * @param array $args    Tool arguments from the AI provider.
+	 * @param int   $user_id WordPress user ID performing the call.
+	 * @return array
 	 */
 	private function get_post_content( array $args, int $user_id ): array {
 		$post_id = \absint( $args['post_id'] ?? 0 );
@@ -127,6 +149,11 @@ class ToolExecutor {
 
 	/**
 	 * Search for posts matching a keyword query.
+	 *
+	 * @since 1.0.0
+	 * @param array $args    Tool arguments from the AI provider.
+	 * @param int   $user_id WordPress user ID performing the call.
+	 * @return array
 	 */
 	private function search_posts( array $args, int $user_id ): array {
 		if ( ! \user_can( $user_id, 'edit_posts' ) ) {
@@ -170,6 +197,11 @@ class ToolExecutor {
 
 	/**
 	 * Create a new post or page.
+	 *
+	 * @since 1.0.0
+	 * @param array $args    Tool arguments from the AI provider.
+	 * @param int   $user_id WordPress user ID performing the call.
+	 * @return array
 	 */
 	private function create_post( array $args, int $user_id ): array {
 		if ( ! (bool) \get_option( 'wp_ai_mind_enable_write_tools', false ) ) {
@@ -220,6 +252,11 @@ class ToolExecutor {
 
 	/**
 	 * Update an existing post or page.
+	 *
+	 * @since 1.0.0
+	 * @param array $args    Tool arguments from the AI provider.
+	 * @param int   $user_id WordPress user ID performing the call.
+	 * @return array
 	 */
 	private function update_post( array $args, int $user_id ): array {
 		if ( ! (bool) \get_option( 'wp_ai_mind_enable_write_tools', false ) ) {
@@ -265,6 +302,11 @@ class ToolExecutor {
 
 	/**
 	 * Retrieve a list of published pages.
+	 *
+	 * @since 1.0.0
+	 * @param array $args    Tool arguments from the AI provider.
+	 * @param int   $user_id WordPress user ID performing the call.
+	 * @return array
 	 */
 	private function get_pages( array $args, int $user_id ): array {
 		if ( ! \user_can( $user_id, 'edit_posts' ) ) {
@@ -298,6 +340,11 @@ class ToolExecutor {
 
 	/**
 	 * Retrieve general site information.
+	 *
+	 * @since 1.0.0
+	 * @param array $args    Tool arguments from the AI provider.
+	 * @param int   $user_id WordPress user ID performing the call.
+	 * @return array
 	 */
 	private function get_site_info( array $args, int $user_id ): array {
 		if ( ! \user_can( $user_id, 'read' ) ) {

--- a/includes/Tools/ToolRegistry.php
+++ b/includes/Tools/ToolRegistry.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Registers all available AI tools and formats them for each provider's wire format.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 namespace WP_AI_Mind\Tools;
@@ -8,9 +14,18 @@ namespace WP_AI_Mind\Tools;
  */
 class ToolRegistry {
 
-	/** @var ToolDefinition[] */
+	/**
+	 * All registered tool definitions.
+	 *
+	 * @var ToolDefinition[]
+	 */
 	private array $tools = [];
 
+	/**
+	 * Register all built-in tool definitions on construction.
+	 *
+	 * @since 1.0.0
+	 */
 	public function __construct() {
 		$this->register_tools();
 	}
@@ -60,10 +75,12 @@ class ToolRegistry {
 		);
 	}
 
-	// -------------------------------------------------------------------------
-	// Tool registration
-	// -------------------------------------------------------------------------
-
+	/**
+	 * Instantiate and register all built-in tool definitions.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
 	private function register_tools(): void {
 		$this->tools[] = new ToolDefinition(
 			name: 'get_recent_posts',
@@ -288,7 +305,8 @@ class ToolRegistry {
 	/**
 	 * Format tools for the Anthropic Claude API.
 	 *
-	 * @param ToolDefinition[] $tools
+	 * @since 1.0.0
+	 * @param ToolDefinition[] $tools Tool definitions to format.
 	 * @return array
 	 */
 	private function format_claude( array $tools ): array {
@@ -311,7 +329,8 @@ class ToolRegistry {
 	/**
 	 * Format tools for the OpenAI API.
 	 *
-	 * @param ToolDefinition[] $tools
+	 * @since 1.0.0
+	 * @param ToolDefinition[] $tools Tool definitions to format.
 	 * @return array
 	 */
 	private function format_openai( array $tools ): array {
@@ -337,7 +356,8 @@ class ToolRegistry {
 	/**
 	 * Format tools for the Google Gemini API.
 	 *
-	 * @param ToolDefinition[] $tools
+	 * @since 1.0.0
+	 * @param ToolDefinition[] $tools Tool definitions to format.
 	 * @return array
 	 */
 	private function format_gemini( array $tools ): array {

--- a/includes/Voice/VoiceInjector.php
+++ b/includes/Voice/VoiceInjector.php
@@ -1,13 +1,31 @@
 <?php
-// includes/Voice/VoiceInjector.php
+/**
+ * Builds system prompts by merging site-wide and per-user voice preferences.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 namespace WP_AI_Mind\Voice;
 
+/**
+ * Builds AI system prompts by merging site-wide and per-user voice preferences.
+ *
+ * @since 1.0.0
+ */
 class VoiceInjector {
 
 	private const SITE_OPTION = 'wp_ai_mind_site_voice';
 	private const USER_META   = 'wp_ai_mind_voice';
 
+	/**
+	 * Build a system prompt combining voice preferences and a feature-specific instruction.
+	 *
+	 * @since 1.0.0
+	 * @param string $feature_instruction Optional feature-specific instruction appended after the voice rules.
+	 * @param int    $user_id             User ID whose meta overrides site-level values; 0 means no user override.
+	 * @return string System prompt string, or empty string if no voice rules are configured.
+	 */
 	public function build_system_prompt( string $feature_instruction = '', int $user_id = 0 ): string {
 		$voice = $this->get_merged_voice( $user_id );
 		$parts = [];
@@ -42,6 +60,13 @@ class VoiceInjector {
 		return $base;
 	}
 
+	/**
+	 * Merge site-level and per-user voice settings; user values take precedence when non-empty.
+	 *
+	 * @since 1.0.0
+	 * @param int $user_id User ID; 0 returns only site-level values.
+	 * @return array<string, string>
+	 */
 	private function get_merged_voice( int $user_id ): array {
 		$site = get_option( self::SITE_OPTION, [] );
 		$site = is_array( $site ) ? $site : [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@semantic-release/release-notes-generator": "^14.0.0",
         "@wordpress/element": ">=6.0.0",
         "@wordpress/scripts": "^31.8.0",
+        "eslint-plugin-jsdoc": "^62.9.0",
         "semantic-release": "^24.0.0"
       },
       "peerDependencies": {
@@ -2842,18 +2843,44 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz",
-      "integrity": "sha512-aKUhyn1QI5Ksbqcr3fFJj16p99QdjUxXAEuFst1Z47DRyoiMwivIH9MV/ARcJOCXVjPfjITciej8ZD2O/6qUmw==",
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.86.0.tgz",
+      "integrity": "sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "comment-parser": "1.4.1",
-        "esquery": "^1.5.0",
-        "jsdoc-type-pratt-parser": "~4.0.0"
+        "@types/estree": "^1.0.8",
+        "@typescript-eslint/types": "^8.58.0",
+        "comment-parser": "1.4.6",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.2.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment/node_modules/@typescript-eslint/types": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -5900,6 +5927,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -7872,6 +7912,31 @@
         }
       }
     },
+    "node_modules/@wordpress/eslint-plugin/node_modules/@es-joy/jsdoccomment": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz",
+      "integrity": "sha512-aKUhyn1QI5Ksbqcr3fFJj16p99QdjUxXAEuFst1Z47DRyoiMwivIH9MV/ARcJOCXVjPfjITciej8ZD2O/6qUmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "comment-parser": "1.4.1",
+        "esquery": "^1.5.0",
+        "jsdoc-type-pratt-parser": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@wordpress/eslint-plugin/node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -7884,6 +7949,53 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-jsdoc": {
+      "version": "46.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.10.1.tgz",
+      "integrity": "sha512-x8wxIpv00Y50NyweDUpa+58ffgSAI5sqe+zcZh33xphD0AVh+1kqr1ombaTRb7Fhpove1zfUuujlX9DWWBP5ag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.41.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.5.0",
+        "is-builtin-module": "^3.2.1",
+        "semver": "^7.5.4",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -10006,9 +10118,9 @@
       }
     },
     "node_modules/comment-parser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
-      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",
+      "integrity": "sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12413,27 +12525,63 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "46.10.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.10.1.tgz",
-      "integrity": "sha512-x8wxIpv00Y50NyweDUpa+58ffgSAI5sqe+zcZh33xphD0AVh+1kqr1ombaTRb7Fhpove1zfUuujlX9DWWBP5ag==",
+      "version": "62.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.9.0.tgz",
+      "integrity": "sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.41.0",
+        "@es-joy/jsdoccomment": "~0.86.0",
+        "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.1",
-        "debug": "^4.3.4",
+        "comment-parser": "1.4.6",
+        "debug": "^4.4.3",
         "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.5.0",
-        "is-builtin-module": "^3.2.1",
-        "semver": "^7.5.4",
-        "spdx-expression-parse": "^4.0.0"
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.4",
+        "spdx-expression-parse": "^4.0.0",
+        "to-valid-identifier": "^1.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
@@ -16678,13 +16826,13 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
-      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/jsdom": {
@@ -21104,6 +21252,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
+      "integrity": "sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-filter": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
@@ -21581,6 +21736,16 @@
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
       "dev": true
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -21622,6 +21787,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -23716,6 +23888,19 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -27142,6 +27327,23 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@wordpress/element": ">=6.0.0"
   },
   "devDependencies": {
-    "@wordpress/element": ">=6.0.0",
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",
     "@semantic-release/changelog": "^6.0.0",
@@ -28,7 +27,9 @@
     "@semantic-release/git": "^10.0.0",
     "@semantic-release/github": "^10.0.0",
     "@semantic-release/release-notes-generator": "^14.0.0",
+    "@wordpress/element": ">=6.0.0",
     "@wordpress/scripts": "^31.8.0",
+    "eslint-plugin-jsdoc": "^62.9.0",
     "semantic-release": "^24.0.0"
   },
   "wp-scripts-config": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,6 +6,7 @@
   <file>uninstall.php</file>
   <arg name="extensions" value="php"/>
   <arg value="sp"/>
+  <rule ref="WordPress-Docs"/>
   <rule ref="WordPress-Extra">
     <!-- Allow short array syntax -->
     <exclude name="Universal.Arrays.DisallowShortArraySyntax"/>

--- a/src/admin/components/Chat/ChatApp.jsx
+++ b/src/admin/components/Chat/ChatApp.jsx
@@ -7,6 +7,14 @@ import QuickActions from '../RightPanel/QuickActions';
 import ModelSelector from '../RightPanel/ModelSelector';
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * Root chat application: conversation list, message thread, and composer.
+ *
+ * Manages the full chat session including conversation CRUD, provider/model
+ * selection, and the context-post attachment flow.
+ *
+ * @return {ReactElement}
+ */
 export default function ChatApp() {
 	const { isPro } = window.wpAiMindData || {};
 
@@ -227,6 +235,11 @@ export default function ChatApp() {
 	);
 }
 
+/**
+ * Placeholder displayed when no messages have been sent yet.
+ *
+ * @return {ReactElement}
+ */
 function EmptyState() {
 	return (
 		<div className="wpaim-empty">

--- a/src/admin/components/Chat/Composer.jsx
+++ b/src/admin/components/Chat/Composer.jsx
@@ -3,6 +3,21 @@ import { Button } from '@wordpress/components';
 import { CornerDownLeft, Loader2, Paperclip, FileText, X } from 'lucide-react';
 import ContextPicker from './ContextPicker';
 
+/**
+ * Message composer with optional post-context attachment.
+ *
+ * Submits on Enter (without Shift) or Send button click. Shows a ContextPicker
+ * popover when the attach button is clicked, and renders an attachment pill
+ * while a post is attached.
+ *
+ * @param {Object}        props
+ * @param {Function}      props.onSend       Called with the trimmed message string when submitted.
+ * @param {boolean}       props.isLoading    Disables the input and shows a spinner while true.
+ * @param {Object|null}   props.attachedPost Currently attached post object (`{ id, title }`) or null.
+ * @param {Function}      props.onAttach     Called with the selected post object when context is chosen.
+ * @param {Function}      props.onDetach     Called when the attachment pill dismiss button is clicked.
+ * @return {ReactElement}
+ */
 export default function Composer( {
 	onSend,
 	isLoading,

--- a/src/admin/components/Chat/ContextPicker.jsx
+++ b/src/admin/components/Chat/ContextPicker.jsx
@@ -2,6 +2,17 @@ import { useState, useEffect, useRef } from '@wordpress/element';
 import { Search } from 'lucide-react';
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * Debounced search popover for attaching a post as chat context.
+ *
+ * Queries /wp-ai-mind/v1/search-posts after 300 ms of inactivity.
+ * Closes on Escape key. Minimum 2 characters before a search is triggered.
+ *
+ * @param {Object}   props
+ * @param {Function} props.onSelect Called with the selected post object when a result is clicked.
+ * @param {Function} props.onClose  Called when the picker should be dismissed without a selection.
+ * @return {ReactElement}
+ */
 export default function ContextPicker( { onSelect, onClose } ) {
 	const [ query, setQuery ] = useState( '' );
 	const [ results, setResults ] = useState( [] );

--- a/src/admin/components/Chat/MessageBubble.jsx
+++ b/src/admin/components/Chat/MessageBubble.jsx
@@ -1,6 +1,21 @@
 import { Cpu } from 'lucide-react';
 import MarkdownContent from '../../../shared/MarkdownContent';
 
+/**
+ * Renders a single chat message bubble.
+ *
+ * AI messages are rendered as sanitised Markdown; user messages are plain text.
+ * Error messages receive an additional error modifier class.
+ *
+ * @param {Object} props
+ * @param {Object} props.message           Message object from the conversation history.
+ * @param {string} props.message.role      Either 'user' or 'assistant'.
+ * @param {string} props.message.content   Message text (Markdown for AI, plain text for user).
+ * @param {string} [props.message.model]   Model slug displayed in the meta line for AI messages.
+ * @param {number} [props.message.tokens]  Token count displayed in the meta line for AI messages.
+ * @param {boolean} [props.message.isError] When true, applies the error modifier class.
+ * @return {ReactElement}
+ */
 export default function MessageBubble( { message } ) {
 	const isAI = message.role === 'assistant';
 

--- a/src/admin/components/Chat/MessageList.jsx
+++ b/src/admin/components/Chat/MessageList.jsx
@@ -2,6 +2,16 @@ import { useEffect, useRef } from '@wordpress/element';
 import { Loader2 } from 'lucide-react';
 import MessageBubble from './MessageBubble';
 
+/**
+ * Scrollable list of message bubbles with a loading indicator.
+ *
+ * Auto-scrolls to the bottom whenever `messages` or `isLoading` changes.
+ *
+ * @param {Object}  props
+ * @param {Array}   props.messages   Array of message objects passed to MessageBubble.
+ * @param {boolean} props.isLoading  When true, appends a spinner bubble at the bottom.
+ * @return {ReactElement}
+ */
 export default function MessageList( { messages, isLoading } ) {
 	const bottomRef = useRef( null );
 

--- a/src/admin/components/RightPanel/ModelSelector.jsx
+++ b/src/admin/components/RightPanel/ModelSelector.jsx
@@ -10,6 +10,21 @@ const PROVIDER_LABELS = {
 	ollama: 'Ollama',
 };
 
+/**
+ * Provider and model selector with a simple/advanced toggle.
+ *
+ * In simple mode, shows the plugin's configured default model label.
+ * In advanced mode, exposes provider and per-provider model dropdowns.
+ * The advanced state is persisted to localStorage.
+ *
+ * @param {Object}   props
+ * @param {Array}    props.providers         Array of provider objects from the /providers endpoint.
+ * @param {string}   props.selectedProvider  Currently selected provider slug.
+ * @param {string}   props.selectedModel     Currently selected model ID, or empty for the provider default.
+ * @param {Function} props.onProviderChange  Called with the new provider slug when changed.
+ * @param {Function} props.onModelChange     Called with the new model ID when changed.
+ * @return {ReactElement}
+ */
 export default function ModelSelector( {
 	providers,
 	selectedProvider,

--- a/src/admin/components/RightPanel/QuickActions.jsx
+++ b/src/admin/components/RightPanel/QuickActions.jsx
@@ -37,6 +37,17 @@ const PRO_ACTIONS = [
 	},
 ];
 
+/**
+ * Pre-defined prompt shortcuts displayed in the right panel.
+ *
+ * Free users see a limited set of actions; Pro users see additional prompts.
+ * Clicking a button fires the prompt directly via onAction.
+ *
+ * @param {Object}   props
+ * @param {Function} props.onAction Called with the prompt string when an action button is clicked.
+ * @param {boolean}  props.isPro    When true, the full Pro action set is displayed.
+ * @return {ReactElement}
+ */
 export default function QuickActions( { onAction, isPro } ) {
 	const actions = isPro ? [ ...FREE_ACTIONS, ...PRO_ACTIONS ] : FREE_ACTIONS;
 

--- a/src/admin/components/Sidebar/ConversationHistory.jsx
+++ b/src/admin/components/Sidebar/ConversationHistory.jsx
@@ -2,6 +2,20 @@
 import { useState } from '@wordpress/element';
 import { Trash2, Check, X } from 'lucide-react';
 
+/**
+ * Sidebar list of past conversations with inline delete confirmation.
+ *
+ * Shows an empty state when there are no conversations. Delete uses a
+ * two-step confirm flow (click → confirm/cancel) to prevent accidental deletion.
+ *
+ * @param {Object}  props
+ * @param {Array}   props.conversations       Array of conversation objects: `{ id, title, updated_at }`.
+ * @param {number|null} props.activeId        ID of the currently open conversation, or null.
+ * @param {Function}    props.onSelect        Called with the conversation ID when a row is clicked.
+ * @param {Function}    props.onDelete        Called with the conversation ID to trigger deletion.
+ * @param {Set}         [props.deletingIds]   Set of conversation IDs currently being deleted (shows disabled state).
+ * @return {ReactElement}
+ */
 export default function ConversationHistory( {
 	conversations,
 	activeId,

--- a/src/admin/dashboard/DashboardApp.jsx
+++ b/src/admin/dashboard/DashboardApp.jsx
@@ -5,6 +5,15 @@ import PageFooter from './PageFooter';
 import OnboardingPage from './OnboardingPage';
 import './dashboard.css';
 
+/**
+ * Root dashboard application shown on the main WP AI Mind admin page.
+ *
+ * Reads all page data from the `wpAiMindDashboard` global injected by PHP.
+ * Renders the onboarding wizard in place of the normal dashboard when
+ * `onboardingSeen` is false, so first-time users are guided through setup.
+ *
+ * @return {ReactElement}
+ */
 export default function DashboardApp() {
 	const data = window.wpAiMindDashboard ?? {};
 	const {

--- a/src/admin/dashboard/OnboardingPage.jsx
+++ b/src/admin/dashboard/OnboardingPage.jsx
@@ -49,6 +49,17 @@ const IMAGE_PROVIDERS = [
 
 // ── Step 1 ────────────────────────────────────────────────────────────────────
 
+/**
+ * First onboarding step — choose between Plugin API, own API key, or Pro.
+ *
+ * @param {Object}   props
+ * @param {string}   props.selection   Currently selected connection type: `'plugin'`, `'own_key'`, or `'pro'`.
+ * @param {Function} props.onSelect    Called with the new selection string when a choice card is clicked.
+ * @param {Function} props.onContinue  Called when the user clicks "Get started".
+ * @param {Function} props.onSkip      Called when the user skips setup entirely.
+ * @param {string}   props.upgradeUrl  URL for the Pro upgrade page (used when `selection === 'pro'`).
+ * @return {ReactElement}
+ */
 function Step1( { selection, onSelect, onContinue, onSkip, upgradeUrl } ) {
 	const choices = [
 		{
@@ -158,6 +169,20 @@ function Step1( { selection, onSelect, onContinue, onSkip, upgradeUrl } ) {
 
 // ── Step 2 ────────────────────────────────────────────────────────────────────
 
+/**
+ * Second onboarding step — select text and image AI providers and enter API keys.
+ *
+ * Supports inline key validation via the /test-key REST endpoint. The image
+ * provider section is optional and collapsible. A separate key input is only
+ * shown when the chosen image provider differs from the text provider.
+ *
+ * @param {Object}   props
+ * @param {Function} props.onBack     Called when the user navigates back to step 1.
+ * @param {Function} props.onFinish   Called with `{ provider, apiKeys, imageProvider }` on completion.
+ * @param {string}   props.nonce      WordPress REST nonce for authenticated requests.
+ * @param {string}   props.restUrl    Base URL for the plugin's REST API.
+ * @return {ReactElement}
+ */
 function Step2( { onBack, onFinish, nonce, restUrl } ) {
 	const [ selectedProvider, setSelectedProvider ] = useState( null );
 	const [ apiKeys, setApiKeys ] = useState( {} );
@@ -521,6 +546,14 @@ function Step2( { onBack, onFinish, nonce, restUrl } ) {
 
 // ── Done screen ───────────────────────────────────────────────────────────────
 
+/**
+ * Final onboarding screen confirming that setup is complete.
+ *
+ * @param {Object} props
+ * @param {string} props.apiTierLabel  Human-readable label describing the chosen API tier.
+ * @param {Object} props.urls          URL map with at least a `chat` key for the CTA link.
+ * @return {ReactElement}
+ */
 function DoneScreen( { apiTierLabel, urls } ) {
 	return (
 		<>
@@ -570,6 +603,19 @@ function DoneScreen( { apiTierLabel, urls } ) {
 
 // ── Root page ─────────────────────────────────────────────────────────────────
 
+/**
+ * Multi-step onboarding wizard rendered in place of the dashboard on first visit.
+ *
+ * Manages a three-state machine: `step1` → `step2` (own-key path only) → `done`.
+ * Each transition persists progress to the /onboarding REST endpoint so the
+ * wizard does not re-appear after completion.
+ *
+ * @param {Object} props
+ * @param {string} props.nonce    WordPress REST nonce for authenticated requests.
+ * @param {string} props.restUrl  Base URL for the plugin's REST API.
+ * @param {Object} props.urls     URL map passed through to child steps (e.g. `upgrade`, `chat`).
+ * @return {ReactElement}
+ */
 export default function OnboardingPage( { nonce, restUrl, urls } ) {
 	const [ step, setStep ] = useState( 'step1' ); // 'step1' | 'step2' | 'done'
 	const [ connection, setConnection ] = useState( 'plugin' ); // 'plugin' | 'own_key' | 'pro'

--- a/src/admin/dashboard/PageFooter.jsx
+++ b/src/admin/dashboard/PageFooter.jsx
@@ -1,3 +1,11 @@
+/**
+ * Footer navigation bar at the bottom of the dashboard page.
+ *
+ * @param {Object} props
+ * @param {Object} props.urls         URL map with at least a `settings` key.
+ * @param {string} props.runSetupUrl  URL that re-triggers the onboarding wizard.
+ * @return {ReactElement}
+ */
 export default function PageFooter( { urls, runSetupUrl } ) {
 	return (
 		<div className="wpaim-dash-footer">

--- a/src/admin/dashboard/ResourceList.jsx
+++ b/src/admin/dashboard/ResourceList.jsx
@@ -21,6 +21,17 @@ const RESOURCES = [
 	},
 ];
 
+/**
+ * List of external documentation and resource links shown on the dashboard.
+ *
+ * The changelog entry uses `version` to build a dynamic description when
+ * the static `desc` field is null.
+ *
+ * @param {Object} props
+ * @param {Object} props.resourceUrls  URL map keyed by resource `urlKey` values.
+ * @param {string} props.version       Current plugin version string (e.g. `'1.2.0'`).
+ * @return {ReactElement}
+ */
 export default function ResourceList( { resourceUrls, version } ) {
 	return (
 		<div>

--- a/src/admin/dashboard/StartTiles.jsx
+++ b/src/admin/dashboard/StartTiles.jsx
@@ -25,6 +25,13 @@ const TILES = [
 	},
 ];
 
+/**
+ * Grid of quick-start action tiles on the dashboard.
+ *
+ * @param {Object} props
+ * @param {Object} props.urls  URL map keyed by tile `urlKey` values (e.g. `generator`, `chat`).
+ * @return {ReactElement}
+ */
 export default function StartTiles( { urls } ) {
 	return (
 		<div>

--- a/src/admin/dashboard/StatusBanner.jsx
+++ b/src/admin/dashboard/StatusBanner.jsx
@@ -1,3 +1,15 @@
+/**
+ * Contextual status banner shown at the top of the dashboard.
+ *
+ * Renders nothing when `bannerState` is `'none'`. Shows a warning when the
+ * site is on the free Plugin API, or an error when the stored API key is
+ * invalid. Each state surfaces the appropriate CTA links.
+ *
+ * @param {Object} props
+ * @param {string} props.bannerState  Current banner variant: `'none'`, `'free_tier'`, or `'invalid_key'`.
+ * @param {Object} props.urls         URL map with at least `settings` and `upgrade` keys.
+ * @return {ReactElement|null}
+ */
 export default function StatusBanner( { bannerState, urls } ) {
 	if ( bannerState === 'none' ) {
 		return null;

--- a/src/admin/settings/FeaturesTab.jsx
+++ b/src/admin/settings/FeaturesTab.jsx
@@ -54,6 +54,18 @@ const MODULES = [
 	},
 ];
 
+/**
+ * Settings tab for toggling AI modules and configuring post-type access.
+ *
+ * Pro-locked modules render as disabled cards; toggling them is a no-op
+ * so no Pro-gate error needs to be surfaced separately. Post-type changes
+ * and the write-tools toggle are persisted immediately on change.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.settings      Full settings object from the REST API.
+ * @param {Function} props.saveSettings  Persists a partial settings patch via POST.
+ * @return {ReactElement}
+ */
 export default function FeaturesTab( { settings, saveSettings } ) {
 	const enabledModules = settings?.enabled_modules ?? [];
 	const isPro = settings?.is_pro ?? false;

--- a/src/admin/settings/ProvidersTab.jsx
+++ b/src/admin/settings/ProvidersTab.jsx
@@ -20,6 +20,19 @@ const IMAGE_PROVIDER_OPTIONS = [
 	{ value: 'gemini', label: 'Google Gemini' },
 ];
 
+/**
+ * Settings tab for configuring AI providers, API keys, and the Ollama endpoint.
+ *
+ * API keys are stored per-provider in a dirty-state map and only persisted
+ * when the user explicitly clicks Save, preventing accidental overwrites.
+ * Pro feature gates (model_selection, own_api_key) are read from wpAiMindData.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.settings      Full settings object from the REST API.
+ * @param {Function} props.saveSettings  Persists a partial settings patch via POST.
+ * @param {boolean}  props.isSaving      True while a save request is in flight.
+ * @return {ReactElement}
+ */
 export default function ProvidersTab( { settings, saveSettings, isSaving } ) {
 	const features = window.wpAiMindData?.features ?? {};
 	const upgradeUrl =

--- a/src/admin/settings/SettingsApp.jsx
+++ b/src/admin/settings/SettingsApp.jsx
@@ -12,6 +12,15 @@ const TABS = [
 	{ name: 'features', title: 'Features' },
 ];
 
+/**
+ * Root settings application with tabbed navigation (Providers, Voice, Features).
+ *
+ * Loads settings from the REST API on mount and passes a saveSettings function
+ * down to each tab, which applies a partial patch to the settings state and
+ * persists it via POST.
+ *
+ * @return {ReactElement}
+ */
 export default function SettingsApp() {
 	const [ settings, setSettings ] = useState( null );
 	const [ isSaving, setIsSaving ] = useState( false );

--- a/src/admin/settings/VoiceTab.jsx
+++ b/src/admin/settings/VoiceTab.jsx
@@ -4,6 +4,19 @@ import { Mic } from 'lucide-react';
 
 const MAX_CHARS = 2000;
 
+/**
+ * Settings tab for defining the site-wide AI writing voice and persona.
+ *
+ * Tracks local dirty state so the textarea is responsive while the REST
+ * save is in flight. Enforces a 2 000-character hard limit and shows a
+ * live character counter that turns red when exceeded.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.settings      Full settings object from the REST API.
+ * @param {Function} props.saveSettings  Persists a partial settings patch via POST.
+ * @param {boolean}  props.isSaving      True while a save request is in flight.
+ * @return {ReactElement}
+ */
 export default function VoiceTab( { settings, saveSettings, isSaving } ) {
 	const [ value, setValue ] = useState( settings?.site_voice ?? '' );
 	const [ isDirty, setIsDirty ] = useState( false );

--- a/src/editor/components/BlockActions.jsx
+++ b/src/editor/components/BlockActions.jsx
@@ -23,6 +23,18 @@ const ACTIONS = [
 	},
 ];
 
+/**
+ * AI action buttons (rewrite, shorten, elaborate) for the currently selected block.
+ *
+ * Reads the selected block's text content from `core/block-editor` and sends it
+ * to the AI via the messages REST endpoint. A new conversation is created lazily
+ * on the first action if `convId` is not provided.
+ *
+ * @param {Object}        props
+ * @param {number|null}   props.convId    Existing conversation ID to append to, or null to create one.
+ * @param {Function}      props.onResult  Called with `(content, clientId)` after a successful AI response.
+ * @return {ReactElement}
+ */
 export default function BlockActions( { convId, onResult } ) {
 	const selectedBlock = useSelect( ( select ) =>
 		select( 'core/block-editor' ).getSelectedBlock()

--- a/src/editor/components/EditorSidebar.jsx
+++ b/src/editor/components/EditorSidebar.jsx
@@ -9,6 +9,15 @@ import SeoPanel from './SeoPanel';
 import '../../styles/tokens.css';
 import '../editor.css';
 
+/**
+ * Block Editor plugin sidebar containing the mini chat, block actions, and SEO panels.
+ *
+ * Registered via `registerPlugin` so it appears in the editor's plugin sidebar
+ * list. Block content updates are dispatched through `core/block-editor` rather
+ * than returned to the component to avoid a React re-render cycle.
+ *
+ * @return {ReactElement}
+ */
 function WpAiMindSidebar() {
 	const postId = useSelect( ( select ) =>
 		select( 'core/editor' ).getCurrentPostId()

--- a/src/editor/components/MiniChat.jsx
+++ b/src/editor/components/MiniChat.jsx
@@ -3,6 +3,18 @@ import { Send, Loader2 } from 'lucide-react';
 import apiFetch from '@wordpress/api-fetch';
 import MarkdownContent from '../../shared/MarkdownContent';
 
+/**
+ * Compact chat interface embedded in the Block Editor plugin sidebar.
+ *
+ * Creates a conversation lazily on the first message, associating it with the
+ * current post via `post_id`. The conversation ID is kept in local state so
+ * subsequent messages append to the same thread without a second POST to
+ * /conversations.
+ *
+ * @param {Object}      props
+ * @param {number|null} props.postId  Current post ID from `core/editor`, passed to the conversation endpoint.
+ * @return {ReactElement}
+ */
 export default function MiniChat( { postId } ) {
 	const [ messages, setMessages ] = useState( [] );
 	const [ input, setInput ] = useState( '' );

--- a/src/editor/components/SeoPanel.jsx
+++ b/src/editor/components/SeoPanel.jsx
@@ -42,6 +42,15 @@ function scoreItem( label, pass, tip ) {
 	);
 }
 
+/**
+ * Live SEO checklist panel in the Block Editor sidebar (Pro only).
+ *
+ * Reads title, content, and excerpt live from `core/editor` state so scores
+ * update as the user types without requiring a save. Renders a locked
+ * placeholder for free-tier users.
+ *
+ * @return {ReactElement}
+ */
 export default function SeoPanel() {
 	const { title, content, excerpt } = useSelect( ( select ) => {
 		const editor = select( 'core/editor' );

--- a/src/frontend/FrontendWidget.jsx
+++ b/src/frontend/FrontendWidget.jsx
@@ -5,6 +5,15 @@ import MarkdownContent from '../shared/MarkdownContent';
 
 const { currentPostId, siteTitle } = window.wpAiMindData || {};
 
+/**
+ * Floating chat widget rendered on the public-facing site via a shortcode.
+ *
+ * Toggled open/closed with a fixed-position button. Conversations are created
+ * lazily on the first message and associated with the current post ID when
+ * available. Network errors show an inline error bubble rather than crashing.
+ *
+ * @return {ReactElement}
+ */
 export default function FrontendWidget() {
 	const [ open, setOpen ] = useState( false );
 	const [ messages, setMessages ] = useState( [] );

--- a/src/generator/components/GeneratorWizard.jsx
+++ b/src/generator/components/GeneratorWizard.jsx
@@ -16,6 +16,15 @@ const LENGTHS = [
 	{ value: 'long', label: 'Long (1200–1800 words)' },
 ];
 
+/**
+ * Multi-step wizard for AI-assisted full post generation.
+ *
+ * Manages a three-state machine: step 1 (brief form) → step 2 (generating
+ * spinner) → step 3 (success screen with preview). On success, the generated
+ * post already exists in WordPress and the user is given a direct edit link.
+ *
+ * @return {ReactElement}
+ */
 export default function GeneratorWizard() {
 	const [ step, setStep ] = useState( 1 ); // 1=brief, 2=generating, 3=done
 	const [ form, setForm ] = useState( {

--- a/src/images/ImagesApp.jsx
+++ b/src/images/ImagesApp.jsx
@@ -23,6 +23,15 @@ const IMAGES_COLUMNS = [
 	},
 ];
 
+/**
+ * Root page component for the AI Images admin screen (Pro only).
+ *
+ * Shows a Pro-gate placeholder for free-tier users. Pro users see a
+ * PostListTable filtered by featured-image presence, with ImagesWorkArea
+ * as the expanded row work area.
+ *
+ * @return {ReactElement}
+ */
 export default function ImagesApp() {
 	if ( ! isPro ) {
 		return (

--- a/src/images/ImagesBadge.jsx
+++ b/src/images/ImagesBadge.jsx
@@ -1,3 +1,13 @@
+/**
+ * Status badge showing whether a post has a featured image.
+ *
+ * Reads the thumbnail URL from the embedded `wp:featuredmedia` data,
+ * so the parent must request `_embed` in the REST query.
+ *
+ * @param {Object} props
+ * @param {Object} props.post  WordPress post object with `featured_media` and `_embedded` set.
+ * @return {ReactElement}
+ */
 export default function ImagesBadge( { post } ) {
 	const media = post._embedded?.[ 'wp:featuredmedia' ]?.[ 0 ];
 	const thumbUrl =

--- a/src/images/ImagesWorkArea.jsx
+++ b/src/images/ImagesWorkArea.jsx
@@ -7,6 +7,20 @@ const { nonce, restUrl, adminUrl = '/wp-admin/' } = window.wpAiMindData ?? {};
 
 const ASPECT_RATIOS = [ '16:9', '1:1', '4:3', '9:16' ];
 
+/**
+ * Expanded work area for generating and setting a featured image on a post.
+ *
+ * Sends a generation request to the /images/generate endpoint and renders a
+ * selectable grid of results. On confirmation, sets the chosen image as the
+ * post's featured media via the post's own REST self-link so the correct
+ * post-type endpoint is used regardless of post type.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.post      WordPress post object with `_links.self` populated.
+ * @param {Function} props.onClose   Called when the work area should be dismissed.
+ * @param {Function} props.onUpdate  Called with a partial post patch after the featured image is set.
+ * @return {ReactElement}
+ */
 export default function ImagesWorkArea( { post, onClose, onUpdate } ) {
 	const [ prompt, setPrompt ] = useState( '' );
 	const [ aspectRatio, setAspectRatio ] = useState( '16:9' );

--- a/src/seo/SeoApp.jsx
+++ b/src/seo/SeoApp.jsx
@@ -32,6 +32,15 @@ const SEO_COLUMNS = [
 	},
 ];
 
+/**
+ * Root page component for the AI SEO admin screen (Pro only).
+ *
+ * Shows a Pro-gate placeholder for free-tier users. Pro users see a
+ * PostListTable filtered by SEO completion status, with SeoWorkArea
+ * as the expanded row work area.
+ *
+ * @return {ReactElement}
+ */
 export default function SeoApp() {
 	if ( ! isPro ) {
 		return (

--- a/src/seo/SeoBadge.jsx
+++ b/src/seo/SeoBadge.jsx
@@ -4,6 +4,12 @@ const STATUS_LABELS = {
 	missing: 'Missing',
 };
 
+/**
+ * Derive a post's SEO completion status from its SEO metadata.
+ *
+ * @param {Object} post WordPress post object with `wpaim_seo_status` field.
+ * @return {string} One of `'complete'`, `'partial'`, or `'missing'`.
+ */
 export function getSeoStatus( post ) {
 	const s = post.wpaim_seo_status;
 	if ( ! s ) {
@@ -20,6 +26,13 @@ export function getSeoStatus( post ) {
 	return 'partial';
 }
 
+/**
+ * Colour-coded badge indicating a post's SEO completion status.
+ *
+ * @param {Object} props
+ * @param {string} props.status  One of `'complete'`, `'partial'`, or `'missing'`.
+ * @return {ReactElement}
+ */
 export default function SeoBadge( { status } ) {
 	return (
 		<span className={ `wpaim-badge wpaim-badge--${ status }` }>

--- a/src/seo/SeoWorkArea.jsx
+++ b/src/seo/SeoWorkArea.jsx
@@ -12,6 +12,20 @@ const EMPTY_FIELDS = {
 	alt_text: '',
 };
 
+/**
+ * Expanded work area for generating and applying SEO metadata to a post.
+ *
+ * Generates meta title, OG description, excerpt, and alt text in one request.
+ * A re-generate guard (`confirmReplace`) prevents accidental overwrites of
+ * already-generated fields. On apply, the work area closes and the parent
+ * table row is patched with updated `wpaim_seo_status` values.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.post      WordPress post object; must include `wpaim_seo_status`.
+ * @param {Function} props.onClose   Called when the work area should be dismissed.
+ * @param {Function} props.onUpdate  Called with a partial post patch after SEO fields are applied.
+ * @return {ReactElement}
+ */
 export default function SeoWorkArea( { post, onClose, onUpdate } ) {
 	const [ fields, setFields ] = useState( EMPTY_FIELDS );
 	const [ hasGenerated, setHasGenerated ] = useState( false );

--- a/src/shared/MarkdownContent.jsx
+++ b/src/shared/MarkdownContent.jsx
@@ -4,6 +4,20 @@ import DOMPurify from 'dompurify';
 
 marked.setOptions( { breaks: true, gfm: true } );
 
+/**
+ * Renders a Markdown string as sanitised HTML.
+ *
+ * Parsing is memoised on `content` to avoid re-running marked + DOMPurify
+ * on every parent re-render.
+ *
+ * @param {Object} props
+ * @param {string} props.content   Raw Markdown string to render.
+ * @param {string} [props.className] Optional CSS class applied to the wrapper div.
+ * @return {ReactElement}
+ *
+ * @example
+ * <MarkdownContent content={ message.content } className="wpaim-bubble__markdown" />
+ */
 export default function MarkdownContent( { content, className } ) {
 	const html = useMemo(
 		() => DOMPurify.sanitize( marked.parse( content || '' ) ),

--- a/src/shared/PostListTable.jsx
+++ b/src/shared/PostListTable.jsx
@@ -5,6 +5,23 @@ import DOMPurify from 'dompurify';
 
 const PER_PAGE = 20;
 
+/**
+ * Shared data table with tab filtering, search, and pagination.
+ *
+ * Fetches all published posts and pages on mount (all pages, not just the
+ * first REST page) and merges them into a single sorted list. Consumer
+ * provides tab definitions, an expandable work area component, and optional
+ * extra column definitions.
+ *
+ * @param {Object}   props
+ * @param {Array}    props.tabs      Tab definitions: `[{ id, label, filter }]` where `filter` is a predicate on a post object.
+ * @param {Function} props.WorkArea  Component rendered in the expanded work-area row; receives `{ post, onClose, onUpdate }`.
+ * @param {Array}    [props.columns] Optional extra column definitions: `[{ label, render, width? }]`.
+ * @return {ReactElement}
+ *
+ * @example
+ * <PostListTable tabs={ SEO_TABS } WorkArea={ SeoWorkArea } columns={ SEO_COLUMNS } />
+ */
 export default function PostListTable( { tabs, WorkArea, columns = [] } ) {
 	const [ posts, setPosts ] = useState( [] );
 	const [ loading, setLoading ] = useState( true );
@@ -211,6 +228,19 @@ export default function PostListTable( { tabs, WorkArea, columns = [] } ) {
 	);
 }
 
+/**
+ * Single row in the post list table, with an optional expandable work area.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.post      WordPress post object from the REST API.
+ * @param {Array}    props.columns   Extra column definitions: `[{ label, render }]`.
+ * @param {boolean}  props.expanded  Whether the work-area row is currently open.
+ * @param {Function} props.onExpand  Called when the expand/collapse button is clicked.
+ * @param {Function} props.onClose   Called to close the work-area row without expanding another.
+ * @param {Function} props.onUpdate  Called with partial post fields after an in-row update.
+ * @param {Function} props.WorkArea  Component to render in the expanded row.
+ * @return {ReactElement}
+ */
 function PostRow( {
 	post,
 	columns,

--- a/src/usage/components/UsageDashboard.jsx
+++ b/src/usage/components/UsageDashboard.jsx
@@ -2,6 +2,15 @@ import { useState, useEffect } from '@wordpress/element';
 import { BarChart2, Zap, Loader2 } from 'lucide-react';
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * Admin page showing token/request usage stats fetched from the REST API.
+ *
+ * Displays used, remaining, and monthly limit counts with a proportional
+ * progress bar. When no limit applies (unlimited tier), the bar is hidden
+ * and remaining shows ∞. The bar turns red when the limit is exhausted.
+ *
+ * @return {ReactElement}
+ */
 export default function UsageDashboard() {
 	const [ data, setData ] = useState( null );
 	const [ isLoading, setIsLoading ] = useState( true );

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Runs when the plugin is deleted via the WordPress admin to remove all plugin data.
+ *
+ * @package WP_AI_Mind
+ */
+
 declare( strict_types=1 );
 
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {

--- a/wp-ai-mind.php
+++ b/wp-ai-mind.php
@@ -11,6 +11,8 @@
  * License:           GPL-2.0-or-later
  * Text Domain:       wp-ai-mind
  * Domain Path:       /languages
+ *
+ * @package WP_AI_Mind
  */
 
 declare( strict_types=1 );
@@ -27,7 +29,7 @@ define( 'WP_AI_MIND_FILE', __FILE__ );
 define( 'WP_AI_MIND_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WP_AI_MIND_URL', plugin_dir_url( __FILE__ ) );
 define( 'WP_AI_MIND_BASENAME', plugin_basename( __FILE__ ) );
-define( 'WP_AI_MIND_HTTP_TIMEOUT', 60 ); // seconds — LLM calls can be slow
+define( 'WP_AI_MIND_HTTP_TIMEOUT', 60 ); // Seconds — LLM calls can be slow.
 
 // Custom PSR-4 autoloader — retained as a safety net for environments where
 // the Composer vendor directory is absent (e.g. a manual plugin upload without


### PR DESCRIPTION
## Summary

- **PHP**: Added complete PHPDoc coverage to all 50 PHP files — file-level docblocks, class docblocks, and `@since`/`@param`/`@return`/`@throws` on every public and private method. Member properties documented with multi-line `@var` blocks. Fixed all `WrongStyle` file comments (replaced `// filename.php` breadcrumbs with proper `/** ... */` docblocks). Fixed `InvalidEndChar`, `ThrowsNotCapital`, and `EmptyThrows` violations.
- **JS**: Added `@param`/`@return` JSDoc to all 33 JSX component and helper files. Changed `@returns` → `@return` to match ESLint preference. Added missing JSDoc to exported helpers (e.g. `getSeoStatus`).
- **Tooling**: Added `WordPress-Docs` ruleset to `phpcs.xml.dist`. Added `eslint-plugin-jsdoc` with `plugin:jsdoc/recommended-error` to `.eslintrc.js`, configured for public-only enforcement with appropriate rule relaxations (`no-undefined-types`, `reject-function-type`, `check-param-names` disabled).

Both linters now pass with zero errors:
- `./vendor/bin/phpcs --standard=phpcs.xml.dist` → 0 errors (2 pre-existing `error_log` warnings in SeoModule)
- `npm run lint:js` → 0 errors

Closes #260

## Test plan

- [ ] Run `./vendor/bin/phpcs --standard=phpcs.xml.dist` — expect 0 errors
- [ ] Run `npm run lint:js` — expect 0 errors
- [ ] Smoke-test plugin in WordPress admin — chat, settings, dashboard pages all load without PHP errors
- [ ] Verify CI passes (lint + unit tests)

https://claude.ai/code/session_01AiAaP33Umn4zofe8eA2zcb

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiAaP33Umn4zofe8eA2zcb)_