### PR TITLE
chore(ci): tighten review trigger, expand coverage, optimise auto-fix file reads

### DIFF
--- a/.github/workflows/batch-auto-fix.yml
+++ b/.github/workflows/batch-auto-fix.yml
@@ -73,49 +73,60 @@ jobs:
 
             ---
 
-            ## Your task
+            ## Your task — two phases
 
-            Work through each issue number listed above **in order**. For each issue,
-            complete steps A–F fully before moving to the next. This ensures every fixed
-            issue is committed, pushed, and closed even if the session ends early.
+            ### Phase 1 — Read all issue bodies and pre-load affected files
 
-            ### A — Read the issue body
+            For every issue number listed above:
             ```
             cat /tmp/issue-<N>-body.txt
             ```
-            The body contains a `## Context` section with the exact source lines to change —
-            use it to go straight to editing without a separate file-read step.
 
-            ### B — Decide: fix or skip
-            - Fix it if the correct change is clear from the codebase alone.
-            - If it requires an external value (API key, secret, account ID, business decision):
-              post a comment on the issue explaining what information is needed, then continue
-              to the next issue. Do NOT stop — always process every issue in the list.
+            Extract the file path from each issue's `## Context` section and build a map of
+            `file → [issue numbers that touch it]`.
 
-            ### C — Apply the minimal fix
-            Read only the files mentioned in the issue. Make the smallest correct change.
-            If this issue has the `nits` label, apply ALL listed nit items in a single commit.
+            Read each unique file **exactly once** now, using the Read tool, and keep the
+            contents in working memory. Do not re-read a file you have already read.
+            Issues that touch no identifiable file are processed last as a single group.
 
-            ### D — Commit
+            ### Phase 2 — Fix and commit each issue individually
+
+            Work through all issues in file-group order (all issues for file A, then file B,
+            etc.) but commit and close each issue as its own atomic unit:
+
+            **A — Apply the minimal fix for this issue**
+            Use the file content already in memory from Phase 1. Make the smallest correct change.
+            If this issue has the `nits` label, apply ALL listed nit items in a single edit.
+            If the fix requires an external value (API key, secret, account ID, business decision):
+            post a comment on the issue explaining what is needed, then move to the next issue
+            without committing. Do NOT stop — always process every issue in the list.
+
+            **B — Run linting (PHP files only)**
+            ```bash
+            ./vendor/bin/phpcs --standard=phpcs.xml.dist <file>
+            ```
+            Fix any new PHPCS violations before committing.
+
+            **C — Commit this issue's fix**
             ```bash
             git commit -m "fix: <concise description> (closes #<N>)"
             ```
 
-            ### E — Push immediately
-            Push after every individual fix so the commit is not lost if the session ends early:
+            **D — Push immediately**
             ```bash
             git push origin ${{ github.event.client_payload.head_branch }}
             ```
+            Push after every individual commit so progress is never lost if the session ends early.
 
-            ### F — Close the issue immediately after pushing
+            **E — Close the issue**
             ```bash
             gh issue close <N> \
               --comment "✅ Fixed in $(git rev-parse --short HEAD). <One sentence summary.>" \
               --repo ${{ github.repository }}
             ```
 
-            ### G — Move to the next issue
-            Repeat A–F for every issue in the list.
+            **F — Move to the next issue**
+            Repeat A–F for every remaining issue.
 
             ---
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
     paths-ignore:
       - "package-lock.json"
       - "composer.lock"
@@ -65,12 +65,36 @@ jobs:
 
             Review this pull request against the repository's CLAUDE.md conventions. Be constructive and helpful.
 
-            Cover:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            Cover the following areas. Tag each finding with its category (e.g. [DRY], [SRP], [Security]).
+
+            **Correctness & safety**
+            - Potential bugs, edge-cases, or logic errors
+            - Security concerns (input sanitisation, escaping, capability checks, nonces)
+            - Data-loss risks or irreversible side-effects
+
+            **Design principles**
+            - **[DRY]** — duplicated logic or data that should be extracted into a shared function/constant
+            - **[SRP]** — classes or functions doing more than one job; hooks that mix unrelated concerns
+            - **[KISS]** — unnecessary complexity, over-engineering, or abstractions with no current use-case
+            - **[YAGNI]** — speculative code, flags, or extension points added "just in case"
+            - **[Separation of concerns]** — presentation logic leaking into data/business layers (or vice versa)
+            - **[Naming]** — misleading, ambiguous, or overly abbreviated identifiers
+
+            **Code quality**
+            - Dead code, commented-out blocks, or unreachable branches
+            - Deeply nested conditionals or high cyclomatic complexity (suggest early returns)
+            - Magic numbers/strings that should be named constants
+            - Inconsistent style or deviations from project conventions (see CLAUDE.md)
+            - **[Reuse]** — new functions, classes, or logic that duplicate or could extend something that already exists in the codebase (reinventing the wheel, missed extension points)
+
+            **Performance**
+            - Unnecessary database queries inside loops (N+1 patterns)
+            - Missing caching opportunities for expensive operations
+            - Autoloaded options that should be non-autoloaded
+
+            **Test coverage**
+            - Untested public methods or critical branches
+            - Assertions that only test the happy path
 
             ### Step 0 — Ensure required labels exist
 
@@ -142,7 +166,7 @@ jobs:
             Structure the comment as:
             1. **Summary** — 1–3 sentence overview of the PR
             2. **Findings** — grouped by severity (bugs → improvements → nits):
-               - For bugs and improvements: include the issue URL inline, e.g. "See #42 for tracking."
+               - Each finding: `[Category] \`path/to/file.php\` — description (See #N for tracking.)`
                - **For nits:** Provide the **full verbose explanation** of each nit as you normally would.
                  Then, at the end of the nits section, add: "All nits are tracked in #N for auto-fix."
                  This keeps the detailed feedback visible in the PR while also referencing the consolidated issue.


### PR DESCRIPTION
## Summary

- **Trigger fix**: `claude-code-review.yml` now fires on `opened` only (dropped `synchronize`) — prevents duplicate reviews and token waste on every pushed commit
- **Expanded coverage**: replaced the generic 5-item list with DRY/SRP/KISS/YAGNI/Reuse categories; each finding is tagged `[Category]` with a file reference in the PR comment
- **Optimised auto-fix**: `batch-auto-fix.yml` prompt restructured into Phase 1 (read each unique file once, build `file → issues` map) + Phase 2 (fix + commit + push + close per issue) — N issues touching the same file now require 1 file read instead of N

## Test plan

- [ ] Open a new test PR → `claude-code-review` workflow fires exactly once
- [ ] Push a follow-up commit to that PR → workflow does **not** re-fire
- [ ] Inspect the review comment: findings show `[Category] \`file.php\`` format
- [ ] Trigger a batch auto-fix run: confirm the Claude session reads each file only once across all issues touching it, and that each issue gets its own commit + close

https://claude.ai/code/session_011DYXCKP7xrA5PVLaP4U1oq

---
_Generated by [Claude Code](https://claude.ai/code/session_011DYXCKP7xrA5PVLaP4U1oq)_