### PR TITLE
ci(release): automate WordPress.org SVN deploy and consolidate build script

### DIFF
--- a/.github/workflows/wporg-deploy.yml
+++ b/.github/workflows/wporg-deploy.yml
@@ -24,6 +24,9 @@ on:
         description: 'Release tag to deploy (e.g. v1.3.3)'
         required: true
 
+permissions:
+  contents: read  # needed to download release assets via gh CLI
+
 jobs:
   deploy:
     name: Deploy to WordPress.org SVN

--- a/.github/workflows/wporg-deploy.yml
+++ b/.github/workflows/wporg-deploy.yml
@@ -1,0 +1,83 @@
+name: WordPress.org Deploy
+
+# Fires when semantic-release publishes a stable (non-pre-release) GitHub Release.
+# Pre-release tags (v1.0.0-beta.1) are skipped automatically via the job condition.
+#
+# Prerequisites before this workflow can succeed:
+#   1. Plugin must be approved and have an SVN repo on WordPress.org.
+#   2. Add repository secrets:
+#      - WPORG_USERNAME  — your WordPress.org committer username
+#      - WPORG_PASSWORD  — your WordPress.org application password
+#        (generate at https://profiles.wordpress.org/<username>/profile/applications/)
+#
+# The workflow downloads the release ZIP built by release.yml, extracts it, then
+# uses 10up/action-wordpress-org-deploy to push to /trunk and create /tags/<version>.
+# See https://github.com/10up/action-wordpress-org-deploy for input reference.
+
+on:
+  release:
+    types: [released]
+  # Allow manual trigger for testing against an existing release tag.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to deploy (e.g. v1.3.3)'
+        required: true
+
+jobs:
+  deploy:
+    name: Deploy to WordPress.org SVN
+    runs-on: ubuntu-latest
+    # Skip pre-release tags (betas, RCs). On workflow_dispatch we always proceed.
+    if: "github.event_name == 'workflow_dispatch' || !github.event.release.prerelease"
+
+    steps:
+      - name: Resolve tag and version
+        id: vars
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=$TAG"     >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download release ZIP
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.vars.outputs.tag }}"
+          VERSION="${{ steps.vars.outputs.version }}"
+          # semantic-release uploads the asset after publishing the release, so
+          # the asset may not be available immediately — retry for up to 5 minutes.
+          for attempt in $(seq 1 10); do
+            if gh release download "$TAG" \
+                 --repo "${{ github.repository }}" \
+                 --pattern "wp-ai-mind-${VERSION}.zip" \
+                 --output plugin.zip 2>/dev/null; then
+              echo "Downloaded wp-ai-mind-${VERSION}.zip"
+              break
+            fi
+            if [[ $attempt -eq 10 ]]; then
+              echo "::error::Release asset wp-ai-mind-${VERSION}.zip not available after 5 minutes"
+              exit 1
+            fi
+            echo "Asset not ready, retrying in 30 s (attempt ${attempt}/10)..."
+            sleep 30
+          done
+
+      - name: Extract ZIP
+        run: |
+          unzip -q plugin.zip
+          echo "Plugin directory contents:"
+          ls wp-ai-mind/
+
+      - name: Deploy to WordPress.org
+        uses: 10up/action-wordpress-org-deploy@v1
+        with:
+          plugin-slug: wp-ai-mind
+          build-dir: ./wp-ai-mind
+          wordpress-username: ${{ secrets.WPORG_USERNAME }}
+          wordpress-password: ${{ secrets.WPORG_PASSWORD }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -24,7 +24,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "sed -i 's/ \\* Version:.*/ * Version:           ${nextRelease.version}/' wp-ai-mind.php && sed -i \"s/define( 'WP_AI_MIND_VERSION', '[^']*' )/define( 'WP_AI_MIND_VERSION', '${nextRelease.version}' )/\" wp-ai-mind.php && sed -i 's/^Stable tag:.*/Stable tag: ${nextRelease.version}/' readme.txt && mkdir -p dist && REPO_DIR=$(pwd) && PLUGIN_TMP=$(mktemp -d) && mkdir -p \"$PLUGIN_TMP/wp-ai-mind\" && cp wp-ai-mind.php uninstall.php readme.txt \"$PLUGIN_TMP/wp-ai-mind/\" && cp -r assets includes languages vendor \"$PLUGIN_TMP/wp-ai-mind/\" && (cd \"$PLUGIN_TMP\" && zip -r \"$REPO_DIR/dist/wp-ai-mind-${nextRelease.version}.zip\" wp-ai-mind/) && rm -rf \"$PLUGIN_TMP\""
+        "prepareCmd": "sed -i 's/ \\* Version:.*/ * Version:           ${nextRelease.version}/' wp-ai-mind.php && sed -i \"s/define( 'WP_AI_MIND_VERSION', '[^']*' )/define( 'WP_AI_MIND_VERSION', '${nextRelease.version}' )/\" wp-ai-mind.php && sed -i 's/^Stable tag:.*/Stable tag: ${nextRelease.version}/' readme.txt && ./bin/build-wporg.sh --version ${nextRelease.version} --skip-build"
       }
     ],
     [

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -77,11 +77,32 @@ Semantic-release will cut a patch release automatically on merge.
 
 ## WP.org SVN submission
 
-Stable releases (non-pre-release) still require a manual SVN push to WordPress.org.
-Download the zip from the GitHub Release and submit via SVN as usual.
+Stable release deployment to WordPress.org is automated via `wporg-deploy.yml`.
+It fires automatically on every stable (non-pre-release) GitHub Release.
 
 Pre-release tags (`v0.3.0-beta.1`) publish a GitHub Release marked as pre-release
-and are not submitted to WP.org.
+and are **not** deployed to WordPress.org.
+
+### First-time setup
+
+The plugin must be approved on WordPress.org before automated deployment can work.
+Initial submission is manual: upload the ZIP from the GitHub Release via
+https://wordpress.org/plugins/developers/add/
+
+Once approved, add these two repository secrets (Settings → Secrets → Actions):
+
+| Secret | Value |
+|---|---|
+| `WPORG_USERNAME` | Your WordPress.org committer username |
+| `WPORG_PASSWORD` | A WordPress.org application password (generate at `profiles.wordpress.org/<user>/profile/applications/`) |
+
+After the secrets are configured, every subsequent stable release is deployed
+automatically — no manual SVN steps needed.
+
+### Manual deploy / testing
+
+You can trigger a deployment manually via the Actions tab:
+select **WordPress.org Deploy** → **Run workflow** → supply the release tag (e.g. `v1.3.3`).
 
 ---
 
@@ -91,6 +112,7 @@ and are not submitted to WP.org.
 |---|---|---|
 | `ci.yml` | PR to `main` | PHPCS, PHPUnit, JS lint, commitlint |
 | `release.yml` | Push to `main` | Full semantic-release pipeline |
+| `wporg-deploy.yml` | Stable release published | Deploy ZIP to WordPress.org SVN |
 | `claude-code-review.yml` | PR opened/updated | Automated code review |
 | `auto-fix-ci.yml` | CI failure | Auto-fix lint issues |
 | `auto-fix-review-issue.yml` | Issue labelled | Auto-fix code review issues |

--- a/bin/build-wporg.sh
+++ b/bin/build-wporg.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 # bin/build-wporg.sh — produce a WP.org-ready zip of the plugin.
-# Usage: ./bin/build-wporg.sh [--version 1.2.3]
+# Usage: ./bin/build-wporg.sh [--version 1.2.3] [--skip-build]
+#   --skip-build  Skip npm and composer steps (use when CI has already run them).
 set -euo pipefail
 
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PLUGIN_SLUG="wp-ai-mind"
-VERSION="${1:-}"
+VERSION=""
+SKIP_BUILD=false
 
-# Parse --version flag
 while [[ $# -gt 0 ]]; do
     case $1 in
         --version) VERSION="$2"; shift 2 ;;
+        --skip-build) SKIP_BUILD=true; shift ;;
         *) shift ;;
     esac
 done
@@ -30,13 +32,13 @@ echo "Building ${PLUGIN_SLUG} v${VERSION}..."
 rm -rf "${DIST_DIR}"
 mkdir -p "${BUILD_DIR}"
 
-# Run JS build
-echo "Running npm build..."
-cd "${PLUGIN_DIR}" && npm run build
+if [[ "$SKIP_BUILD" == "false" ]]; then
+    echo "Running npm build..."
+    cd "${PLUGIN_DIR}" && npm run build
 
-# Install production PHP dependencies
-echo "Installing PHP dependencies..."
-cd "${PLUGIN_DIR}" && composer install --no-dev --optimize-autoloader --no-interaction
+    echo "Installing PHP dependencies..."
+    cd "${PLUGIN_DIR}" && composer install --no-dev --optimize-autoloader --no-interaction
+fi
 
 # Copy only production files (allowlist — safe by default, new dev tooling never leaks in)
 rsync -a \


### PR DESCRIPTION
## Summary

- **Consolidates the build pipeline**: replaces the duplicate inline ZIP-building shell block in `.releaserc.json` with a call to `bin/build-wporg.sh --skip-build`, so CI and local builds use the same code path. Also fixes the silent omission of `CHANGELOG.md` from release ZIPs.
- **Adds `--skip-build` flag** to `bin/build-wporg.sh` so it can be called from semantic-release without redundantly re-running `npm run build` and `composer install`.
- **Automates WordPress.org SVN deployment** via a new `.github/workflows/wporg-deploy.yml` workflow that fires on every stable (non-pre-release) GitHub Release, downloads the release ZIP, and pushes to WordPress.org SVN using `10up/action-wordpress-org-deploy`. Includes a `workflow_dispatch` trigger for manual testing.
- **Updates `RELEASING.md`** to document the automated WP.org deploy flow, first-time secret setup, and manual trigger option.

## Why not the proposed restructuring?

An earlier proposal suggested moving plugin code into a `/plugin/` subdirectory. That was rejected because:
1. The build pipeline already produces a clean ZIP via an allowlist rsync — dev files never leak into production.
2. Moving files would break PHP `require_once` paths, Composer PSR-4 mappings, webpack entry points, CI workflows, and the semantic-release config — all for zero functional benefit.

## Test plan

- [ ] Verify `bin/build-wporg.sh` runs locally without `--skip-build` and produces a correct ZIP including `CHANGELOG.md`
- [ ] Confirm CI passes on this PR (PHPCS, PHPUnit, JS lint, commitlint)
- [ ] After merging a future `feat(...)` or `fix(...)` PR, confirm `release.yml` succeeds and the GitHub Release ZIP contains `CHANGELOG.md`
- [ ] Once `WPORG_USERNAME` and `WPORG_PASSWORD` secrets are configured (after initial WP.org submission), use the manual `workflow_dispatch` trigger on `wporg-deploy.yml` to validate SVN deployment

https://claude.ai/code/session_019pJYbLDyExL4XCv9eDY8ty

---
_Generated by [Claude Code](https://claude.ai/code/session_019pJYbLDyExL4XCv9eDY8ty)_