### PR TITLE
chore(release): switch to batched weekly releases with improved changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 10 * * 5'   # every Friday at 10:00 UTC
 
 # Prevent concurrent releases (e.g. two fast merges)
 concurrency:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -19,7 +19,26 @@
         ]
       }
     ],
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            {"type": "feat",     "section": "New Features",             "hidden": false},
+            {"type": "fix",      "section": "Bug Fixes",                "hidden": false},
+            {"type": "perf",     "section": "Performance Improvements", "hidden": false},
+            {"type": "refactor", "section": "Code Refactors",           "hidden": false},
+            {"type": "docs",     "section": "Documentation",            "hidden": false},
+            {"type": "test",     "section": "Tests",                    "hidden": true},
+            {"type": "style",    "section": "Style",                    "hidden": true},
+            {"type": "build",    "section": "Build System",             "hidden": true},
+            {"type": "ci",       "section": "Continuous Integration",   "hidden": true},
+            {"type": "chore",    "section": "Chores",                   "hidden": true}
+          ]
+        }
+      }
+    ],
     "@semantic-release/changelog",
     [
       "@semantic-release/exec",

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ from your commit messages.
 ```
 feature/* ──PR──▶ main
                     │
-                    ▼ (on every merge)
+                    ▼ (batched — see "Triggering a release" below)
              release.yml runs
                     │
            reads conventional commits
@@ -33,6 +33,29 @@ feature/* ──PR──▶ main
 ```
 
 **You never touch versions, tags, or changelogs.**
+
+---
+
+## Triggering a release
+
+Releases are **not triggered automatically on every merge to `main`**. Instead:
+
+| Trigger | When | How |
+|---|---|---|
+| Scheduled | Every Friday at 10:00 UTC | Automatic — bundles the week's merged PRs |
+| Manual | Any time | Actions tab → **Release** → **Run workflow** |
+
+The scheduled run exits cleanly if there are no releasable commits since the last tag —
+no release is created and no version is bumped.
+
+### Out-of-band (hotfix) release
+
+If a critical fix needs to ship before Friday:
+
+1. Merge the `fix(scope):` PR to `main` as normal.
+2. Go to **Actions → Release → Run workflow** and click **Run workflow**.
+3. Semantic-release reads all commits since the last tag (including the hotfix) and cuts
+   a patch release.
 
 ---
 
@@ -111,7 +134,7 @@ select **WordPress.org Deploy** → **Run workflow** → supply the release tag 
 | File | Trigger | Purpose |
 |---|---|---|
 | `ci.yml` | PR to `main` | PHPCS, PHPUnit, JS lint, commitlint |
-| `release.yml` | Push to `main` | Full semantic-release pipeline |
+| `release.yml` | Weekly schedule (Fri 10:00 UTC) or `workflow_dispatch` | Full semantic-release pipeline |
 | `wporg-deploy.yml` | Stable release published | Deploy ZIP to WordPress.org SVN |
 | `claude-code-review.yml` | PR opened/updated | Automated code review |
 | `auto-fix-ci.yml` | CI failure | Auto-fix lint issues |

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@semantic-release/release-notes-generator": "^14.0.0",
         "@wordpress/element": ">=6.0.0",
         "@wordpress/scripts": "^31.8.0",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "eslint-plugin-jsdoc": "^62.9.0",
         "semantic-release": "^24.0.0"
       },
@@ -2115,6 +2116,19 @@
       },
       "engines": {
         "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -10361,16 +10375,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@semantic-release/release-notes-generator": "^14.0.0",
     "@wordpress/element": ">=6.0.0",
     "@wordpress/scripts": "^31.8.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "eslint-plugin-jsdoc": "^62.9.0",
     "semantic-release": "^24.0.0"
   },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replace `on: push to main` trigger in `release.yml` with a weekly schedule (Fridays 10:00 UTC) and `workflow_dispatch` — releases are now batched rather than one-per-PR
- Update `.releaserc.json` to use the `conventionalcommits` preset for `@semantic-release/release-notes-generator`, with explicit named sections for all commit types (`feat`, `fix`, `perf`, `refactor`, `docs` visible; `test`, `style`, `build`, `ci`, `chore` hidden)
- Add `conventional-changelog-conventionalcommits` devDependency required by the new preset
- Update `RELEASING.md` to document the new cadence and manual trigger instructions

## Why

The previous setup released on every merge to `main`, producing 3–5 releases per day during active development (v1.4.0 → v1.7.1 in 48 hours). Each release contained a single changelog entry, making semantic version numbers meaningless and generating excessive WordPress.org SVN deploys.

Batching via a weekly schedule bundles the week's PRs into one release with a rich, multi-section changelog. `workflow_dispatch` provides an escape hatch for hotfixes.

## Test plan

- [ ] Confirm `release.yml` no longer triggers on a direct push to `main` (push a `chore:` commit and verify no release workflow fires)
- [ ] Trigger `workflow_dispatch` manually from the Actions tab and verify semantic-release runs end-to-end
- [ ] After the first batched release, inspect `CHANGELOG.md` for correct section grouping (New Features, Bug Fixes, etc.)
- [ ] Confirm `wporg-deploy.yml` still fires on the GitHub Release publication event (trigger is unchanged)

https://claude.ai/code/session_0141ffEqenKV1fndFqNimKtL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0141ffEqenKV1fndFqNimKtL)_