### PR TITLE
docs(seo): correct generate_for_post PHPDoc Authorization note

### DIFF
--- a/includes/Modules/Seo/SeoModule.php
+++ b/includes/Modules/Seo/SeoModule.php
@@ -162,9 +162,9 @@ class SeoModule {
 	 *
 	 * **Authorization:** This method performs a post-level capability check.
 	 * It verifies that $user_id holds 'edit_post' for $post_id and returns a
-	 * 'forbidden' WP_Error if not. Both direct callers (handle_generate, ToolExecutor)
-	 * also enforce this upstream as defence-in-depth; any future caller should
-	 * do the same.
+	 * 'forbidden' WP_Error if not. The REST path enforces 'edit_posts' via the
+	 * route permission_callback; any future caller should supply its own guard
+	 * at minimum.
 	 *
 	 * **Side effects:** On success this method fires a live AI provider request
 	 * and records token consumption via NJ_Usage_Tracker::log_usage(). Callers

--- a/includes/Modules/Seo/SeoModule.php
+++ b/includes/Modules/Seo/SeoModule.php
@@ -160,11 +160,11 @@ class SeoModule {
 	 * alt_text, and tokens_used. Returns WP_Error on provider or parsing failure.
 	 * Token usage is NOT logged here — callers must call NJ_Usage_Tracker::log_usage() after a successful return.
 	 *
-	 * **Authorization:** This method does not perform any capability check.
-	 * Callers MUST verify that the acting user holds 'edit_post' permission for
-	 * $post_id before invoking it. The REST path enforces this via
-	 * handle_generate(); the chat path enforces it via ToolExecutor::generate_seo_meta().
-	 * Any future caller must supply its own guard.
+	 * **Authorization:** This method performs a post-level capability check.
+	 * It verifies that $user_id holds 'edit_post' for $post_id and returns a
+	 * 'forbidden' WP_Error if not. Both direct callers (handle_generate, ToolExecutor)
+	 * also enforce this upstream as defence-in-depth; any future caller should
+	 * do the same.
 	 *
 	 * **Side effects:** On success this method fires a live AI provider request
 	 * and records token consumption via NJ_Usage_Tracker::log_usage(). Callers


### PR DESCRIPTION
## Summary

- Corrects the `**Authorization:**` paragraph in `SeoModule::generate_for_post()` PHPDoc, which incorrectly stated the method performs no capability check while the code clearly calls `user_can( $user_id, 'edit_post', $post_id )`.
- No functional change — pure documentation fix.

## Background

Reviewed PRs #406, #418, and #421. All three are CI-fix auto-PRs that were created against older snapshots of `main`. Their intended changes were applied through PRs #402, #407, #420, and #422 — often with improvements. The three PRs have been closed as superseded (see their comments).

The only genuine gap was this PHPDoc inconsistency introduced when PR #407 was merged. The docblock was copied from an earlier design where `generate_for_post()` had no auth check, but the merged implementation retained the check as defence-in-depth.

## Test plan

- [ ] `php -l includes/Modules/Seo/SeoModule.php` — no syntax errors
- [ ] PHPCS and PHPUnit CI jobs pass (no code change, only a comment block)

https://claude.ai/code/session_01MJSoLTffMQJPoQkgCxCEy5

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJSoLTffMQJPoQkgCxCEy5)_