### PR TITLE
test(seo): fix full-suite PHPUnit failures introduced by #407

### DIFF
--- a/tests/Helpers/WpdbStubFactory.php
+++ b/tests/Helpers/WpdbStubFactory.php
@@ -1,0 +1,30 @@
+<?php
+declare( strict_types=1 );
+
+namespace WP_AI_Mind\Tests\Helpers;
+
+/**
+ * Factory for the minimal $wpdb stub shared across the test suite.
+ *
+ * This stub satisfies NJ_Usage_Tracker::log_usage() without requiring a real database
+ * connection. Individual tests that need specific $wpdb behaviour use Mockery instead.
+ *
+ * @since 1.4.1
+ */
+final class WpdbStubFactory {
+
+	/**
+	 * Creates a minimal $wpdb stub that satisfies log_usage() without crashing.
+	 *
+	 * @since 1.4.1
+	 * @return object
+	 */
+	public static function create(): object {
+		return new class() {
+			public string $usermeta      = 'wp_usermeta';
+			public int    $rows_affected = 1;
+			public function prepare( string $sql, ...$args ): string { return $sql; }
+			public function query( string $sql ): int { return 1; }
+		};
+	}
+}

--- a/tests/Unit/Modules/Seo/SeoModuleTest.php
+++ b/tests/Unit/Modules/Seo/SeoModuleTest.php
@@ -78,6 +78,15 @@ class SeoModuleTest extends TestCase {
 	}
 
 	public function test_generate_for_post_returns_error_on_invalid_json_response(): void {
+		// Stub $wpdb so AbstractProvider::maybe_log() → log_usage() doesn't crash.
+		global $wpdb;
+		$wpdb = new class() { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			public string $usermeta      = 'wp_usermeta';
+			public int    $rows_affected = 1;
+			public function prepare( string $sql, ...$args ): string { return $sql; }
+			public function query( string $sql ): int { return 1; }
+		};
+
 		$post               = new \stdClass();
 		$post->ID           = 1;
 		$post->post_title   = 'Test';
@@ -127,6 +136,15 @@ class SeoModuleTest extends TestCase {
 	}
 
 	public function test_generate_for_post_returns_sanitised_array_on_success(): void {
+		// Stub $wpdb so AbstractProvider::maybe_log() → log_usage() doesn't crash.
+		global $wpdb;
+		$wpdb = new class() { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			public string $usermeta      = 'wp_usermeta';
+			public int    $rows_affected = 1;
+			public function prepare( string $sql, ...$args ): string { return $sql; }
+			public function query( string $sql ): int { return 1; }
+		};
+
 		$post               = new \stdClass();
 		$post->ID           = 1;
 		$post->post_title   = 'Great Post';

--- a/tests/Unit/Modules/Seo/SeoModuleTest.php
+++ b/tests/Unit/Modules/Seo/SeoModuleTest.php
@@ -6,6 +6,7 @@ namespace WP_AI_Mind\Tests\Unit\Modules\Seo;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use WP_AI_Mind\Modules\Seo\SeoModule;
+use WP_AI_Mind\Tests\Helpers\WpdbStubFactory;
 use PHPUnit\Framework\TestCase;
 
 class SeoModuleTest extends TestCase {
@@ -78,14 +79,9 @@ class SeoModuleTest extends TestCase {
 	}
 
 	public function test_generate_for_post_returns_error_on_invalid_json_response(): void {
-		// Stub $wpdb so AbstractProvider::maybe_log() → log_usage() doesn't crash.
+		// Stub $wpdb so AbstractProvider::maybe_log() -> log_usage() doesn't crash.
 		global $wpdb;
-		$wpdb = new class() { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			public string $usermeta      = 'wp_usermeta';
-			public int    $rows_affected = 1;
-			public function prepare( string $sql, ...$args ): string { return $sql; }
-			public function query( string $sql ): int { return 1; }
-		};
+		$wpdb = WpdbStubFactory::create(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intentional test stub.
 
 		$post               = new \stdClass();
 		$post->ID           = 1;
@@ -136,14 +132,9 @@ class SeoModuleTest extends TestCase {
 	}
 
 	public function test_generate_for_post_returns_sanitised_array_on_success(): void {
-		// Stub $wpdb so AbstractProvider::maybe_log() → log_usage() doesn't crash.
+		// Stub $wpdb so AbstractProvider::maybe_log() -> log_usage() doesn't crash.
 		global $wpdb;
-		$wpdb = new class() { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			public string $usermeta      = 'wp_usermeta';
-			public int    $rows_affected = 1;
-			public function prepare( string $sql, ...$args ): string { return $sql; }
-			public function query( string $sql ): int { return 1; }
-		};
+		$wpdb = WpdbStubFactory::create(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intentional test stub.
 
 		$post               = new \stdClass();
 		$post->ID           = 1;

--- a/tests/Unit/Modules/Seo/SeoModuleTest.php
+++ b/tests/Unit/Modules/Seo/SeoModuleTest.php
@@ -17,6 +17,9 @@ class SeoModuleTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
+		// Restore a valid $wpdb baseline so log_usage() does not crash in later test classes.
+		global $wpdb;
+		$wpdb = WpdbStubFactory::create(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intentional test stub.
 		Monkey\tearDown();
 		parent::tearDown();
 	}

--- a/tests/Unit/Tiers/NJUsageTrackerTest.php
+++ b/tests/Unit/Tiers/NJUsageTrackerTest.php
@@ -15,9 +15,14 @@ class NJUsageTrackerTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		// Reset $wpdb mock between tests.
+		// Restore the bootstrap $wpdb stub so subsequent tests can call log_usage() safely.
 		global $wpdb;
-		$wpdb = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wpdb = new class() { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			public string $usermeta      = 'wp_usermeta';
+			public int    $rows_affected = 1;
+			public function prepare( string $sql, ...$args ): string { return $sql; }
+			public function query( string $sql ): int { return 1; }
+		};
 		Monkey\tearDown();
 		parent::tearDown();
 	}

--- a/tests/Unit/Tiers/NJUsageTrackerTest.php
+++ b/tests/Unit/Tiers/NJUsageTrackerTest.php
@@ -5,6 +5,7 @@ namespace WP_AI_Mind\Tests\Unit\Tiers;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
+use WP_AI_Mind\Tests\Helpers\WpdbStubFactory;
 use WP_AI_Mind\Tiers\NJ_Usage_Tracker;
 
 class NJUsageTrackerTest extends TestCase {
@@ -17,12 +18,7 @@ class NJUsageTrackerTest extends TestCase {
 	protected function tearDown(): void {
 		// Restore the bootstrap $wpdb stub so subsequent tests can call log_usage() safely.
 		global $wpdb;
-		$wpdb = new class() { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			public string $usermeta      = 'wp_usermeta';
-			public int    $rows_affected = 1;
-			public function prepare( string $sql, ...$args ): string { return $sql; }
-			public function query( string $sql ): int { return 1; }
-		};
+		$wpdb = WpdbStubFactory::create(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		Monkey\tearDown();
 		parent::tearDown();
 	}

--- a/tests/Unit/Tiers/NJUsageTrackerTest.php
+++ b/tests/Unit/Tiers/NJUsageTrackerTest.php
@@ -16,7 +16,7 @@ class NJUsageTrackerTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		// Restore the bootstrap $wpdb stub so subsequent tests can call log_usage() safely.
+		// Restore a valid $wpdb baseline so log_usage() does not crash in later test classes.
 		global $wpdb;
 		$wpdb = WpdbStubFactory::create(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		Monkey\tearDown();

--- a/tests/Unit/Tools/ToolExecutorTest.php
+++ b/tests/Unit/Tools/ToolExecutorTest.php
@@ -191,6 +191,7 @@ class ToolExecutorTest extends TestCase {
 		Functions\when( 'get_user_meta' )->justReturn( 'free' );
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'wp_strip_all_tags' )->alias( fn( $s ) => $s );
+		Functions\when( '__' )->alias( fn( $s ) => $s );
 
 		$executor = $this->make_executor();
 		$result   = $executor->execute( 'generate_seo_meta', [ 'post_id' => 5 ], 1 );
@@ -211,6 +212,7 @@ class ToolExecutorTest extends TestCase {
 		Functions\when( 'get_post' )->justReturn( $post );
 		Functions\when( 'user_can' )->justReturn( true );
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( '__' )->alias( fn( $s ) => $s );
 		$month_key = 'wp_ai_mind_usage_' . gmdate( 'Y_m' );
 		// Return 'pro_managed' for the tier key and a huge usage count for the month key.
 		Functions\when( 'get_user_meta' )->alias(

--- a/tests/Unit/Tools/ToolExecutorTest.php
+++ b/tests/Unit/Tools/ToolExecutorTest.php
@@ -191,6 +191,7 @@ class ToolExecutorTest extends TestCase {
 		Functions\when( 'get_user_meta' )->justReturn( 'free' );
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'wp_strip_all_tags' )->alias( fn( $s ) => $s );
+
 		Functions\when( '__' )->alias( fn( $s ) => $s );
 
 		$executor = $this->make_executor();
@@ -212,6 +213,7 @@ class ToolExecutorTest extends TestCase {
 		Functions\when( 'get_post' )->justReturn( $post );
 		Functions\when( 'user_can' )->justReturn( true );
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
 		Functions\when( '__' )->alias( fn( $s ) => $s );
 		$month_key = 'wp_ai_mind_usage_' . gmdate( 'Y_m' );
 		// Return 'pro_managed' for the tier key and a huge usage count for the month key.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -100,11 +100,6 @@ if ( ! function_exists( 'rest_ensure_response' ) ) {
 // that don't set up their own $wpdb mock (e.g. provider tests).
 global $wpdb;
 if ( null === $wpdb ) {
-	$wpdb               = new class() {
-		public string $usermeta      = 'wp_usermeta';
-		public int    $rows_affected = 1;
-		public function prepare( string $sql, ...$args ): string { return $sql; }
-		public function query( string $sql ): int { return 1; }
-	};
+	$wpdb = \WP_AI_Mind\Tests\Helpers\WpdbStubFactory::create();
 }
 


### PR DESCRIPTION
## Summary

Three separate issues caused tests to fail only when the entire suite ran (not in isolation), all introduced or exposed by the auto-fix commits on PR #407:

- **`SeoModuleTest` (invalid_json, success paths):** `AbstractProvider::maybe_log()` calls `NJ_Usage_Tracker::log_usage()` → `$wpdb->query()` on every HTTP 200 response. When an earlier test class left `$wpdb` in a bad state, these tests crashed. Added an explicit `$wpdb` stub at the top of each affected test so `log_usage()` can't crash regardless of prior test state.

- **`NJUsageTrackerTest::tearDown()`:** Was resetting `global $wpdb = null`, leaving all subsequent tests that call `log_usage()` without a usable `$wpdb`. Changed to restore the same anonymous-class stub that `tests/bootstrap.php` creates, so the global is always valid between test classes.

- **`ToolExecutorTest` (free_tier, limit_exceeded):** Auto-fix commit `56ebdaa` wrapped the `note` and `Monthly limit reached` strings in `__()`, but the two affected tests did not stub `__()`. Added the missing `Functions\when('__')->alias(fn($s)=>$s)` to each.

## Test plan

- [ ] `./vendor/bin/phpunit tests/Unit/ --colors=always` — all 231 tests pass (was: 2 errors + 2 failures)
- [ ] `./vendor/bin/phpcs --standard=phpcs.xml.dist tests/Unit/Modules/Seo/SeoModuleTest.php tests/Unit/Tiers/NJUsageTrackerTest.php tests/Unit/Tools/ToolExecutorTest.php` — no errors

https://claude.ai/code/session_016TiGgBHHf6Gkzp9NJw7EUE

---
_Generated by [Claude Code](https://claude.ai/code/session_016TiGgBHHf6Gkzp9NJw7EUE)_