### PR TITLE
feat(security): add registration challenge and trial-to-free expiry

### DIFF
--- a/includes/Admin/ActivationVerifyRestController.php
+++ b/includes/Admin/ActivationVerifyRestController.php
@@ -35,7 +35,7 @@ class ActivationVerifyRestController {
 	private const NAMESPACE  = 'wp-ai-mind/v1';
 	private const ROUTE      = '/activation-verify';
 	private const TRANSIENT  = 'wp_ai_mind_challenge_';
-	private const CHALLENGE_TTL = 300; // seconds — must match worker CHALLENGE_TTL
+	private const CHALLENGE_TTL = 300; // Seconds — must match worker CHALLENGE_TTL.
 
 	/**
 	 * Register the REST route. No authentication required — the Worker calls this.

--- a/includes/Admin/ActivationVerifyRestController.php
+++ b/includes/Admin/ActivationVerifyRestController.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * REST endpoint called by the proxy Worker to verify a site is live and running
+ * WP AI Mind.
+ *
+ * @package WP_AI_Mind
+ */
+
+declare( strict_types=1 );
+
+namespace WP_AI_Mind\Admin;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles the GET /wp-ai-mind/v1/activation-verify callback invoked by the
+ * Cloudflare Worker during site registration.
+ *
+ * The Worker generates a challenge token, stores it in KV, and sends it back
+ * to the plugin via /register. The plugin stores the challenge as a transient
+ * (store_challenge). The Worker then calls this endpoint to confirm the token
+ * matches — proving a live WordPress site with the plugin active is at the
+ * registered URL.
+ *
+ * @since 1.3.0
+ */
+class ActivationVerifyRestController {
+
+	private const NAMESPACE  = 'wp-ai-mind/v1';
+	private const ROUTE      = '/activation-verify';
+	private const TRANSIENT  = 'wp_ai_mind_challenge_';
+	private const CHALLENGE_TTL = 300; // seconds — must match worker CHALLENGE_TTL
+
+	/**
+	 * Register the REST route. No authentication required — the Worker calls this.
+	 *
+	 * @since 1.3.0
+	 * @return void
+	 */
+	public static function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			self::ROUTE,
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ static::class, 'handle' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
+					'challenge' => [
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+						'validate_callback' => static function ( string $value ): bool {
+							return (bool) preg_match( '/^[0-9a-f]{64}$/', $value );
+						},
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Handle the activation-verify request.
+	 *
+	 * Returns 200 when the challenge transient is found, 403 when it is not.
+	 *
+	 * @since 1.3.0
+	 * @param WP_REST_Request $request The incoming REST request.
+	 * @return WP_REST_Response
+	 */
+	public static function handle( WP_REST_Request $request ): WP_REST_Response {
+		$challenge = $request->get_param( 'challenge' );
+
+		if ( get_transient( self::TRANSIENT . $challenge ) ) {
+			return new WP_REST_Response( [ 'verified' => true ], 200 );
+		}
+
+		return new WP_REST_Response( [ 'error' => 'Challenge not found' ], 403 );
+	}
+
+	/**
+	 * Store a challenge token as a transient so the Worker callback can verify it.
+	 *
+	 * Called by NJ_Site_Registration immediately after fetching the challenge
+	 * from the Worker, before sending it back in the /register request body.
+	 *
+	 * @since 1.3.0
+	 * @param string $challenge 64-character hex challenge token.
+	 * @return void
+	 */
+	public static function store_challenge( string $challenge ): void {
+		set_transient( self::TRANSIENT . $challenge, 1, self::CHALLENGE_TTL );
+	}
+}

--- a/includes/Admin/ActivationVerifyRestController.php
+++ b/includes/Admin/ActivationVerifyRestController.php
@@ -32,9 +32,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class ActivationVerifyRestController {
 
-	private const NAMESPACE  = 'wp-ai-mind/v1';
-	private const ROUTE      = '/activation-verify';
-	private const TRANSIENT  = 'wp_ai_mind_challenge_';
+	private const NAMESPACE     = 'wp-ai-mind/v1';
+	private const ROUTE         = '/activation-verify';
+	private const TRANSIENT     = 'wp_ai_mind_challenge_';
 	private const CHALLENGE_TTL = 300; // Seconds — must match worker CHALLENGE_TTL.
 
 	/**
@@ -78,6 +78,7 @@ class ActivationVerifyRestController {
 		$challenge = $request->get_param( 'challenge' );
 
 		if ( get_transient( self::TRANSIENT . $challenge ) ) {
+			delete_transient( self::TRANSIENT . $challenge );
 			return new WP_REST_Response( [ 'verified' => true ], 200 );
 		}
 

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -99,6 +99,7 @@ class Plugin {
 		add_action( 'wp_ai_mind_register_menu', [ \WP_AI_Mind\Admin\AdminMenu::class, 'register' ] );
 		add_action( 'wp_ai_mind_register_rest_routes', [ \WP_AI_Mind\Admin\OnboardingRestController::class, 'register_routes' ] );
 		add_action( 'wp_ai_mind_register_rest_routes', [ \WP_AI_Mind\Admin\TestKeyRestController::class, 'register_routes' ] );
+		add_action( 'wp_ai_mind_register_rest_routes', [ \WP_AI_Mind\Admin\ActivationVerifyRestController::class, 'register_routes' ] );
 		\WP_AI_Mind\Admin\NJ_Tier_Status_Page::register_hooks();
 		\WP_AI_Mind\Admin\NJ_Api_Key_Settings::register_hooks();
 		\WP_AI_Mind\Admin\NJ_Usage_Widget::register_hooks();

--- a/includes/Proxy/NJ_Site_Registration.php
+++ b/includes/Proxy/NJ_Site_Registration.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace WP_AI_Mind\Proxy;
 
 use WP_Error;
+use WP_AI_Mind\Admin\ActivationVerifyRestController;
 use WP_AI_Mind\Tiers\NJ_Tier_Config;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -110,16 +111,51 @@ class NJ_Site_Registration {
 	/**
 	 * Send a registration request to the proxy Worker.
 	 *
+	 * Performs a two-step challenge handshake: fetches a single-use challenge
+	 * token from the Worker, stores it as a transient so the Worker callback
+	 * can verify it, then sends the challenge alongside the site URL.
+	 *
 	 * @since 1.2.0
 	 * @return string|WP_Error The stored site token on success, or a WP_Error on failure.
 	 */
 	public static function register(): string|WP_Error {
+		$proxy_url = NJ_Tier_Config::get_proxy_url();
+
+		// Step 1 — fetch a single-use challenge from the Worker.
+		$challenge_response = wp_remote_get(
+			$proxy_url . '/activation-challenge',
+			[ 'timeout' => 10 ]
+		);
+
+		if ( is_wp_error( $challenge_response ) ) {
+			return $challenge_response;
+		}
+
+		$challenge_code = (int) wp_remote_retrieve_response_code( $challenge_response );
+		$challenge_body = json_decode( wp_remote_retrieve_body( $challenge_response ), true ) ?? [];
+
+		if ( 200 !== $challenge_code || empty( $challenge_body['challenge'] ) ) {
+			return new WP_Error( 'challenge_failed', "Could not obtain activation challenge (HTTP {$challenge_code})" );
+		}
+
+		$challenge = sanitize_text_field( $challenge_body['challenge'] );
+
+		// Step 2 — store the challenge locally so the Worker callback succeeds.
+		ActivationVerifyRestController::store_challenge( $challenge );
+
+		// Step 3 — register with the Worker, sending the challenge token.
 		$response = wp_remote_post(
-			NJ_Tier_Config::get_proxy_url() . '/register',
+			$proxy_url . '/register',
 			[
 				'headers' => [ 'Content-Type' => 'application/json' ],
-				'body'    => wp_json_encode( [ 'site_url' => home_url() ] ),
-				'timeout' => 15,
+				'body'    => wp_json_encode(
+					[
+						'site_url'        => home_url(),
+						'challenge_token' => $challenge,
+					]
+				),
+				// Increased timeout: Worker makes a callback to this site before responding.
+				'timeout' => 20,
 			]
 		);
 

--- a/tests/Unit/Admin/ActivationVerifyRestControllerTest.php
+++ b/tests/Unit/Admin/ActivationVerifyRestControllerTest.php
@@ -1,0 +1,109 @@
+<?php
+declare( strict_types=1 );
+
+namespace WP_AI_Mind\Tests\Unit\Admin;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_AI_Mind\Admin\ActivationVerifyRestController;
+
+class ActivationVerifyRestControllerTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	// ── Route registration ──────────────────────────────────────────────────────
+
+	public function test_register_routes_registers_activation_verify_endpoint(): void {
+		$registered_ns    = null;
+		$registered_route = null;
+
+		Functions\when( 'register_rest_route' )->alias(
+			function ( $ns, $route ) use ( &$registered_ns, &$registered_route ) {
+				$registered_ns    = $ns;
+				$registered_route = $route;
+			}
+		);
+
+		ActivationVerifyRestController::register_routes();
+
+		$this->assertSame( 'wp-ai-mind/v1', $registered_ns );
+		$this->assertSame( '/activation-verify', $registered_route );
+	}
+
+	// ── store_challenge ─────────────────────────────────────────────────────────
+
+	public function test_store_challenge_sets_transient_with_challenge_key(): void {
+		$captured_key = null;
+
+		Functions\when( 'set_transient' )->alias(
+			function ( string $key ) use ( &$captured_key ) {
+				$captured_key = $key;
+			}
+		);
+
+		ActivationVerifyRestController::store_challenge( 'abc123' );
+
+		$this->assertStringContainsString( 'abc123', $captured_key );
+		$this->assertStringStartsWith( 'wp_ai_mind_challenge_', $captured_key );
+	}
+
+	// ── handle — challenge found ────────────────────────────────────────────────
+
+	public function test_handle_returns_200_when_challenge_transient_exists(): void {
+		Functions\when( 'get_transient' )->justReturn( 1 );
+
+		$request = new \WP_REST_Request( 'GET' );
+		$request->set_param( 'challenge', str_repeat( 'a', 64 ) );
+
+		$response = ActivationVerifyRestController::handle( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertTrue( $response->data['verified'] );
+	}
+
+	// ── handle — challenge missing ──────────────────────────────────────────────
+
+	public function test_handle_returns_403_when_challenge_transient_is_absent(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+
+		$request = new \WP_REST_Request( 'GET' );
+		$request->set_param( 'challenge', str_repeat( 'b', 64 ) );
+
+		$response = ActivationVerifyRestController::handle( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertArrayHasKey( 'error', $response->data );
+	}
+
+	// ── handle — get_transient uses the correct key ─────────────────────────────
+
+	public function test_handle_looks_up_transient_with_correct_prefixed_key(): void {
+		$challenge    = str_repeat( 'c', 64 );
+		$captured_key = null;
+
+		Functions\when( 'get_transient' )->alias(
+			function ( string $key ) use ( &$captured_key ) {
+				$captured_key = $key;
+				return 1;
+			}
+		);
+
+		$request = new \WP_REST_Request( 'GET' );
+		$request->set_param( 'challenge', $challenge );
+
+		ActivationVerifyRestController::handle( $request );
+
+		$this->assertSame( 'wp_ai_mind_challenge_' . $challenge, $captured_key );
+	}
+}

--- a/tests/Unit/Admin/ActivationVerifyRestControllerTest.php
+++ b/tests/Unit/Admin/ActivationVerifyRestControllerTest.php
@@ -60,6 +60,7 @@ class ActivationVerifyRestControllerTest extends TestCase {
 
 	public function test_handle_returns_200_when_challenge_transient_exists(): void {
 		Functions\when( 'get_transient' )->justReturn( 1 );
+		Functions\when( 'delete_transient' )->justReturn( true );
 
 		$request = new \WP_REST_Request( 'GET' );
 		$request->set_param( 'challenge', str_repeat( 'a', 64 ) );
@@ -69,6 +70,25 @@ class ActivationVerifyRestControllerTest extends TestCase {
 		$this->assertInstanceOf( \WP_REST_Response::class, $response );
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertTrue( $response->data['verified'] );
+	}
+
+	public function test_handle_deletes_transient_after_successful_verification(): void {
+		$challenge    = str_repeat( 'a', 64 );
+		$deleted_key  = null;
+
+		Functions\when( 'get_transient' )->justReturn( 1 );
+		Functions\when( 'delete_transient' )->alias(
+			function ( string $key ) use ( &$deleted_key ) {
+				$deleted_key = $key;
+			}
+		);
+
+		$request = new \WP_REST_Request( 'GET' );
+		$request->set_param( 'challenge', $challenge );
+
+		ActivationVerifyRestController::handle( $request );
+
+		$this->assertSame( 'wp_ai_mind_challenge_' . $challenge, $deleted_key );
 	}
 
 	// ── handle — challenge missing ──────────────────────────────────────────────
@@ -98,6 +118,7 @@ class ActivationVerifyRestControllerTest extends TestCase {
 				return 1;
 			}
 		);
+		Functions\when( 'delete_transient' )->justReturn( true );
 
 		$request = new \WP_REST_Request( 'GET' );
 		$request->set_param( 'challenge', $challenge );

--- a/tests/Unit/Proxy/NJSiteRegistrationTest.php
+++ b/tests/Unit/Proxy/NJSiteRegistrationTest.php
@@ -20,6 +20,8 @@ class NJSiteRegistrationTest extends TestCase {
 		parent::tearDown();
 	}
 
+	// ── Accessors ───────────────────────────────────────────────────────────────
+
 	public function test_get_site_token_returns_stored_token(): void {
 		Functions\expect( 'get_option' )
 			->with( NJ_Site_Registration::OPTION_TOKEN, '' )
@@ -61,5 +63,154 @@ class NJSiteRegistrationTest extends TestCase {
 
 		$this->assertStringContainsString( 'lemonsqueezy.com', $url );
 		$this->assertStringContainsString( 'mytoken', $url );
+	}
+
+	// ── register() — challenge fetch failure ────────────────────────────────────
+
+	public function test_register_returns_wp_error_when_challenge_request_fails(): void {
+		Functions\when( 'wp_remote_get' )->justReturn(
+			new \WP_Error( 'http_request_failed', 'Connection refused' )
+		);
+		Functions\when( 'is_wp_error' )->alias( fn( $v ) => $v instanceof \WP_Error );
+
+		$result = NJ_Site_Registration::register();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	public function test_register_returns_wp_error_when_challenge_response_is_not_200(): void {
+		Functions\when( 'wp_remote_get' )->justReturn( [] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 500 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{}' );
+
+		$result = NJ_Site_Registration::register();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'challenge_failed', $result->get_error_code() );
+	}
+
+	public function test_register_returns_wp_error_when_challenge_body_has_no_challenge_key(): void {
+		Functions\when( 'wp_remote_get' )->justReturn( [] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"other":"value"}' );
+
+		$result = NJ_Site_Registration::register();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'challenge_failed', $result->get_error_code() );
+	}
+
+	// ── register() — registration request failure ───────────────────────────────
+
+	public function test_register_returns_wp_error_when_registration_post_fails(): void {
+		$challenge = str_repeat( 'a', 64 );
+
+		// Challenge fetch succeeds.
+		Functions\when( 'wp_remote_get' )->justReturn( [] );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"challenge":"' . $challenge . '"}' );
+		Functions\when( 'sanitize_text_field' )->alias( fn( $s ) => $s );
+		Functions\when( 'set_transient' )->justReturn( true );
+		Functions\when( 'home_url' )->justReturn( 'https://mysite.example.com' );
+		Functions\when( 'wp_json_encode' )->alias( fn( $d ) => json_encode( $d ) );
+
+		// Registration POST fails.
+		Functions\when( 'wp_remote_post' )->justReturn(
+			new \WP_Error( 'http_request_failed', 'Connection refused' )
+		);
+		Functions\when( 'is_wp_error' )->alias( fn( $v ) => $v instanceof \WP_Error );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+
+		$result = NJ_Site_Registration::register();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	public function test_register_returns_wp_error_when_registration_returns_non_2xx(): void {
+		$challenge = str_repeat( 'b', 64 );
+
+		Functions\when( 'wp_remote_get' )->justReturn( [] );
+		Functions\when( 'wp_remote_post' )->justReturn( [] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		// First body call returns the challenge, second returns the registration failure.
+		Functions\when( 'wp_remote_retrieve_body' )->alias(
+			( function () use ( $challenge ) {
+				$calls = 0;
+				return function () use ( $challenge, &$calls ): string {
+					++$calls;
+					return 1 === $calls
+						? '{"challenge":"' . $challenge . '"}'
+						: '{"error":"site verification failed"}';
+				};
+			} )()
+		);
+		Functions\when( 'sanitize_text_field' )->alias( fn( $s ) => $s );
+		Functions\when( 'set_transient' )->justReturn( true );
+		Functions\when( 'home_url' )->justReturn( 'https://mysite.example.com' );
+		Functions\when( 'wp_json_encode' )->alias( fn( $d ) => json_encode( $d ) );
+
+		// Registration returns 403 from the worker.
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+
+		// Override: first call 200 (challenge), second call 403 (register).
+		$callNum = 0;
+		Functions\when( 'wp_remote_retrieve_response_code' )->alias(
+			function () use ( &$callNum ): int {
+				++$callNum;
+				return 1 === $callNum ? 200 : 403;
+			}
+		);
+
+		$result = NJ_Site_Registration::register();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'registration_failed', $result->get_error_code() );
+	}
+
+	// ── register() — happy path ─────────────────────────────────────────────────
+
+	public function test_register_stores_token_and_returns_it_on_success(): void {
+		$challenge     = str_repeat( 'c', 64 );
+		$token         = str_repeat( 'd', 64 );
+		$captured_args = null;
+
+		Functions\when( 'wp_remote_get' )->justReturn( [] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_post' )->alias(
+			function ( $url, $args ) use ( &$captured_args ) {
+				$captured_args = $args;
+				return [];
+			}
+		);
+		$callNum = 0;
+		Functions\when( 'wp_remote_retrieve_response_code' )->alias(
+			function () use ( &$callNum ): int {
+				return 1 === ++$callNum ? 200 : 201;
+			}
+		);
+		$bodyCallNum = 0;
+		Functions\when( 'wp_remote_retrieve_body' )->alias(
+			function () use ( &$bodyCallNum, $challenge, $token ): string {
+				return 1 === ++$bodyCallNum
+					? '{"challenge":"' . $challenge . '"}'
+					: '{"token":"' . $token . '","tier":"trial"}';
+			}
+		);
+		Functions\when( 'sanitize_text_field' )->alias( fn( $s ) => $s );
+		Functions\when( 'set_transient' )->justReturn( true );
+		Functions\when( 'home_url' )->justReturn( 'https://mysite.example.com' );
+		Functions\when( 'wp_json_encode' )->alias( fn( $d ) => json_encode( $d ) );
+		Functions\when( 'update_option' )->justReturn( true );
+
+		$result = NJ_Site_Registration::register();
+
+		$this->assertSame( $token, $result );
+
+		// Confirm challenge_token is forwarded in the registration body.
+		$body = json_decode( $captured_args['body'], true );
+		$this->assertSame( $challenge, $body['challenge_token'] );
+		$this->assertSame( 'https://mysite.example.com', $body['site_url'] );
 	}
 }

--- a/tests/Unit/Proxy/NJSiteRegistrationTest.php
+++ b/tests/Unit/Proxy/NJSiteRegistrationTest.php
@@ -110,7 +110,7 @@ class NJSiteRegistrationTest extends TestCase {
 		// Challenge fetch succeeds.
 		Functions\when( 'wp_remote_get' )->justReturn( [] );
 		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"challenge":"' . $challenge . '"}' );
-		Functions\when( 'sanitize_text_field' )->alias( fn( $s ) => $s );
+		Functions\when( 'sanitize_text_field' )->returnArg();
 		Functions\when( 'set_transient' )->justReturn( true );
 		Functions\when( 'home_url' )->justReturn( 'https://mysite.example.com' );
 		Functions\when( 'wp_json_encode' )->alias( fn( $d ) => json_encode( $d ) );
@@ -133,7 +133,6 @@ class NJSiteRegistrationTest extends TestCase {
 		Functions\when( 'wp_remote_get' )->justReturn( [] );
 		Functions\when( 'wp_remote_post' )->justReturn( [] );
 		Functions\when( 'is_wp_error' )->justReturn( false );
-		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
 		// First body call returns the challenge, second returns the registration failure.
 		Functions\when( 'wp_remote_retrieve_body' )->alias(
 			( function () use ( $challenge ) {
@@ -146,15 +145,12 @@ class NJSiteRegistrationTest extends TestCase {
 				};
 			} )()
 		);
-		Functions\when( 'sanitize_text_field' )->alias( fn( $s ) => $s );
+		Functions\when( 'sanitize_text_field' )->returnArg();
 		Functions\when( 'set_transient' )->justReturn( true );
 		Functions\when( 'home_url' )->justReturn( 'https://mysite.example.com' );
 		Functions\when( 'wp_json_encode' )->alias( fn( $d ) => json_encode( $d ) );
 
-		// Registration returns 403 from the worker.
-		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
-
-		// Override: first call 200 (challenge), second call 403 (register).
+		// First call 200 (challenge), second call 403 (register).
 		$callNum = 0;
 		Functions\when( 'wp_remote_retrieve_response_code' )->alias(
 			function () use ( &$callNum ): int {
@@ -198,7 +194,7 @@ class NJSiteRegistrationTest extends TestCase {
 					: '{"token":"' . $token . '","tier":"trial"}';
 			}
 		);
-		Functions\when( 'sanitize_text_field' )->alias( fn( $s ) => $s );
+		Functions\when( 'sanitize_text_field' )->returnArg();
 		Functions\when( 'set_transient' )->justReturn( true );
 		Functions\when( 'home_url' )->justReturn( 'https://mysite.example.com' );
 		Functions\when( 'wp_json_encode' )->alias( fn( $d ) => json_encode( $d ) );

--- a/wp-ai-mind-proxy/src/auth.ts
+++ b/wp-ai-mind-proxy/src/auth.ts
@@ -7,6 +7,7 @@ export interface AuthResult {
 	site_token?: string;
 	tier?: SiteTier;
 	site_url?: string;
+	record?: SiteRecord;
 }
 
 export async function authenticateRequest(
@@ -36,6 +37,7 @@ export async function authenticateRequest(
 		site_token: token,
 		tier: record.tier,
 		site_url: record.site_url,
+		record,
 	};
 }
 

--- a/wp-ai-mind-proxy/src/constants.ts
+++ b/wp-ai-mind-proxy/src/constants.ts
@@ -1,0 +1,3 @@
+// src/constants.ts
+
+export const TRIAL_PERIOD_MS = 30 * 24 * 60 * 60 * 1000;

--- a/wp-ai-mind-proxy/src/index.ts
+++ b/wp-ai-mind-proxy/src/index.ts
@@ -4,9 +4,9 @@ import { Env, ProxyRequest, ProxyTier, SiteRecord } from './types';
 import { authenticateRequest } from './auth';
 import { handleActivationChallenge, handleRegistration } from './registration';
 import { handleWebhook } from './webhook';
+import { TRIAL_PERIOD_MS } from './constants';
 
 const MAX_BODY_BYTES = 1_048_576; // 1 MB
-const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
 export default {
 	async fetch( request: Request, env: Env ): Promise< Response > {
@@ -77,7 +77,7 @@ async function handleChatProxy(
 		if ( effectiveTier === 'trial' && auth.record ) {
 			const startedAt =
 				auth.record.trial_started_at ?? auth.record.created_at;
-			if ( Date.now() - startedAt > THIRTY_DAYS_MS ) {
+			if ( Date.now() - startedAt > TRIAL_PERIOD_MS ) {
 				const demoted: SiteRecord = { ...auth.record, tier: 'free' };
 				await env.USAGE_KV.put(
 					`site:${ siteToken }`,

--- a/wp-ai-mind-proxy/src/index.ts
+++ b/wp-ai-mind-proxy/src/index.ts
@@ -1,27 +1,36 @@
 // src/index.ts
 
-import { Env, ProxyRequest, ProxyTier } from './types';
+import { Env, ProxyRequest, ProxyTier, SiteRecord } from './types';
 import { authenticateRequest } from './auth';
-import { handleRegistration } from './registration';
+import { handleActivationChallenge, handleRegistration } from './registration';
 import { handleWebhook } from './webhook';
 
 const MAX_BODY_BYTES = 1_048_576; // 1 MB
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
 export default {
 	async fetch( request: Request, env: Env ): Promise< Response > {
-		if ( request.method !== 'POST' ) {
-			return jsonResponse( { error: 'Method not allowed' }, 405 );
-		}
-
 		const { pathname } = new URL( request.url );
 
+		if ( pathname === '/activation-challenge' ) {
+			return handleActivationChallenge( request, env );
+		}
 		if ( pathname === '/register' ) {
+			if ( request.method !== 'POST' ) {
+				return jsonResponse( { error: 'Method not allowed' }, 405 );
+			}
 			return handleRegistration( request, env );
 		}
 		if ( pathname === '/webhook' ) {
+			if ( request.method !== 'POST' ) {
+				return jsonResponse( { error: 'Method not allowed' }, 405 );
+			}
 			return handleWebhook( request, env );
 		}
 		if ( pathname === '/v1/chat' ) {
+			if ( request.method !== 'POST' ) {
+				return jsonResponse( { error: 'Method not allowed' }, 405 );
+			}
 			return handleChatProxy( request, env );
 		}
 
@@ -63,7 +72,23 @@ async function handleChatProxy(
 			);
 		}
 
-		const rateLimitCheck = await checkRateLimit( siteToken, tier, env );
+		// Lazily downgrade expired trials to free without blocking the request.
+		let effectiveTier = tier as ProxyTier;
+		if ( effectiveTier === 'trial' && auth.record ) {
+			if (
+				Date.now() - auth.record.trial_started_at >
+				THIRTY_DAYS_MS
+			) {
+				const demoted: SiteRecord = { ...auth.record, tier: 'free' };
+				await env.USAGE_KV.put(
+					`site:${ siteToken }`,
+					JSON.stringify( demoted )
+				);
+				effectiveTier = 'free';
+			}
+		}
+
+		const rateLimitCheck = await checkRateLimit( siteToken, effectiveTier, env );
 		if ( ! rateLimitCheck.allowed ) {
 			return jsonResponse(
 				{
@@ -75,10 +100,10 @@ async function handleChatProxy(
 			);
 		}
 
-		const selectedModel = getModelForTier( tier, model );
+		const selectedModel = getModelForTier( effectiveTier, model );
 		const clampedMaxTokens = Math.min(
-			maxTokens ?? ( tier === 'free' ? 1000 : 4000 ),
-			MAX_TOKENS[ tier ]
+			maxTokens ?? ( effectiveTier === 'free' ? 1000 : 4000 ),
+			MAX_TOKENS[ effectiveTier ]
 		);
 
 		const anthropicBody: Record< string, unknown > = {

--- a/wp-ai-mind-proxy/src/index.ts
+++ b/wp-ai-mind-proxy/src/index.ts
@@ -75,10 +75,9 @@ async function handleChatProxy(
 		// Lazily downgrade expired trials to free without blocking the request.
 		let effectiveTier = tier as ProxyTier;
 		if ( effectiveTier === 'trial' && auth.record ) {
-			if (
-				Date.now() - auth.record.trial_started_at >
-				THIRTY_DAYS_MS
-			) {
+			const startedAt =
+				auth.record.trial_started_at ?? auth.record.created_at;
+			if ( Date.now() - startedAt > THIRTY_DAYS_MS ) {
 				const demoted: SiteRecord = { ...auth.record, tier: 'free' };
 				await env.USAGE_KV.put(
 					`site:${ siteToken }`,

--- a/wp-ai-mind-proxy/src/registration.ts
+++ b/wp-ai-mind-proxy/src/registration.ts
@@ -62,14 +62,13 @@ export async function handleRegistration(
 		return jsonResponse( { error: 'challenge_token required' }, 403 );
 	}
 
-	// Validate challenge: must exist in KV (single-use, deleted before callback).
+	// Validate challenge: must exist in KV (single-use, deleted after successful callback).
 	const storedChallenge = await env.USAGE_KV.get(
 		`challenge:${ challengeToken }`
 	);
 	if ( ! storedChallenge ) {
 		return jsonResponse( { error: 'Invalid or expired challenge' }, 403 );
 	}
-	await env.USAGE_KV.delete( `challenge:${ challengeToken }` );
 
 	// Verify the site is live by calling back to its WP REST endpoint.
 	const verifyUrl =
@@ -89,6 +88,9 @@ export async function handleRegistration(
 	if ( ! callbackOk ) {
 		return jsonResponse( { error: 'Site verification failed' }, 403 );
 	}
+	// Consume the challenge only after a successful callback so a transient
+	// network failure does not permanently invalidate the token.
+	await env.USAGE_KV.delete( `challenge:${ challengeToken }` );
 
 	// Idempotent — return the existing token if already registered.
 	// If the stored record is an expired trial, demote it to free.

--- a/wp-ai-mind-proxy/src/registration.ts
+++ b/wp-ai-mind-proxy/src/registration.ts
@@ -5,6 +5,33 @@ import { generateToken } from './auth';
 
 export const REGISTRATION_RATE_LIMIT = 5; // max new registrations per IP per hour
 const REGISTRATION_WINDOW_TTL = 3600; // seconds
+const CHALLENGE_TTL = 300; // seconds
+
+/**
+ * Generate a single-use registration challenge token and store it in KV.
+ * The PHP plugin fetches this first, stores it as a transient, then sends it
+ * back during /register so the worker can verify the site is live.
+ */
+export async function handleActivationChallenge(
+	request: Request,
+	env: Env
+): Promise< Response > {
+	if ( request.method !== 'GET' ) {
+		return jsonResponse( { error: 'Method not allowed' }, 405 );
+	}
+
+	const bytes = new Uint8Array( 32 );
+	crypto.getRandomValues( bytes );
+	const challenge = Array.from( bytes )
+		.map( ( b ) => b.toString( 16 ).padStart( 2, '0' ) )
+		.join( '' );
+
+	await env.USAGE_KV.put( `challenge:${ challenge }`, '1', {
+		expirationTtl: CHALLENGE_TTL,
+	} );
+
+	return jsonResponse( { challenge } );
+}
 
 export async function handleRegistration(
 	request: Request,
@@ -14,9 +41,12 @@ export async function handleRegistration(
 		return jsonResponse( { error: 'Method not allowed' }, 405 );
 	}
 
-	let body: { site_url?: string };
+	let body: { site_url?: string; challenge_token?: string };
 	try {
-		body = ( await request.json() ) as { site_url?: string };
+		body = ( await request.json() ) as {
+			site_url?: string;
+			challenge_token?: string;
+		};
 	} catch {
 		return jsonResponse( { error: 'Invalid JSON' }, 400 );
 	}
@@ -26,7 +56,42 @@ export async function handleRegistration(
 		return jsonResponse( { error: 'Invalid site_url' }, 400 );
 	}
 
+	// Challenge is mandatory — no token means an unverified registration attempt.
+	const challengeToken = ( body.challenge_token ?? '' ).trim();
+	if ( ! challengeToken ) {
+		return jsonResponse( { error: 'challenge_token required' }, 403 );
+	}
+
+	// Validate challenge: must exist in KV (single-use, deleted before callback).
+	const storedChallenge = await env.USAGE_KV.get(
+		`challenge:${ challengeToken }`
+	);
+	if ( ! storedChallenge ) {
+		return jsonResponse( { error: 'Invalid or expired challenge' }, 403 );
+	}
+	await env.USAGE_KV.delete( `challenge:${ challengeToken }` );
+
+	// Verify the site is live by calling back to its WP REST endpoint.
+	const verifyUrl =
+		siteUrl.replace( /\/$/, '' ) +
+		'/wp-json/wp-ai-mind/v1/activation-verify' +
+		'?challenge=' +
+		encodeURIComponent( challengeToken );
+	let callbackOk = false;
+	try {
+		const cbRes = await fetch( verifyUrl, {
+			signal: AbortSignal.timeout( 10_000 ),
+		} );
+		callbackOk = cbRes.ok;
+	} catch {
+		callbackOk = false;
+	}
+	if ( ! callbackOk ) {
+		return jsonResponse( { error: 'Site verification failed' }, 403 );
+	}
+
 	// Idempotent — return the existing token if already registered.
+	// If the stored record is an expired trial, demote it to free.
 	const urlHash = await sha256( siteUrl );
 	const existingToken = await env.USAGE_KV.get( `site_url:${ urlHash }` );
 	if ( existingToken ) {
@@ -35,6 +100,21 @@ export async function handleRegistration(
 			'json'
 		);
 		if ( record ) {
+			const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+			if (
+				record.tier === 'trial' &&
+				Date.now() - record.trial_started_at > THIRTY_DAYS_MS
+			) {
+				const demoted: SiteRecord = { ...record, tier: 'free' };
+				await env.USAGE_KV.put(
+					`site:${ existingToken }`,
+					JSON.stringify( demoted )
+				);
+				return jsonResponse( {
+					token: existingToken,
+					tier: 'free',
+				} );
+			}
 			return jsonResponse( { token: existingToken, tier: record.tier } );
 		}
 	}
@@ -61,16 +141,18 @@ export async function handleRegistration(
 	} );
 
 	const token = generateToken();
+	const now = Date.now();
 	const record: SiteRecord = {
 		site_url: siteUrl,
-		tier: 'free',
-		created_at: Date.now(),
+		tier: 'trial',
+		created_at: now,
+		trial_started_at: now,
 	};
 
 	await env.USAGE_KV.put( `site:${ token }`, JSON.stringify( record ) );
 	await env.USAGE_KV.put( `site_url:${ urlHash }`, token );
 
-	return jsonResponse( { token, tier: 'free' }, 201 );
+	return jsonResponse( { token, tier: 'trial' }, 201 );
 }
 
 function getCurrentHour(): string {

--- a/wp-ai-mind-proxy/src/registration.ts
+++ b/wp-ai-mind-proxy/src/registration.ts
@@ -2,6 +2,7 @@
 
 import { Env, SiteRecord } from './types';
 import { generateToken } from './auth';
+import { TRIAL_PERIOD_MS } from './constants';
 
 export const REGISTRATION_RATE_LIMIT = 5; // max new registrations per IP per hour
 const REGISTRATION_WINDOW_TTL = 3600; // seconds
@@ -102,11 +103,10 @@ export async function handleRegistration(
 			'json'
 		);
 		if ( record ) {
-			const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 			const startedAt = record.trial_started_at ?? record.created_at;
 			if (
 				record.tier === 'trial' &&
-				Date.now() - startedAt > THIRTY_DAYS_MS
+				Date.now() - startedAt > TRIAL_PERIOD_MS
 			) {
 				const demoted: SiteRecord = { ...record, tier: 'free' };
 				await env.USAGE_KV.put(

--- a/wp-ai-mind-proxy/src/registration.ts
+++ b/wp-ai-mind-proxy/src/registration.ts
@@ -5,6 +5,7 @@ import { generateToken } from './auth';
 import { TRIAL_PERIOD_MS } from './constants';
 
 export const REGISTRATION_RATE_LIMIT = 5; // max new registrations per IP per hour
+export const CHALLENGE_RATE_LIMIT = 20; // max challenge requests per IP per hour
 const REGISTRATION_WINDOW_TTL = 3600; // seconds
 const CHALLENGE_TTL = 300; // seconds
 
@@ -20,6 +21,23 @@ export async function handleActivationChallenge(
 	if ( request.method !== 'GET' ) {
 		return jsonResponse( { error: 'Method not allowed' }, 405 );
 	}
+
+	// Rate-limit challenge issuance by IP to prevent KV exhaustion.
+	const ip = request.headers.get( 'CF-Connecting-IP' ) ?? 'unknown';
+	const challengeRateLimitKey = `challenge_ip:${ ip }:${ getCurrentHour() }`;
+	const challengeAttempts = parseInt(
+		( await env.USAGE_KV.get( challengeRateLimitKey ) ) ?? '0',
+		10
+	);
+	if ( challengeAttempts >= CHALLENGE_RATE_LIMIT ) {
+		return jsonResponse(
+			{ error: 'Too many challenge requests. Try again later.' },
+			429
+		);
+	}
+	await env.USAGE_KV.put( challengeRateLimitKey, String( challengeAttempts + 1 ), {
+		expirationTtl: REGISTRATION_WINDOW_TTL,
+	} );
 
 	const bytes = new Uint8Array( 32 );
 	crypto.getRandomValues( bytes );

--- a/wp-ai-mind-proxy/src/registration.ts
+++ b/wp-ai-mind-proxy/src/registration.ts
@@ -101,9 +101,10 @@ export async function handleRegistration(
 		);
 		if ( record ) {
 			const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+			const startedAt = record.trial_started_at ?? record.created_at;
 			if (
 				record.tier === 'trial' &&
-				Date.now() - record.trial_started_at > THIRTY_DAYS_MS
+				Date.now() - startedAt > THIRTY_DAYS_MS
 			) {
 				const demoted: SiteRecord = { ...record, tier: 'free' };
 				await env.USAGE_KV.put(

--- a/wp-ai-mind-proxy/src/registration.ts
+++ b/wp-ai-mind-proxy/src/registration.ts
@@ -95,16 +95,16 @@ export async function handleRegistration(
 		'/wp-json/wp-ai-mind/v1/activation-verify' +
 		'?challenge=' +
 		encodeURIComponent( challengeToken );
-	let callbackOk = false;
+	let siteVerified = false;
 	try {
 		const cbRes = await fetch( verifyUrl, {
 			signal: AbortSignal.timeout( 10_000 ),
 		} );
-		callbackOk = cbRes.ok;
+		siteVerified = cbRes.ok;
 	} catch {
-		callbackOk = false;
+		siteVerified = false;
 	}
-	if ( ! callbackOk ) {
+	if ( ! siteVerified ) {
 		return jsonResponse( { error: 'Site verification failed' }, 403 );
 	}
 	// Consume the challenge only after a successful callback so a transient

--- a/wp-ai-mind-proxy/src/types.ts
+++ b/wp-ai-mind-proxy/src/types.ts
@@ -19,6 +19,7 @@ export interface SiteRecord {
 	site_url: string;
 	tier: SiteTier;
 	created_at: number;
+	trial_started_at: number;
 	ls_licence_key?: string;
 }
 

--- a/wp-ai-mind-proxy/src/types.ts
+++ b/wp-ai-mind-proxy/src/types.ts
@@ -19,7 +19,7 @@ export interface SiteRecord {
 	site_url: string;
 	tier: SiteTier;
 	created_at: number;
-	trial_started_at: number;
+	trial_started_at?: number;
 	ls_licence_key?: string;
 }
 

--- a/wp-ai-mind-proxy/test/chat-proxy.test.ts
+++ b/wp-ai-mind-proxy/test/chat-proxy.test.ts
@@ -1,9 +1,13 @@
 /// <reference types="@cloudflare/workers-types" />
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import worker from '../src/index';
 import { makeEnv } from './helpers/kv-mock';
 import type { SiteRecord } from '../src/types';
+
+afterEach( () => {
+	vi.restoreAllMocks();
+} );
 
 const TEST_TOKEN =
 	'deadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678';
@@ -12,35 +16,88 @@ const VALID_BODY = JSON.stringify( {
 	messages: [ { role: 'user', content: 'Hello' } ],
 } );
 
-async function makeEnvWithSiteToken( tier: SiteRecord[ 'tier' ] ) {
+async function makeEnvWithSiteToken(
+	tier: SiteRecord[ 'tier' ],
+	trialStartedAt?: number
+) {
 	const env = makeEnv();
 	const record: SiteRecord = {
 		site_url: 'https://example.com',
 		tier,
 		created_at: Date.now(),
+		trial_started_at: trialStartedAt ?? Date.now(),
 	};
 	await env.USAGE_KV.put( `site:${ TEST_TOKEN }`, JSON.stringify( record ) );
 	return env;
 }
 
+function makeChatRequest() {
+	return new Request( 'https://worker.example.com/v1/chat', {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${ TEST_TOKEN }`,
+			'Content-Type': 'application/json',
+		},
+		body: VALID_BODY,
+	} );
+}
+
 describe( 'handleChatProxy', () => {
 	it( 'returns 403 for pro_byok tier', async () => {
 		const env = await makeEnvWithSiteToken( 'pro_byok' );
-		const request = new Request( 'https://worker.example.com/v1/chat', {
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${ TEST_TOKEN }`,
-				'Content-Type': 'application/json',
-			},
-			body: VALID_BODY,
-		} );
-
-		const response = await worker.fetch( request, env );
+		const response = await worker.fetch( makeChatRequest(), env );
 
 		expect( response.status ).toBe( 403 );
 		const json = await response.json();
 		expect( json ).toEqual( {
 			error: 'BYOK tier must call Anthropic directly',
 		} );
+	} );
+
+	it( 'demotes an expired trial to free and stores the updated record', async () => {
+		// trial_started_at is 31 days ago — past the 30-day window.
+		const thirtyOneDaysAgo = Date.now() - 31 * 24 * 60 * 60 * 1000;
+		const env = await makeEnvWithSiteToken( 'trial', thirtyOneDaysAgo );
+
+		// Stub fetch so the Anthropic call returns a rate-limit (429) — the
+		// important thing is that the demote path runs before the upstream call.
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				new Response( JSON.stringify( { error: 'rate limited' } ), {
+					status: 429,
+				} )
+			)
+		);
+
+		await worker.fetch( makeChatRequest(), env );
+
+		// Record in KV must now show tier=free.
+		const updated = await env.USAGE_KV.get< SiteRecord >(
+			`site:${ TEST_TOKEN }`,
+			'json'
+		) as SiteRecord;
+		expect( updated.tier ).toBe( 'free' );
+	} );
+
+	it( 'does not demote an active trial (< 30 days)', async () => {
+		const env = await makeEnvWithSiteToken( 'trial' ); // trial_started_at = now
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				new Response( JSON.stringify( { error: 'rate limited' } ), {
+					status: 429,
+				} )
+			)
+		);
+
+		await worker.fetch( makeChatRequest(), env );
+
+		const record = await env.USAGE_KV.get< SiteRecord >(
+			`site:${ TEST_TOKEN }`,
+			'json'
+		) as SiteRecord;
+		expect( record.tier ).toBe( 'trial' );
 	} );
 } );

--- a/wp-ai-mind-proxy/test/registration.test.ts
+++ b/wp-ai-mind-proxy/test/registration.test.ts
@@ -1,11 +1,30 @@
 /// <reference types="@cloudflare/workers-types" />
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
 	handleRegistration,
+	handleActivationChallenge,
 	REGISTRATION_RATE_LIMIT,
 } from '../src/registration';
 import { makeEnv } from './helpers/kv-mock';
+
+afterEach( () => {
+	vi.restoreAllMocks();
+} );
+
+/** Seed a valid challenge in KV and stub fetch to return 200 for the callback. */
+async function makeEnvWithChallenge(
+	challenge: string,
+	callbackOk = true
+): ReturnType< typeof makeEnv > & Promise< ReturnType< typeof makeEnv > > {
+	const env = makeEnv();
+	await env.USAGE_KV.put( `challenge:${ challenge }`, '1' );
+	vi.stubGlobal(
+		'fetch',
+		vi.fn().mockResolvedValue( new Response( '{}', { status: callbackOk ? 200 : 500 } ) )
+	);
+	return env;
+}
 
 function makeRequest(
 	opts: {
@@ -25,6 +44,34 @@ function makeRequest(
 		},
 	} );
 }
+
+// ── handleActivationChallenge ──────────────────────────────────────────────
+
+describe( 'handleActivationChallenge', () => {
+	it( 'returns 405 for a POST request', async () => {
+		const env = makeEnv();
+		const req = new Request( 'https://worker.example.com/activation-challenge', {
+			method: 'POST',
+		} );
+		const res = await handleActivationChallenge( req, env );
+		expect( res.status ).toBe( 405 );
+	} );
+
+	it( 'returns a 64-char hex challenge and stores it in KV', async () => {
+		const env = makeEnv();
+		const req = new Request( 'https://worker.example.com/activation-challenge', {
+			method: 'GET',
+		} );
+		const res = await handleActivationChallenge( req, env );
+		expect( res.status ).toBe( 200 );
+		const data = ( await res.json() ) as { challenge: string };
+		expect( data.challenge ).toMatch( /^[0-9a-f]{64}$/ );
+		const stored = await env.USAGE_KV.get( `challenge:${ data.challenge }` );
+		expect( stored ).toBe( '1' );
+	} );
+} );
+
+// ── handleRegistration ──────────────────────────────────────────────────────
 
 describe( 'handleRegistration', () => {
 	it( 'returns 405 for a GET request', async () => {
@@ -56,31 +103,160 @@ describe( 'handleRegistration', () => {
 		expect( res.status ).toBe( 400 );
 	} );
 
-	it( 'returns 200/201 and a token for a valid new registration', async () => {
+	it( 'returns 403 when challenge_token is missing', async () => {
 		const env = makeEnv();
 		const res = await handleRegistration(
 			makeRequest( { body: { site_url: 'https://example.com' } } ),
 			env
 		);
-		// spec allows 200 or 201 for new registration
-		expect( [ 200, 201 ] ).toContain( res.status );
+		expect( res.status ).toBe( 403 );
+		const data = ( await res.json() ) as { error: string };
+		expect( data.error ).toMatch( /challenge_token/i );
+	} );
+
+	it( 'returns 403 when challenge_token is not in KV (invalid/expired)', async () => {
+		const env = makeEnv();
+		const res = await handleRegistration(
+			makeRequest( {
+				body: {
+					site_url: 'https://example.com',
+					challenge_token: 'a'.repeat( 64 ),
+				},
+			} ),
+			env
+		);
+		expect( res.status ).toBe( 403 );
+		const data = ( await res.json() ) as { error: string };
+		expect( data.error ).toMatch( /invalid or expired/i );
+	} );
+
+	it( 'returns 403 when the site callback returns non-200', async () => {
+		const challenge = 'b'.repeat( 64 );
+		const env = await makeEnvWithChallenge( challenge, false );
+		const res = await handleRegistration(
+			makeRequest( {
+				body: {
+					site_url: 'https://example.com',
+					challenge_token: challenge,
+				},
+			} ),
+			env
+		);
+		expect( res.status ).toBe( 403 );
+		const data = ( await res.json() ) as { error: string };
+		expect( data.error ).toMatch( /site verification failed/i );
+	} );
+
+	it( 'returns 201 and tier=trial for a valid new registration', async () => {
+		const challenge = 'c'.repeat( 64 );
+		const env = await makeEnvWithChallenge( challenge );
+		const res = await handleRegistration(
+			makeRequest( {
+				body: {
+					site_url: 'https://example.com',
+					challenge_token: challenge,
+				},
+			} ),
+			env
+		);
+		expect( res.status ).toBe( 201 );
 		const data = ( await res.json() ) as { token: string; tier: string };
 		expect( typeof data.token ).toBe( 'string' );
 		expect( data.token.length ).toBeGreaterThan( 0 );
-		expect( data.tier ).toBe( 'free' );
+		expect( data.tier ).toBe( 'trial' );
+	} );
+
+	it( 'consumes the challenge (single-use)', async () => {
+		const challenge = 'd'.repeat( 64 );
+		const env = await makeEnvWithChallenge( challenge );
+
+		await handleRegistration(
+			makeRequest( {
+				body: {
+					site_url: 'https://used-once.example.com',
+					challenge_token: challenge,
+				},
+			} ),
+			env
+		);
+
+		// Second attempt with same challenge token must fail.
+		vi.restoreAllMocks();
+		const res2 = await handleRegistration(
+			makeRequest( {
+				body: {
+					site_url: 'https://used-once.example.com',
+					challenge_token: challenge,
+				},
+			} ),
+			env
+		);
+		expect( res2.status ).toBe( 403 );
 	} );
 
 	it( 're-registering the same URL returns the same token (idempotent)', async () => {
-		const env = makeEnv();
+		const challenge1 = 'e'.repeat( 64 );
+		const env = await makeEnvWithChallenge( challenge1 );
 		const body = { site_url: 'https://idempotent-site.example.com' };
 
-		const res1 = await handleRegistration( makeRequest( { body } ), env );
+		const res1 = await handleRegistration(
+			makeRequest( { body: { ...body, challenge_token: challenge1 } } ),
+			env
+		);
 		const data1 = ( await res1.json() ) as { token: string };
 
-		const res2 = await handleRegistration( makeRequest( { body } ), env );
+		// Seed a second challenge for the second call.
+		const challenge2 = 'f'.repeat( 64 );
+		await env.USAGE_KV.put( `challenge:${ challenge2 }`, '1' );
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue( new Response( '{}', { status: 200 } ) )
+		);
+
+		const res2 = await handleRegistration(
+			makeRequest( { body: { ...body, challenge_token: challenge2 } } ),
+			env
+		);
 		const data2 = ( await res2.json() ) as { token: string };
 
 		expect( data1.token ).toBe( data2.token );
+	} );
+
+	it( 'idempotent re-registration of an expired trial returns tier=free', async () => {
+		const challenge1 = '1'.repeat( 64 );
+		const env = await makeEnvWithChallenge( challenge1 );
+		const siteUrl = 'https://expired-trial.example.com';
+
+		// Initial registration — creates trial record.
+		const res1 = await handleRegistration(
+			makeRequest( { body: { site_url: siteUrl, challenge_token: challenge1 } } ),
+			env
+		);
+		const { token } = ( await res1.json() ) as { token: string };
+
+		// Backdate trial_started_at by 31 days.
+		const stored = await env.USAGE_KV.get< import('../src/types').SiteRecord >(
+			`site:${ token }`,
+			'json'
+		) as import('../src/types').SiteRecord;
+		const expired = { ...stored, trial_started_at: Date.now() - 31 * 24 * 60 * 60 * 1000 };
+		await env.USAGE_KV.put( `site:${ token }`, JSON.stringify( expired ) );
+
+		// Re-register — must come back as free.
+		const challenge2 = '2'.repeat( 64 );
+		await env.USAGE_KV.put( `challenge:${ challenge2 }`, '1' );
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue( new Response( '{}', { status: 200 } ) )
+		);
+
+		const res2 = await handleRegistration(
+			makeRequest( { body: { site_url: siteUrl, challenge_token: challenge2 } } ),
+			env
+		);
+		const data2 = ( await res2.json() ) as { token: string; tier: string };
+		expect( data2.token ).toBe( token );
+		expect( data2.tier ).toBe( 'free' );
 	} );
 
 	it( 'returns 429 when IP exceeds the registration rate limit', async () => {
@@ -88,18 +264,37 @@ describe( 'handleRegistration', () => {
 		const ip = '203.0.113.42';
 
 		for ( let i = 1; i <= REGISTRATION_RATE_LIMIT; i++ ) {
+			const ch = String( i ).padStart( 2, '0' ).repeat( 32 );
+			await env.USAGE_KV.put( `challenge:${ ch }`, '1' );
+			vi.stubGlobal(
+				'fetch',
+				vi.fn().mockResolvedValue( new Response( '{}', { status: 200 } ) )
+			);
 			await handleRegistration(
 				makeRequest( {
-					body: { site_url: `https://site${ i }.example.com` },
+					body: {
+						site_url: `https://site${ i }.example.com`,
+						challenge_token: ch,
+					},
 					headers: { 'CF-Connecting-IP': ip },
 				} ),
 				env
 			);
 		}
 
+		const chExtra = '99'.repeat( 32 );
+		await env.USAGE_KV.put( `challenge:${ chExtra }`, '1' );
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue( new Response( '{}', { status: 200 } ) )
+		);
+
 		const res = await handleRegistration(
 			makeRequest( {
-				body: { site_url: 'https://site6.example.com' },
+				body: {
+					site_url: 'https://site6.example.com',
+					challenge_token: chExtra,
+				},
 				headers: { 'CF-Connecting-IP': ip },
 			} ),
 			env

--- a/wp-ai-mind-proxy/test/registration.test.ts
+++ b/wp-ai-mind-proxy/test/registration.test.ts
@@ -16,7 +16,7 @@ afterEach( () => {
 async function makeEnvWithChallenge(
 	challenge: string,
 	callbackOk = true
-): ReturnType< typeof makeEnv > & Promise< ReturnType< typeof makeEnv > > {
+): Promise< ReturnType< typeof makeEnv > > {
 	const env = makeEnv();
 	await env.USAGE_KV.put( `challenge:${ challenge }`, '1' );
 	vi.stubGlobal(


### PR DESCRIPTION
## Summary

- **Registration challenge**: The `/register` endpoint now requires a single-use 64-char hex challenge token. The worker issues it via `GET /activation-challenge`, stores it in KV (5-min TTL), then calls back to the site's `GET /wp-ai-mind/v1/activation-verify?challenge=…` before accepting the registration. Raw HTTP clients without the plugin cannot respond to the callback and are rejected with 403.
- **Trial → free lazy expiry**: After 30 days, chat requests against a `trial` token silently downgrade `effectiveTier` to `free` (free-tier rate limits apply, no error returned to the user). The KV record is updated in-place. Re-registering an expired trial site also returns `tier: 'free'` via the idempotency path.
- New `ActivationVerifyRestController` (`GET /wp-ai-mind/v1/activation-verify`) — no authentication required, called by the worker only.
- `NJ_Site_Registration::register()` updated to the two-step challenge handshake (fetch challenge → store transient → POST /register with `challenge_token`).

## Test plan

- [ ] Worker vitest suite: 38 tests pass (`npx vitest run` in `wp-ai-mind-proxy/`)
- [ ] PHP unit suite: 242 tests pass (`./vendor/bin/phpunit tests/Unit/`)
- [ ] Manual: deactivate/reactivate plugin on local Docker — registration completes via challenge flow (check WP debug log)
- [ ] Manual: `curl -X POST {worker}/register -d '{"site_url":"https://example.com"}'` → 403 (no challenge token)
- [ ] Manual: same with forged challenge → 403 (not in KV)
- [ ] Manual: backdate `trial_started_at` by 31 days in KV → chat request succeeds, record shows `tier: 'free'`

https://claude.ai/code/session_012sA15EJaybTChS9CB9bwBE

---
_Generated by [Claude Code](https://claude.ai/code/session_012sA15EJaybTChS9CB9bwBE)_