### PR TITLE
docs(agents): add @example requirement for shared/reusable React components

### DIFF
--- a/.claude/agents/wordpress-coder.md
+++ b/.claude/agents/wordpress-coder.md
@@ -152,7 +152,7 @@ If any match is found inside HTML content (not inside a `<!-- wp:... -->` commen
 - Sanitize ALL input: `sanitize_text_field()`, `absint()`
 - Follow WordPress PHP Coding Standards
 - Write PHPDoc for ALL public PHP methods and classes (see documentation standards in `CLAUDE.md`)
-- Write JSDoc for ALL exported React components (see documentation standards in `CLAUDE.md`)
+- Write JSDoc for ALL exported React components (`@param` per prop, `@returns`; shared/reusable components also require `@example` — see documentation standards in `CLAUDE.md`)
 - Add inline "why" comments only where the reason is non-obvious — never describe what the code does
 - Use proper WordPress hooks and filters
 - Ensure accessibility compliance

--- a/.claude/agents/wordpress-standards-validator.md
+++ b/.claude/agents/wordpress-standards-validator.md
@@ -88,7 +88,7 @@ This is a SEPARATE checklist from styling. Block validation errors are caused by
 - **Security:** Uses proper sanitisation, validation, and nonce verification
 - **Performance:** Efficient database queries, proper caching, per-block CSS loading
 - **Accessibility:** WCAG compliance and WordPress accessibility standards
-- **Maintainability:** Code is readable; all public PHP methods and classes have PHPDoc blocks (`@since`, `@param`, `@return`); all exported React components have JSDoc. Inline comments explain "why", not "what".
+- **Maintainability:** Code is readable; all public PHP methods and classes have PHPDoc blocks (`@since`, `@param`, `@return`); all exported React components have JSDoc (`@param` per prop, `@returns`; shared/reusable components also require `@example`). Inline comments explain "why", not "what".
 - **WordPress Way:** Uses WordPress APIs instead of custom solutions when possible
 - **Backwards Compatibility:** Considers WordPress version requirements
 - **Scalability:** Solution can handle growth without major refactoring


### PR DESCRIPTION
## Summary

- Extends the `wordpress-standards-validator` Maintainability criterion to state that shared/reusable React components also require a JSDoc `@example` block (fixes #265)
- Extends the JSDoc bullet in `wordpress-coder` to include the same `@example` requirement inline (fixes #267)

## Test plan

- [ ] Read `.claude/agents/wordpress-standards-validator.md` line ~91: confirm `shared/reusable components also require @example` appears in the Maintainability criterion
- [ ] Read `.claude/agents/wordpress-coder.md` line ~155: confirm JSDoc bullet reads `@param per prop, @returns; shared/reusable components also require @example`
- [ ] No code files changed — no runtime tests needed

https://claude.ai/code/session_01V4jcabpcqFKsADReUBUgLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4jcabpcqFKsADReUBUgLJ)_