### PR TITLE
ci(release): auto-reconcile orphaned version tags before semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,34 @@ jobs:
       - name: Build assets
         run: npm run build
 
+      - name: Reconcile orphaned version tags
+        # semantic-release determines the last release by finding the highest
+        # vX.Y.Z tag that is a git ancestor of HEAD. If the branch history ever
+        # diverges from the tagged history (e.g. after a force-push), those tags
+        # become unreachable from HEAD. semantic-release then falls back to an
+        # older tag, re-computes the same next version, and fails when it tries
+        # to create a tag that already exists — AFTER already pushing a release
+        # commit to main. This step detects any such orphaned tags and moves
+        # them to HEAD so semantic-release treats them as already released.
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          moved=""
+          for tag in $(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V); do
+            if ! git merge-base --is-ancestor "$tag" HEAD 2>/dev/null; then
+              echo "Orphaned tag $tag is not on this branch — moving to HEAD"
+              git tag -f "$tag" HEAD
+              git push -f origin "refs/tags/$tag"
+              moved="$moved $tag"
+            fi
+          done
+          if [ -n "$moved" ]; then
+            echo "::warning::Moved orphaned version tags to HEAD:$moved. Branch history likely diverged from tag history."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Release
         run: npx semantic-release
         env:

--- a/src/admin/dashboard/UsageWidget.jsx
+++ b/src/admin/dashboard/UsageWidget.jsx
@@ -50,7 +50,9 @@ export default function UsageWidget( { usage } ) {
 							: ' wpaim-usage-widget__value--limit-reached'
 					}` }
 				>
-					{ hasLimit ? usedPct + '%' : __( 'Unlimited', 'wp-ai-mind' ) }
+					{ hasLimit
+						? usedPct + '%'
+						: __( 'Unlimited', 'wp-ai-mind' ) }
 				</span>
 				{ hasLimit && (
 					<span className="wpaim-usage-widget__sub-label">


### PR DESCRIPTION
## Root cause

When a branch history diverges from the tag history (e.g. after a force-push to `main`), `vX.Y.Z` tags become unreachable from HEAD. `semantic-release` only considers tags that are **ancestors** of the current branch HEAD when determining the last release. When it can't see the correct tags, it:

1. Falls back to an older tag (e.g. `v1.3.6` instead of `v1.4.0`)
2. Correctly computes the next version (e.g. `v1.4.0`)
3. Pushes a `chore(release): 1.4.0 [skip ci]` commit to `main`
4. Tries to create the `v1.4.0` tag — **fails** with `fatal: tag 'v1.4.0' already exists`

This left two orphaned `chore(release): 1.4.0 [skip ci]` commits on `main` (at `5d8f16e` and `4bc10bb`) with no corresponding tag on the branch history, making every subsequent merge to `main` fail the same way.

## Fix

Add a **Reconcile orphaned version tags** step before `npx semantic-release` runs. The step:

- Iterates over all `vX.Y.Z` tags in the repo
- For each tag **not reachable** from `HEAD`, force-moves it to `HEAD` and pushes
- Emits a `::warning::` annotation if any tags were moved (visible in the Actions summary)

After this step runs in the failing state, `semantic-release` sees the moved tags as the last releases and correctly determines there is nothing new to release.

## Behaviour on the current broken state

When this PR is merged, the next non-`[skip ci]` commit pushed to `main` will trigger the release workflow. The reconcile step will:

1. Detect `v1.4.0` (at `d46c8ac`) and `v1.4.1` (at `03aaf33`) as orphaned
2. Move both to the current `HEAD`
3. `semantic-release` then sees `v1.4.1` as the last release → no new release triggered
4. Future `feat`/`fix` merges will release correctly from `v1.4.1` onwards

## Test plan

- [ ] Merge this PR — the release workflow should run, move the orphaned tags, and exit cleanly (no new release)
- [ ] Merge any subsequent `fix(...)` PR — should release `v1.4.2` cleanly
- [ ] Confirm no duplicate `chore(release)` commits appear on `main`

https://claude.ai/code/session_017obBCqAn1PzT26c8RthbEy

---
_Generated by [Claude Code](https://claude.ai/code/session_017obBCqAn1PzT26c8RthbEy)_