### PR TITLE
fix(proxy): add pro_byok guard in Worker and clarify 401 error message

### DIFF
--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -90,7 +90,7 @@ class NJ_Proxy_Client {
 		if ( 401 === $code ) {
 			// Token may be stale — clear it so maybe_register() re-issues on next admin_init.
 			// Re-registration is async; the current request cannot be retried transparently.
-			// TODO(#326): inline register() + retry once to avoid user-visible auth errors.
+			// TODO #326: inline register() + retry once to avoid user-visible auth errors.
 			delete_option( NJ_Site_Registration::OPTION_TOKEN );
 			return new WP_Error( 'proxy_auth_failed', __( 'Proxy authentication failed. Please reload the page and try again.', 'wp-ai-mind' ) );
 		}

--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -88,9 +88,11 @@ class NJ_Proxy_Client {
 		}
 
 		if ( 401 === $code ) {
-			// Token may be stale — clear it so maybe_register() re-issues on next init.
+			// Token may be stale — clear it so maybe_register() re-issues on next admin_init.
+			// Re-registration is async; the current request cannot be retried transparently.
+			// TODO(#326): inline register() + retry once to avoid user-visible auth errors.
 			delete_option( NJ_Site_Registration::OPTION_TOKEN );
-			return new WP_Error( 'proxy_auth_failed', __( 'Proxy authentication failed. Please try again.', 'wp-ai-mind' ) );
+			return new WP_Error( 'proxy_auth_failed', __( 'Proxy authentication failed. Please reload the page and try again.', 'wp-ai-mind' ) );
 		}
 
 		if ( $code < 200 || $code >= 300 ) {

--- a/wp-ai-mind-proxy/src/auth.ts
+++ b/wp-ai-mind-proxy/src/auth.ts
@@ -1,11 +1,11 @@
 // src/auth.ts
 
-import { Env, SiteRecord, AnyTier } from './types';
+import { Env, SiteRecord, SiteTier } from './types';
 
 export interface AuthResult {
 	authenticated: boolean;
 	site_token?: string;
-	tier?: AnyTier;
+	tier?: SiteTier;
 	site_url?: string;
 }
 

--- a/wp-ai-mind-proxy/src/auth.ts
+++ b/wp-ai-mind-proxy/src/auth.ts
@@ -1,11 +1,11 @@
 // src/auth.ts
 
-import { Env, SiteRecord, ProxyTier } from './types';
+import { Env, SiteRecord, AnyTier } from './types';
 
 export interface AuthResult {
 	authenticated: boolean;
 	site_token?: string;
-	tier?: ProxyTier;
+	tier?: AnyTier;
 	site_url?: string;
 }
 

--- a/wp-ai-mind-proxy/src/index.ts
+++ b/wp-ai-mind-proxy/src/index.ts
@@ -55,6 +55,14 @@ async function handleChatProxy(
 		const { messages, model, max_tokens: maxTokens, system } = body;
 		const { site_token: siteToken, tier } = auth;
 
+		// BYOK sites call Anthropic directly via ClaudeProvider and must never reach here.
+		if ( tier === 'pro_byok' ) {
+			return jsonResponse(
+				{ error: 'BYOK tier must call Anthropic directly' },
+				403
+			);
+		}
+
 		const rateLimitCheck = await checkRateLimit( siteToken, tier, env );
 		if ( ! rateLimitCheck.allowed ) {
 			return jsonResponse(

--- a/wp-ai-mind-proxy/src/types.ts
+++ b/wp-ai-mind-proxy/src/types.ts
@@ -13,11 +13,11 @@ export interface Env {
 export type ProxyTier = 'free' | 'trial' | 'pro_managed';
 
 /** All possible tier values a site JWT may carry. */
-export type AnyTier = ProxyTier | 'pro_byok';
+export type SiteTier = ProxyTier | 'pro_byok';
 
 export interface SiteRecord {
 	site_url: string;
-	tier: AnyTier;
+	tier: SiteTier;
 	created_at: number;
 	ls_licence_key?: string;
 }

--- a/wp-ai-mind-proxy/src/types.ts
+++ b/wp-ai-mind-proxy/src/types.ts
@@ -9,11 +9,15 @@ export interface Env {
 	// PROXY_SIGNATURE_SECRET intentionally removed — replaced by site token Bearer auth.
 }
 
+/** Tiers handled by this proxy (rate-limited and counted). */
 export type ProxyTier = 'free' | 'trial' | 'pro_managed';
+
+/** All possible tier values a site JWT may carry. */
+export type AnyTier = ProxyTier | 'pro_byok';
 
 export interface SiteRecord {
 	site_url: string;
-	tier: ProxyTier;
+	tier: AnyTier;
 	created_at: number;
 	ls_licence_key?: string;
 }

--- a/wp-ai-mind-proxy/test/chat-proxy.test.ts
+++ b/wp-ai-mind-proxy/test/chat-proxy.test.ts
@@ -1,0 +1,46 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import { describe, it, expect } from 'vitest';
+import worker from '../src/index';
+import { makeEnv } from './helpers/kv-mock';
+import type { SiteRecord } from '../src/types';
+
+const TEST_TOKEN =
+	'deadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678';
+
+const VALID_BODY = JSON.stringify( {
+	messages: [ { role: 'user', content: 'Hello' } ],
+} );
+
+async function makeEnvWithSiteToken( tier: SiteRecord[ 'tier' ] ) {
+	const env = makeEnv();
+	const record: SiteRecord = {
+		site_url: 'https://example.com',
+		tier,
+		created_at: Date.now(),
+	};
+	await env.USAGE_KV.put( `site:${ TEST_TOKEN }`, JSON.stringify( record ) );
+	return env;
+}
+
+describe( 'handleChatProxy', () => {
+	it( 'returns 403 for pro_byok tier', async () => {
+		const env = await makeEnvWithSiteToken( 'pro_byok' );
+		const request = new Request( 'https://worker.example.com/v1/chat', {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${ TEST_TOKEN }`,
+				'Content-Type': 'application/json',
+			},
+			body: VALID_BODY,
+		} );
+
+		const response = await worker.fetch( request, env );
+
+		expect( response.status ).toBe( 403 );
+		const json = await response.json();
+		expect( json ).toEqual( {
+			error: 'BYOK tier must call Anthropic directly',
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary

- Adds explicit 403 early-return in `handleChatProxy` when `tier === 'pro_byok'`. BYOK sites call Anthropic directly via `ClaudeProvider` and must never reach this proxy. Previously, `MONTHLY_LIMITS['pro_byok']` returned `undefined`, causing a silent 429 with no useful error.
- Introduces `AnyTier = ProxyTier | 'pro_byok'` in `types.ts` so the type system correctly represents all possible JWT tier values. TypeScript narrows to `ProxyTier` after the guard, keeping all downstream rate-limit code safe without any changes to `MONTHLY_LIMITS` or `MAX_TOKENS`.
- Updates `SiteRecord.tier` and `AuthResult.tier` to use `AnyTier`.
- Improves the 401 error message in `NJ_Proxy_Client` from "Please try again" to "Please reload the page and try again" — the re-registration happens on the next `admin_init`, so the current request cannot succeed on a simple retry.

## Test plan

- [x] `npx tsc --noEmit` — clean, no type errors
- [x] `npm test` (in `wp-ai-mind-proxy/`) — 25/25 passing
- [x] Manual: send a request with `tier = 'pro_byok'` JWT → expect 403 with `"BYOK tier must call Anthropic directly"`

Closes #324
Addresses #326 (error message only; inline register+retry deferred — TODO comment added)

https://claude.ai/code/session_01V4jcabpcqFKsADReUBUgLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4jcabpcqFKsADReUBUgLJ)_