### PR TITLE
fix(tiers): prevent infinite loop in maybe_demote_expired_trials()

### DIFF
--- a/includes/Tiers/NJ_Tier_Manager.php
+++ b/includes/Tiers/NJ_Tier_Manager.php
@@ -123,15 +123,18 @@ class NJ_Tier_Manager {
 	 * Intended to be called by a daily WP-Cron event. Processes users in batches
 	 * to avoid memory exhaustion on sites with large user tables.
 	 *
+	 * The loop uses no offset because each demotion removes the user from the
+	 * 'trial' result set, so the next query always fetches from the new front.
+	 * The `$demoted > 0` guard prevents an infinite loop when a full batch
+	 * contains only active (non-expired) trial users — without it the query
+	 * would return the same 200 users indefinitely.
+	 *
 	 * @since 1.2.0
 	 * @return void
 	 */
 	public static function maybe_demote_expired_trials(): void {
 		$batch_size = 200;
 
-		// No offset — each demotion removes the user from the 'trial' result set,
-		// so the next query always fetches from the new front of the list.
-		// An advancing offset would skip users as the set shrinks mid-loop.
 		do {
 			$users = get_users(
 				[
@@ -141,12 +144,14 @@ class NJ_Tier_Manager {
 					'number'     => $batch_size,
 				]
 			);
-			$found = count( $users );
+			$found   = count( $users );
+			$demoted = 0;
 			foreach ( $users as $user_id ) {
 				if ( ! self::is_trial_active( (int) $user_id ) ) {
 					self::set_user_tier( 'free', (int) $user_id );
+					++$demoted;
 				}
 			}
-		} while ( $found === $batch_size );
+		} while ( $found === $batch_size && $demoted > 0 );
 	}
 }

--- a/includes/Tiers/NJ_Tier_Manager.php
+++ b/includes/Tiers/NJ_Tier_Manager.php
@@ -148,8 +148,9 @@ class NJ_Tier_Manager {
 			$demoted = 0;
 			foreach ( $users as $user_id ) {
 				if ( ! self::is_trial_active( (int) $user_id ) ) {
-					self::set_user_tier( 'free', (int) $user_id );
-					++$demoted;
+					if ( self::set_user_tier( 'free', (int) $user_id ) ) {
+						++$demoted;
+					}
 				}
 			}
 		} while ( $found === $batch_size && $demoted > 0 );

--- a/tests/Unit/Tiers/NJTierManagerTest.php
+++ b/tests/Unit/Tiers/NJTierManagerTest.php
@@ -159,6 +159,62 @@ class NJTierManagerTest extends TestCase {
 		$this->assertTrue( NJ_Tier_Manager::is_trial_active( 6 ) );
 	}
 
+	public function test_maybe_demote_expired_trials_exits_when_no_demotions_in_full_batch(): void {
+		// 200 trial users, all still active — loop must exit after one pass (no progress).
+		$user_ids   = range( 1, 200 );
+		$started_at = (string) time(); // all trials started now, so none are expired
+
+		Functions\expect( 'get_users' )
+			->once()
+			->andReturn( $user_ids );
+
+		// is_trial_active() calls get_user_meta twice per user: once for tier, once for trial_started.
+		Functions\expect( 'get_user_meta' )
+			->times( 400 )
+			->andReturnUsing(
+				function ( $uid, $key ) use ( $started_at ) {
+					if ( 'wp_ai_mind_tier' === $key ) {
+						return 'trial';
+					}
+					return $started_at;
+				}
+			);
+
+		// set_user_tier / update_user_meta must NOT be called — no users are demoted.
+		Functions\expect( 'update_user_meta' )->never();
+
+		NJ_Tier_Manager::maybe_demote_expired_trials();
+		$this->addToAssertionCount( 1 ); // loop exited without infinite loop
+	}
+
+	public function test_maybe_demote_expired_trials_demotes_expired_users_and_continues(): void {
+		$expired_start = time() - ( 31 * DAY_IN_SECONDS );
+
+		// First batch: 200 expired users → all demoted → second batch: fewer than 200.
+		Functions\expect( 'get_users' )
+			->twice()
+			->andReturn( range( 1, 200 ), range( 201, 210 ) );
+
+		// Tier meta for is_trial_active(): all are 'trial'.
+		Functions\expect( 'get_user_meta' )
+			->andReturnUsing(
+				function ( $uid, $key ) use ( $expired_start ) {
+					if ( 'wp_ai_mind_tier' === $key ) {
+						return 'trial';
+					}
+					return (string) $expired_start;
+				}
+			);
+
+		// update_user_meta called once per user (set_user_tier stores 'free').
+		Functions\expect( 'update_user_meta' )
+			->times( 210 )
+			->andReturn( true );
+
+		NJ_Tier_Manager::maybe_demote_expired_trials();
+		$this->addToAssertionCount( 1 );
+	}
+
 	public function test_tier_config_has_four_tiers(): void {
 		$this->assertContains( 'free', NJ_Tier_Config::get_valid_tiers() );
 		$this->assertContains( 'trial', NJ_Tier_Config::get_valid_tiers() );

--- a/tests/Unit/Tiers/NJTierManagerTest.php
+++ b/tests/Unit/Tiers/NJTierManagerTest.php
@@ -7,6 +7,11 @@ use PHPUnit\Framework\TestCase;
 use WP_AI_Mind\Tiers\NJ_Tier_Config;
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 
+/**
+ * Unit tests for NJ_Tier_Manager.
+ *
+ * @since 1.1.0
+ */
 class NJTierManagerTest extends TestCase {
 
 	protected function setUp(): void {
@@ -159,6 +164,11 @@ class NJTierManagerTest extends TestCase {
 		$this->assertTrue( NJ_Tier_Manager::is_trial_active( 6 ) );
 	}
 
+	/**
+	 * Verifies that the loop exits after one pass when a full batch yields zero successful demotions.
+	 *
+	 * @since 1.1.0
+	 */
 	public function test_maybe_demote_expired_trials_exits_when_no_demotions_in_full_batch(): void {
 		// 200 trial users, all still active — loop must exit after one pass (no progress).
 		$user_ids   = range( 1, 200 );
@@ -187,6 +197,11 @@ class NJTierManagerTest extends TestCase {
 		$this->addToAssertionCount( 1 ); // loop exited without infinite loop
 	}
 
+	/**
+	 * Verifies that all expired-trial users are demoted across multiple batches and the loop terminates.
+	 *
+	 * @since 1.1.0
+	 */
 	public function test_maybe_demote_expired_trials_demotes_expired_users_and_continues(): void {
 		$expired_start = time() - ( 31 * DAY_IN_SECONDS );
 

--- a/tests/Unit/Tiers/NJTierManagerTest.php
+++ b/tests/Unit/Tiers/NJTierManagerTest.php
@@ -215,6 +215,47 @@ class NJTierManagerTest extends TestCase {
 		$this->addToAssertionCount( 1 );
 	}
 
+	/**
+	 * Verifies that the loop continues when a full batch contains a mix of expired and active
+	 * trials, and terminates once a subsequent batch is smaller than the batch size.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_maybe_demote_expired_trials_continues_while_partial_batch_demoted(): void {
+		$expired_start = time() - ( 31 * DAY_IN_SECONDS );
+		$active_start  = (string) time();
+
+		// First batch: 200 users — 100 expired, 100 active.
+		// Second batch: fewer than 200 users → loop terminates.
+		Functions\expect( 'get_users' )
+			->twice()
+			->andReturn( range( 1, 200 ), range( 201, 210 ) );
+
+		// Users 1–100 are expired; 101–200 are active.
+		// Second batch (201–210) are all expired.
+		Functions\expect( 'get_user_meta' )
+			->andReturnUsing(
+				function ( $uid, $key ) use ( $expired_start, $active_start ) {
+					if ( 'wp_ai_mind_tier' === $key ) {
+						return 'trial';
+					}
+					// Users 101–200 are still within their trial window.
+					if ( $uid >= 101 && $uid <= 200 ) {
+						return $active_start;
+					}
+					return (string) $expired_start;
+				}
+			);
+
+		// update_user_meta called once per expired user: 100 from batch 1 + 10 from batch 2.
+		Functions\expect( 'update_user_meta' )
+			->times( 110 )
+			->andReturn( true );
+
+		NJ_Tier_Manager::maybe_demote_expired_trials();
+		$this->addToAssertionCount( 1 ); // loop terminated without infinite loop
+	}
+
 	public function test_tier_config_has_four_tiers(): void {
 		$this->assertContains( 'free', NJ_Tier_Config::get_valid_tiers() );
 		$this->assertContains( 'trial', NJ_Tier_Config::get_valid_tiers() );


### PR DESCRIPTION
## Summary

- Fixes an infinite loop in `NJ_Tier_Manager::maybe_demote_expired_trials()` that occurs when ≥ 200 trial users are all still in active (non-expired) trials
- Adds a `$demoted` counter; the `while` condition now requires `$demoted > 0` so the loop exits when a full batch makes no progress
- Adds two unit tests covering the no-demotion-in-full-batch scenario and the multi-batch demoting scenario

## Root cause

The original loop exited only when `$found < $batch_size`. This assumption held only if at least one user was demoted per batch (removing them from the result set). With ≥ 200 active trial users and zero expired ones, `$found` was always 200 and the cron job looped forever until PHP timed out.

## Test plan

- [x] `./vendor/bin/phpunit tests/Unit/Tiers/NJTierManagerTest.php` — 22/22 passing
- [x] Verify new test `test_maybe_demote_expired_trials_exits_when_no_demotions_in_full_batch` fails on the old code and passes on the fix

Closes #323

https://claude.ai/code/session_01V4jcabpcqFKsADReUBUgLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4jcabpcqFKsADReUBUgLJ)_