### PR TITLE
fix(proxy): inline re-register and retry on 401 to avoid user-visible auth errors

### DIFF
--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -95,12 +95,13 @@ class NJ_Proxy_Client {
 
 		if ( 401 === $code ) {
 			// Token is stale — re-register inline and retry the request once.
+			// On success, $code and $body are re-assigned; subsequent checks apply to the retry response.
 			delete_option( NJ_Site_Registration::OPTION_TOKEN );
 			$new_token = NJ_Site_Registration::register();
 			if ( is_wp_error( $new_token ) ) {
 				return new WP_Error( 'proxy_auth_failed', __( 'Proxy authentication failed. Please reload the page and try again.', 'wp-ai-mind' ) );
 			}
-			$retry = wp_remote_post(
+			$retry_response = wp_remote_post(
 				NJ_Tier_Config::get_proxy_url() . '/v1/chat',
 				[
 					'headers' => [
@@ -111,10 +112,10 @@ class NJ_Proxy_Client {
 					'timeout' => 60,
 				]
 			);
-			if ( is_wp_error( $retry ) ) {
-				return $retry;
+			if ( is_wp_error( $retry_response ) ) {
+				return $retry_response;
 			}
-			[ 'code' => $code, 'body' => $body ] = self::parse_response( $retry );
+			[ 'code' => $code, 'body' => $body ] = self::parse_response( $retry_response );
 			if ( 429 === $code ) {
 				return new WP_Error( 'rate_limit_exceeded', __( 'Monthly usage limit reached.', 'wp-ai-mind' ) );
 			}
@@ -135,6 +136,9 @@ class NJ_Proxy_Client {
 
 	/**
 	 * Extract HTTP status code and decoded JSON body from a wp_remote_post() response.
+	 *
+	 * Native return type is bare `array` because PHP does not support typed array shapes;
+	 * the precise shape is documented in the @return tag for static-analysis tools (PHPStan).
 	 *
 	 * @since 1.3.6
 	 * @param array<string, mixed> $raw Raw response array from wp_remote_post().

--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -115,6 +115,9 @@ class NJ_Proxy_Client {
 				return $retry;
 			}
 			[ 'code' => $code, 'body' => $body ] = self::parse_response( $retry );
+			if ( 429 === $code ) {
+				return new WP_Error( 'rate_limit_exceeded', __( 'Monthly usage limit reached.', 'wp-ai-mind' ) );
+			}
 		}
 
 		if ( $code < 200 || $code >= 300 ) {

--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -30,6 +30,11 @@ class NJ_Proxy_Client {
 	/**
 	 * Send a chat request through the Cloudflare proxy.
 	 *
+	 * On an HTTP 401 response the stored site token is deleted and the site is
+	 * re-registered inline; the request is then retried once with the new token.
+	 * If re-registration itself fails, the auth error is returned to the caller.
+	 *
+	 * @since 1.2.0
 	 * @param array<array{role: string, content: string}> $messages Chat message history.
 	 * @param array<string, mixed>                        $options  Supports 'model', 'max_tokens', 'system'.
 	 * @return array<string, mixed>|WP_Error
@@ -82,19 +87,34 @@ class NJ_Proxy_Client {
 			return $response;
 		}
 
-		$code = (int) wp_remote_retrieve_response_code( $response );
-		$body = json_decode( wp_remote_retrieve_body( $response ), true ) ?? [];
+		[ 'code' => $code, 'body' => $body ] = self::parse_response( $response );
 
 		if ( 429 === $code ) {
 			return new WP_Error( 'rate_limit_exceeded', __( 'Monthly usage limit reached.', 'wp-ai-mind' ) );
 		}
 
 		if ( 401 === $code ) {
-			// Token may be stale — clear it so maybe_register() re-issues on next admin_init.
-			// Re-registration is async; the current request cannot be retried transparently.
-			// TODO #326: inline register() + retry once to avoid user-visible auth errors.
+			// Token is stale — re-register inline and retry the request once.
 			delete_option( NJ_Site_Registration::OPTION_TOKEN );
-			return new WP_Error( 'proxy_auth_failed', __( 'Proxy authentication failed. Please reload the page and try again.', 'wp-ai-mind' ) );
+			$new_token = NJ_Site_Registration::register();
+			if ( is_wp_error( $new_token ) ) {
+				return new WP_Error( 'proxy_auth_failed', __( 'Proxy authentication failed. Please reload the page and try again.', 'wp-ai-mind' ) );
+			}
+			$retry = wp_remote_post(
+				NJ_Tier_Config::get_proxy_url() . '/v1/chat',
+				[
+					'headers' => [
+						'Content-Type'  => 'application/json',
+						'Authorization' => 'Bearer ' . $new_token,
+					],
+					'body'    => $body_json,
+					'timeout' => 60,
+				]
+			);
+			if ( is_wp_error( $retry ) ) {
+				return $retry;
+			}
+			[ 'code' => $code, 'body' => $body ] = self::parse_response( $retry );
 		}
 
 		if ( $code < 200 || $code >= 300 ) {
@@ -108,5 +128,19 @@ class NJ_Proxy_Client {
 		}
 
 		return $body;
+	}
+
+	/**
+	 * Extract HTTP status code and decoded JSON body from a wp_remote_post() response.
+	 *
+	 * @since 1.3.6
+	 * @param array<string, mixed> $raw Raw response array from wp_remote_post().
+	 * @return array{code: int, body: array<string, mixed>}
+	 */
+	private static function parse_response( array $raw ): array {
+		return [
+			'code' => (int) wp_remote_retrieve_response_code( $raw ),
+			'body' => json_decode( wp_remote_retrieve_body( $raw ), true ) ?? [],
+		];
 	}
 }

--- a/tests/Unit/Proxy/NJProxyClientTest.php
+++ b/tests/Unit/Proxy/NJProxyClientTest.php
@@ -57,7 +57,10 @@ class NJProxyClientTest extends TestCase {
 		$this->assertSame( 'rate_limit_exceeded', $result->get_error_code() );
 	}
 
-	public function test_chat_clears_token_and_returns_error_on_401(): void {
+	/**
+	 * @covers \WP_AI_Mind\Proxy\NJ_Proxy_Client::chat
+	 */
+	public function test_chat_clears_token_and_returns_error_on_401_when_reregistration_fails(): void {
 		Functions\expect( 'get_option' )
 			->with( NJ_Site_Registration::OPTION_TOKEN, '' )
 			->andReturn( 'test-token' );
@@ -73,6 +76,8 @@ class NJProxyClientTest extends TestCase {
 		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
 		Functions\when( 'is_wp_error' )->alias( fn( $v ) => $v instanceof \WP_Error );
 		Functions\when( 'wp_remote_post' )->justReturn( [] );
+		Functions\when( 'home_url' )->justReturn( 'https://example.com' );
+		// All response code calls return 401 — registration will also fail with 401.
 		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 401 );
 		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{}' );
 		Functions\expect( 'delete_option' )
@@ -84,6 +89,59 @@ class NJProxyClientTest extends TestCase {
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'proxy_auth_failed', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers \WP_AI_Mind\Proxy\NJ_Proxy_Client::chat
+	 */
+	public function test_chat_reregisters_inline_on_401_and_retries_successfully(): void {
+		Functions\expect( 'get_option' )
+			->with( NJ_Site_Registration::OPTION_TOKEN, '' )
+			->andReturn( 'stale-token' );
+		Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		Functions\when( 'get_user_meta' )->alias(
+			function ( $user_id, $key ) {
+				if ( 'wp_ai_mind_tier' === $key ) {
+					return 'free';
+				}
+				return 0;
+			}
+		);
+		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+		Functions\when( 'is_wp_error' )->alias( fn( $v ) => $v instanceof \WP_Error );
+		Functions\when( 'wp_remote_post' )->justReturn( [] );
+		Functions\when( 'home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+
+		// Sequence: first chat call → 401, register call → 201, retry chat → 200.
+		$codes = [ 401, 201, 200 ];
+		$idx   = 0;
+		Functions\when( 'wp_remote_retrieve_response_code' )->alias(
+			function () use ( &$codes, &$idx ) {
+				return $codes[ $idx++ ] ?? 200;
+			}
+		);
+
+		$success_body = json_encode( [
+			'content' => [ [ 'type' => 'text', 'text' => 'hello' ] ],
+			'usage'   => [ 'input_tokens' => 5, 'output_tokens' => 3 ],
+		] );
+		$bodies = [ '{}', json_encode( [ 'token' => 'new-token' ] ), $success_body ];
+		$bidx   = 0;
+		Functions\when( 'wp_remote_retrieve_body' )->alias(
+			function () use ( &$bodies, &$bidx ) {
+				return $bodies[ $bidx++ ] ?? '{}';
+			}
+		);
+
+		Functions\expect( 'delete_option' )->once()->with( NJ_Site_Registration::OPTION_TOKEN );
+		Functions\expect( 'update_option' )->once()->with( NJ_Site_Registration::OPTION_TOKEN, 'new-token' );
+		Functions\when( '__' )->alias( fn( $s ) => $s );
+
+		$result = NJ_Proxy_Client::chat( [ [ 'role' => 'user', 'content' => 'hi' ] ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'content', $result );
 	}
 
 	public function test_chat_returns_rate_limit_error_on_429(): void {

--- a/tests/Unit/Proxy/NJProxyClientTest.php
+++ b/tests/Unit/Proxy/NJProxyClientTest.php
@@ -144,6 +144,163 @@ class NJProxyClientTest extends TestCase {
 		$this->assertArrayHasKey( 'content', $result );
 	}
 
+	/**
+	 * @covers \WP_AI_Mind\Proxy\NJ_Proxy_Client::chat
+	 */
+	public function test_chat_returns_rate_limit_error_when_retry_returns_429(): void {
+		Functions\expect( 'get_option' )
+			->with( NJ_Site_Registration::OPTION_TOKEN, '' )
+			->andReturn( 'stale-token' );
+		Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		Functions\when( 'get_user_meta' )->alias(
+			function ( $user_id, $key ) {
+				if ( 'wp_ai_mind_tier' === $key ) {
+					return 'free';
+				}
+				return 0;
+			}
+		);
+		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+		Functions\when( 'is_wp_error' )->alias( fn( $v ) => $v instanceof \WP_Error );
+		Functions\when( 'wp_remote_post' )->justReturn( [] );
+		Functions\when( 'home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+
+		// Sequence: initial chat → 401, register → 201, retry chat → 429.
+		$codes = [ 401, 201, 429 ];
+		$idx   = 0;
+		Functions\when( 'wp_remote_retrieve_response_code' )->alias(
+			function () use ( &$codes, &$idx ) {
+				return $codes[ $idx++ ] ?? 200;
+			}
+		);
+
+		$bodies = [ '{}', json_encode( [ 'token' => 'new-token' ] ), '{}' ];
+		$bidx   = 0;
+		Functions\when( 'wp_remote_retrieve_body' )->alias(
+			function () use ( &$bodies, &$bidx ) {
+				return $bodies[ $bidx++ ] ?? '{}';
+			}
+		);
+
+		Functions\expect( 'delete_option' )->once()->with( NJ_Site_Registration::OPTION_TOKEN );
+		Functions\expect( 'update_option' )->once()->with( NJ_Site_Registration::OPTION_TOKEN, 'new-token' );
+		Functions\when( '__' )->alias( fn( $s ) => $s );
+
+		$result = NJ_Proxy_Client::chat( [ [ 'role' => 'user', 'content' => 'hi' ] ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'rate_limit_exceeded', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers \WP_AI_Mind\Proxy\NJ_Proxy_Client::chat
+	 */
+	public function test_chat_returns_proxy_error_when_retry_returns_500(): void {
+		Functions\expect( 'get_option' )
+			->with( NJ_Site_Registration::OPTION_TOKEN, '' )
+			->andReturn( 'stale-token' );
+		Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		Functions\when( 'get_user_meta' )->alias(
+			function ( $user_id, $key ) {
+				if ( 'wp_ai_mind_tier' === $key ) {
+					return 'free';
+				}
+				return 0;
+			}
+		);
+		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+		Functions\when( 'is_wp_error' )->alias( fn( $v ) => $v instanceof \WP_Error );
+		Functions\when( 'wp_remote_post' )->justReturn( [] );
+		Functions\when( 'home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+
+		// Sequence: initial chat → 401, register → 201, retry chat → 500.
+		$codes = [ 401, 201, 500 ];
+		$idx   = 0;
+		Functions\when( 'wp_remote_retrieve_response_code' )->alias(
+			function () use ( &$codes, &$idx ) {
+				return $codes[ $idx++ ] ?? 200;
+			}
+		);
+
+		$bodies = [ '{}', json_encode( [ 'token' => 'new-token' ] ), json_encode( [ 'error' => 'Internal Server Error' ] ) ];
+		$bidx   = 0;
+		Functions\when( 'wp_remote_retrieve_body' )->alias(
+			function () use ( &$bodies, &$bidx ) {
+				return $bodies[ $bidx++ ] ?? '{}';
+			}
+		);
+
+		Functions\expect( 'delete_option' )->once()->with( NJ_Site_Registration::OPTION_TOKEN );
+		Functions\expect( 'update_option' )->once()->with( NJ_Site_Registration::OPTION_TOKEN, 'new-token' );
+		Functions\when( '__' )->alias( fn( $s ) => $s );
+
+		$result = NJ_Proxy_Client::chat( [ [ 'role' => 'user', 'content' => 'hi' ] ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'proxy_error', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers \WP_AI_Mind\Proxy\NJ_Proxy_Client::chat
+	 */
+	public function test_chat_propagates_wp_error_when_retry_network_fails(): void {
+		Functions\expect( 'get_option' )
+			->with( NJ_Site_Registration::OPTION_TOKEN, '' )
+			->andReturn( 'stale-token' );
+		Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		Functions\when( 'get_user_meta' )->alias(
+			function ( $user_id, $key ) {
+				if ( 'wp_ai_mind_tier' === $key ) {
+					return 'free';
+				}
+				return 0;
+			}
+		);
+		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+		Functions\when( 'home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+
+		$network_error = new \WP_Error( 'http_request_failed', 'Connection timed out.' );
+
+		// Sequence: initial chat → 401, register → 201, retry chat → WP_Error.
+		$calls = 0;
+		Functions\when( 'wp_remote_post' )->alias(
+			function () use ( &$calls, $network_error ) {
+				++$calls;
+				// Third wp_remote_post call is the retry; return a network error.
+				return $calls >= 3 ? $network_error : [];
+			}
+		);
+		Functions\when( 'is_wp_error' )->alias( fn( $v ) => $v instanceof \WP_Error );
+
+		$codes = [ 401, 201 ];
+		$idx   = 0;
+		Functions\when( 'wp_remote_retrieve_response_code' )->alias(
+			function () use ( &$codes, &$idx ) {
+				return $codes[ $idx++ ] ?? 200;
+			}
+		);
+
+		$bodies = [ '{}', json_encode( [ 'token' => 'new-token' ] ) ];
+		$bidx   = 0;
+		Functions\when( 'wp_remote_retrieve_body' )->alias(
+			function () use ( &$bodies, &$bidx ) {
+				return $bodies[ $bidx++ ] ?? '{}';
+			}
+		);
+
+		Functions\expect( 'delete_option' )->once()->with( NJ_Site_Registration::OPTION_TOKEN );
+		Functions\expect( 'update_option' )->once()->with( NJ_Site_Registration::OPTION_TOKEN, 'new-token' );
+		Functions\when( '__' )->alias( fn( $s ) => $s );
+
+		$result = NJ_Proxy_Client::chat( [ [ 'role' => 'user', 'content' => 'hi' ] ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'http_request_failed', $result->get_error_code() );
+	}
+
 	public function test_chat_returns_rate_limit_error_on_429(): void {
 		Functions\expect( 'get_option' )
 			->with( NJ_Site_Registration::OPTION_TOKEN, '' )


### PR DESCRIPTION
## Summary

- When the proxy returns HTTP 401 (stale site token), `NJ_Proxy_Client::chat()` previously deleted the token and immediately returned a `proxy_auth_failed` error. Re-registration only fired on the next `admin_init`, so the first request after a stale token always failed with a user-visible error.
- Now: on 401 the client deletes the stale token, calls `NJ_Site_Registration::register()` inline, and — if registration succeeds — retries the original request once with the new token. The user sees a seamless experience rather than an error.
- If re-registration itself fails, the `proxy_auth_failed` error is still returned (same fallback as before).
- Extracts a private `parse_response()` helper to avoid duplicating the HTTP response parsing across the initial request and the retry.

## Test plan

- [x] `./vendor/bin/phpunit tests/Unit/ --colors=always` — 219 tests, all pass.
- [x] Renamed existing 401 test to `test_chat_clears_token_and_returns_error_on_401_when_reregistration_fails` to clarify scope.
- [x] Added `test_chat_reregisters_inline_on_401_and_retries_successfully` covering the happy path (stale token → inline re-register → retry succeeds).
- [ ] Manual: set an invalid token in `wp_options` (`wp_ai_mind_site_token`), send a chat message — should succeed transparently on the first attempt.

Closes #326

https://claude.ai/code/session_015CAfMhkjcXBZowSF2WenBA

---
_Generated by [Claude Code](https://claude.ai/code/session_015CAfMhkjcXBZowSF2WenBA)_