### PR TITLE
docs(tests): add phpdoc blocks, update @since, prune refs on delete, add unit tests

### DIFF
--- a/includes/DB/ConversationStore.php
+++ b/includes/DB/ConversationStore.php
@@ -143,6 +143,7 @@ class ConversationStore {
 	 * Update the title of an existing conversation.
 	 *
 	 * @since 1.0.0
+	 * @since 1.3.4 Return type changed from void to bool.
 	 * @param int    $conversation_id The conversation record ID.
 	 * @param string $title           New title text; sanitised before storage.
 	 * @return bool True on success, false if the DB update failed.

--- a/src/admin/components/Chat/ChatApp.jsx
+++ b/src/admin/components/Chat/ChatApp.jsx
@@ -117,10 +117,12 @@ export default function ChatApp() {
 				path: `/wp-ai-mind/v1/conversations/${ convId }`,
 				method: 'DELETE',
 			} );
+			titlePatchedConvsRef.current.delete( convId );
 			removeConversationFromState( convId );
 		} catch ( e ) {
 			if ( e?.data?.status === 404 ) {
 				// Already gone on the server — remove from list.
+				titlePatchedConvsRef.current.delete( convId );
 				removeConversationFromState( convId );
 			} else {
 				// eslint-disable-next-line no-console

--- a/tests/Unit/DB/ConversationStoreTest.php
+++ b/tests/Unit/DB/ConversationStoreTest.php
@@ -8,12 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Minimal wpdb stub that supports insert() and update().
+ *
+ * @package WP_AI_Mind\Tests
  */
 class FakeWpdb {
     public string $prefix    = 'wp_';
     public int    $insert_id = 0;
 
-    public function insert( string $table, array $data, array $format = [] ): int {
+    public function insert( string $table, array $data, array $format = [] ): int|false {
         return 1;
     }
 

--- a/tests/Unit/DB/ConversationStoreTest.php
+++ b/tests/Unit/DB/ConversationStoreTest.php
@@ -7,13 +7,17 @@ use WP_AI_Mind\DB\ConversationStore;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Minimal wpdb stub that supports insert().
+ * Minimal wpdb stub that supports insert() and update().
  */
 class FakeWpdb {
     public string $prefix    = 'wp_';
     public int    $insert_id = 0;
 
     public function insert( string $table, array $data, array $format = [] ): int {
+        return 1;
+    }
+
+    public function update( string $table, array $data, array $where, array $formats = [], array $where_formats = [] ): int|false {
         return 1;
     }
 }
@@ -49,5 +53,37 @@ class ConversationStoreTest extends TestCase {
         $store = new ConversationStore();
         $id    = $store->add_message( 42, 'user', 'Hello', 'gpt-4o', 10 );
         $this->assertSame( 99, $id );
+    }
+
+    /**
+     * @covers \WP_AI_Mind\DB\ConversationStore::update_title
+     */
+    public function test_update_title_returns_true_on_success(): void {
+        global $wpdb;
+        $wpdb = new FakeWpdb();
+
+        Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+
+        $store  = new ConversationStore();
+        $result = $store->update_title( 1, 'New title' );
+        $this->assertTrue( $result );
+    }
+
+    /**
+     * @covers \WP_AI_Mind\DB\ConversationStore::update_title
+     */
+    public function test_update_title_returns_false_when_wpdb_update_fails(): void {
+        global $wpdb;
+        $wpdb = new class extends FakeWpdb {
+            public function update( string $table, array $data, array $where, array $formats = [], array $where_formats = [] ): int|false {
+                return false;
+            }
+        };
+
+        Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+
+        $store  = new ConversationStore();
+        $result = $store->update_title( 1, 'New title' );
+        $this->assertFalse( $result );
     }
 }

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -384,6 +384,9 @@ class ChatRestControllerTest extends TestCase {
 
     // ── Permission check ───────────────────────────────────────────────────────
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::check_permission
+     */
     public function test_permission_check_returns_true_for_editors(): void {
         Functions\when( 'current_user_can' )->justReturn( true );
         $controller = new ChatRestController( $this->tool_registry, $this->tool_executor );
@@ -392,6 +395,9 @@ class ChatRestControllerTest extends TestCase {
         $this->assertTrue( $result );
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::check_permission
+     */
     public function test_permission_check_fails_for_non_editors(): void {
         Functions\when( 'current_user_can' )->justReturn( false );
         Functions\when( '__' )->alias( fn( $s ) => $s );
@@ -401,6 +407,9 @@ class ChatRestControllerTest extends TestCase {
         $this->assertInstanceOf( \WP_Error::class, $result );
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::check_permission
+     */
     public function test_permission_check_error_has_403_status(): void {
         Functions\when( 'current_user_can' )->justReturn( false );
         Functions\when( '__' )->alias( fn( $s ) => $s );
@@ -526,6 +535,9 @@ class ChatRestControllerTest extends TestCase {
         $this->assertSame( 'Final answer', $response->data['content'] );
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::send_message
+     */
     public function test_send_message_returns_429_with_retry_after_header_on_rate_limit(): void {
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
         Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );
@@ -565,6 +577,9 @@ class ChatRestControllerTest extends TestCase {
         $this->assertGreaterThanOrEqual( 0, (int) $headers['Retry-After'], 'Retry-After must be a non-negative number of seconds.' );
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::send_message
+     */
     public function test_send_message_maps_provider_403_to_502(): void {
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
         Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -51,6 +51,9 @@ class ChatRestControllerTest extends TestCase {
         };
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::update_conversation
+     */
     public function test_update_conversation_returns_404_when_not_found(): void {
         Functions\when( '__' )->alias( fn( $s ) => $s );
 
@@ -69,6 +72,9 @@ class ChatRestControllerTest extends TestCase {
         $this->assertSame( 404, $response->get_error_data()['status'] );
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::update_conversation
+     */
     public function test_update_conversation_returns_403_when_not_owned(): void {
         Functions\when( '__' )->alias( fn( $s ) => $s );
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
@@ -88,6 +94,9 @@ class ChatRestControllerTest extends TestCase {
         $this->assertSame( 403, $response->get_error_data()['status'] );
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::update_conversation
+     */
     public function test_update_conversation_happy_path_calls_update_title_and_returns_updated(): void {
         Functions\when( 'get_current_user_id' )->justReturn( 5 );
         Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
@@ -112,6 +121,9 @@ class ChatRestControllerTest extends TestCase {
         $this->assertSame( [ 'updated' => true ], $response->data );
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::update_conversation
+     */
     public function test_update_conversation_sanitises_html_in_title(): void {
         Functions\when( 'get_current_user_id' )->justReturn( 3 );
         Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => strip_tags( $v ) );
@@ -133,6 +145,9 @@ class ChatRestControllerTest extends TestCase {
         $this->assertInstanceOf( \WP_REST_Response::class, $response );
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::update_conversation
+     */
     public function test_update_conversation_returns_500_when_db_update_fails(): void {
         Functions\when( '__' )->alias( fn( $s ) => $s );
         Functions\when( 'get_current_user_id' )->justReturn( 5 );
@@ -156,6 +171,9 @@ class ChatRestControllerTest extends TestCase {
 
     // ── list_conversations ────────────────────────────────────────────────────
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::list_conversations
+     */
     public function test_list_conversations_returns_only_expected_keys(): void {
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
 
@@ -202,6 +220,9 @@ class ChatRestControllerTest extends TestCase {
         $this->assertArrayNotHasKey( 'post_id', $item, 'post_id must not be exposed in the response.' );
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::list_conversations
+     */
     public function test_list_conversations_casts_id_to_int(): void {
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
 
@@ -231,6 +252,9 @@ class ChatRestControllerTest extends TestCase {
         $this->assertSame( 99, $response->data[0]['id'], 'id must be cast to int, not returned as a string.' );
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::list_conversations
+     */
     public function test_list_conversations_returns_empty_array_when_no_conversations(): void {
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
 
@@ -262,6 +286,9 @@ class ChatRestControllerTest extends TestCase {
 
     // ── create_conversation ───────────────────────────────────────────────────
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::create_conversation
+     */
     public function test_create_conversation_returns_201_with_conversation_data(): void {
         $store_mock = $this->createMock( \WP_AI_Mind\DB\ConversationStore::class );
         $store_mock->method( 'create' )->willReturn( 7 );
@@ -296,6 +323,9 @@ class ChatRestControllerTest extends TestCase {
         $this->assertArrayHasKey( 'updated_at', $response->data );
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::create_conversation
+     */
     public function test_create_conversation_returns_500_when_db_insert_fails(): void {
         Functions\when( '__' )->alias( fn( $s ) => $s );
 
@@ -329,6 +359,9 @@ class ChatRestControllerTest extends TestCase {
         $this->assertArrayHasKey( 'message', $response->data );
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::create_conversation
+     */
     public function test_create_conversation_returns_500_when_get_conversation_returns_null(): void {
         Functions\when( '__' )->alias( fn( $s ) => $s );
 
@@ -364,6 +397,9 @@ class ChatRestControllerTest extends TestCase {
 
     // ── Route registration ─────────────────────────────────────────────────────
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::register_routes
+     */
     public function test_register_routes_registers_expected_endpoints(): void {
         $registered = [];
         Functions\when( 'register_rest_route' )->alias(
@@ -422,6 +458,9 @@ class ChatRestControllerTest extends TestCase {
 
     // ── Ownership guard ────────────────────────────────────────────────────────
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::send_message
+     */
     public function test_send_message_returns_403_when_conversation_not_owned(): void {
         // Arrange: conversation belongs to user 999, but current user is 1.
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
@@ -460,6 +499,9 @@ class ChatRestControllerTest extends TestCase {
 
     // ── Tool loop ──────────────────────────────────────────────────────────────
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::send_message
+     */
     public function test_send_message_tool_loop_executes_tool_and_returns_final(): void {
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
         Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );
@@ -616,6 +658,9 @@ class ChatRestControllerTest extends TestCase {
         $this->assertSame( 502, $response->get_status(), 'Provider 403 must be masked as 502.' );
     }
 
+    /**
+     * @covers \WP_AI_Mind\Modules\Chat\ChatRestController::send_message
+     */
     public function test_send_message_returns_500_after_max_iterations(): void {
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
         Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );


### PR DESCRIPTION
## Summary

- **#353 nit 2** — Add `@covers` PHPDoc blocks to five public test methods in `ChatRestControllerTest` that were missing them.
- **#369 nit 1** — Add secondary `@since 1.3.4` note to `ConversationStore::update_title()` documenting the `void` → `bool` return-type change.
- **#369 nit 2** — Prune `titlePatchedConvsRef.current` when a conversation is deleted (both the 200 and 404-already-gone branches) to prevent unbounded `Set` growth.
- **#368** — Add `FakeWpdb::update()` stub and two new unit tests for `ConversationStore::update_title()` covering the success path and the `$wpdb->update()` failure path. The REST-controller error path (`update_conversation` → 500) was already tested; this adds the direct store-level coverage the issue asked for.

No logic changes — documentation, dead-code cleanup, and tests only.

## Test plan

- [x] `./vendor/bin/phpunit tests/Unit/ --colors=always` — 220 tests, 455 assertions, all pass (including the 2 new `ConversationStore` tests).

Closes #353, #369, #368

https://claude.ai/code/session_015CAfMhkjcXBZowSF2WenBA

---
_Generated by [Claude Code](https://claude.ai/code/session_015CAfMhkjcXBZowSF2WenBA)_