### PR TITLE
chore(wporg): wordpress.org submission readiness fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+GNU GENERAL PUBLIC LICENSE
+Version 2, June 1991
+
+This plugin is licensed under the GNU General Public License v2 or later.
+Full license text: https://www.gnu.org/licenses/gpl-2.0.html
+
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,338 @@
-GNU GENERAL PUBLIC LICENSE
-Version 2, June 1991
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
-This plugin is licensed under the GNU General Public License v2 or later.
-Full license text: https://www.gnu.org/licenses/gpl-2.0.html
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-SPDX-License-Identifier: GPL-2.0-or-later
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/includes/Admin/ActivationNotice.php
+++ b/includes/Admin/ActivationNotice.php
@@ -59,12 +59,12 @@ class ActivationNotice {
 		?>
 		<div class="notice notice-info is-dismissible">
 			<p>
-				<strong><?php \esc_html_e( 'WP AI Mind is almost ready!', 'wp-ai-mind' ); ?></strong>
+				<strong><?php \esc_html_e( 'WP AI Mind — External Services & Privacy Notice', 'wp-ai-mind' ); ?></strong>
 			</p>
 			<p>
 				<?php
 				\esc_html_e(
-					'To power the free AI chat, the plugin connects to a secure relay service. Only your site address is shared during setup — no content leaves your site until you start a conversation. Your messages are then forwarded to the AI provider on your behalf.',
+					'This plugin connects to a secure relay service (WP AI Mind proxy) and to third-party AI providers (Anthropic Claude, OpenAI, Google Gemini). Only your site address is shared during setup — no content leaves your site until you start a conversation. Your messages are then forwarded to the AI provider on your behalf.',
 					'wp-ai-mind'
 				);
 				?>

--- a/includes/Admin/ActivationNotice.php
+++ b/includes/Admin/ActivationNotice.php
@@ -9,13 +9,20 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Admin;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Displays a one-time admin notice after plugin activation disclosing
- * that the plugin transmits data to third-party AI services.
+ * that the plugin connects to the WP AI Mind proxy service and to
+ * third-party AI providers.
  *
  * Uses the wp_ai_mind_just_activated option as a single-use flag.
  * The option is deleted before rendering so it cannot be displayed twice,
  * even if the page is reloaded.
+ *
+ * @since 1.0.0
  */
 class ActivationNotice {
 
@@ -23,6 +30,9 @@ class ActivationNotice {
 
 	/**
 	 * Register the admin_notices hook.
+	 *
+	 * @since 1.0.0
+	 * @return void
 	 */
 	public static function register(): void {
 		\add_action( 'admin_notices', [ self::class, 'maybe_display' ] );
@@ -31,6 +41,9 @@ class ActivationNotice {
 	/**
 	 * Display the notice if the activation flag is set and the current user
 	 * has manage_options capability. Deletes the flag before rendering.
+	 *
+	 * @since 1.0.0
+	 * @return void
 	 */
 	public static function maybe_display(): void {
 		if ( ! \get_option( self::OPTION ) ) {
@@ -41,16 +54,25 @@ class ActivationNotice {
 		}
 		// Delete before rendering — single-use flag, prevents re-display on reload.
 		\delete_option( self::OPTION );
+
+		$learn_more_url = 'https://wpaimind.com/privacy-policy';
 		?>
 		<div class="notice notice-info is-dismissible">
 			<p>
-				<strong><?php \esc_html_e( 'WP AI Mind — External Services Notice', 'wp-ai-mind' ); ?></strong>
+				<strong><?php \esc_html_e( 'WP AI Mind is almost ready!', 'wp-ai-mind' ); ?></strong>
 			</p>
 			<p>
 				<?php
 				\esc_html_e(
-					'WP AI Mind sends the content you submit to third-party AI providers (OpenAI, Anthropic Claude, Google Gemini, Ollama). Your data is governed by each provider\'s privacy policy. Configure your active provider under WP AI Mind → Settings.',
+					'To power the free AI chat, the plugin connects to a secure relay service. Only your site address is shared during setup — no content leaves your site until you start a conversation. Your messages are then forwarded to the AI provider on your behalf.',
 					'wp-ai-mind'
+				);
+				?>
+				<?php
+				printf(
+					' <a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+					\esc_url( $learn_more_url ),
+					\esc_html__( 'Learn more', 'wp-ai-mind' )
 				);
 				?>
 			</p>

--- a/includes/Admin/ActivationNotice.php
+++ b/includes/Admin/ActivationNotice.php
@@ -26,7 +26,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class ActivationNotice {
 
-	private const OPTION = 'wp_ai_mind_just_activated';
+	private const OPTION         = 'wp_ai_mind_just_activated';
+	private const LEARN_MORE_URL = 'https://wpaimind.com/privacy-policy';
 
 	/**
 	 * Register the admin_notices hook.
@@ -55,7 +56,6 @@ class ActivationNotice {
 		// Delete before rendering — single-use flag, prevents re-display on reload.
 		\delete_option( self::OPTION );
 
-		$learn_more_url = 'https://wpaimind.com/privacy-policy';
 		?>
 		<div class="notice notice-info is-dismissible">
 			<p>
@@ -72,7 +72,7 @@ class ActivationNotice {
 				echo wp_kses(
 					sprintf(
 						' <a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
-						\esc_url( $learn_more_url ),
+						\esc_url( self::LEARN_MORE_URL ),
 						\esc_html__( 'Learn more', 'wp-ai-mind' )
 					),
 					[

--- a/includes/Admin/ActivationNotice.php
+++ b/includes/Admin/ActivationNotice.php
@@ -69,10 +69,19 @@ class ActivationNotice {
 				);
 				?>
 				<?php
-				printf(
-					' <a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
-					\esc_url( $learn_more_url ),
-					\esc_html__( 'Learn more', 'wp-ai-mind' )
+				echo wp_kses(
+					sprintf(
+						' <a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+						\esc_url( $learn_more_url ),
+						\esc_html__( 'Learn more', 'wp-ai-mind' )
+					),
+					[
+						'a' => [
+							'href'   => true,
+							'target' => true,
+							'rel'    => true,
+						],
+					]
 				);
 				?>
 			</p>

--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Admin;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Registers the top-level WP AI Mind admin menu and all sub-menu pages.
  *

--- a/includes/Admin/ChatPage.php
+++ b/includes/Admin/ChatPage.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Admin;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Providers\ProviderFactory;
 use WP_AI_Mind\Settings\ProviderSettings;
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;

--- a/includes/Admin/DashboardPage.php
+++ b/includes/Admin/DashboardPage.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Admin;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Settings\ProviderSettings;
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 use WP_AI_Mind\Tiers\NJ_Usage_Tracker;

--- a/includes/Admin/GeneratorPage.php
+++ b/includes/Admin/GeneratorPage.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Admin;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 
 /**

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Admin;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 
 /**

--- a/includes/Admin/UsagePage.php
+++ b/includes/Admin/UsagePage.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Admin;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Renders the WP AI Mind usage & cost admin page.
  *

--- a/includes/Core/Autoloader.php
+++ b/includes/Core/Autoloader.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Core;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * PSR-4 autoloader for the WP_AI_Mind namespace.
  *

--- a/includes/Core/ModuleRegistry.php
+++ b/includes/Core/ModuleRegistry.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Core;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Registry that tracks enabled/disabled state for all AI modules.
  *

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Core;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\DB\Schema;
 use WP_AI_Mind\Proxy\NJ_Site_Registration;
 

--- a/includes/DB/ConversationStore.php
+++ b/includes/DB/ConversationStore.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\DB;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Data-access layer for conversations and their messages.
  *

--- a/includes/DB/Schema.php
+++ b/includes/DB/Schema.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\DB;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Manages the plugin's custom database tables.
  *

--- a/includes/Modules/Chat/ChatModule.php
+++ b/includes/Modules/Chat/ChatModule.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Modules\Chat;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Tools\ToolRegistry;
 use WP_AI_Mind\Tools\ToolExecutor;
 

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Modules\Chat;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\DB\ConversationStore;
 use WP_AI_Mind\Providers\ProviderFactory;
 use WP_AI_Mind\Providers\CompletionRequest;

--- a/includes/Modules/Chat/SettingsRestController.php
+++ b/includes/Modules/Chat/SettingsRestController.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Modules\Chat;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Settings\ProviderSettings;
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 

--- a/includes/Modules/Editor/EditorModule.php
+++ b/includes/Modules/Editor/EditorModule.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Modules\Editor;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 
 /**

--- a/includes/Modules/Frontend/FrontendWidgetModule.php
+++ b/includes/Modules/Frontend/FrontendWidgetModule.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Modules\Frontend;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 
 /**

--- a/includes/Modules/Generator/GeneratorModule.php
+++ b/includes/Modules/Generator/GeneratorModule.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Modules\Generator;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 use WP_AI_Mind\Tiers\NJ_Usage_Tracker;
 

--- a/includes/Modules/Images/ImagesModule.php
+++ b/includes/Modules/Images/ImagesModule.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Modules\Images;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Providers\ProviderFactory;
 use WP_AI_Mind\Providers\ProviderException;
 use WP_AI_Mind\Settings\ProviderSettings;

--- a/includes/Modules/Seo/SeoModule.php
+++ b/includes/Modules/Seo/SeoModule.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Modules\Seo;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Providers\ProviderFactory;
 use WP_AI_Mind\Providers\CompletionRequest;
 use WP_AI_Mind\Providers\ProviderException;

--- a/includes/Modules/Usage/UsageModule.php
+++ b/includes/Modules/Usage/UsageModule.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Modules\Usage;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;
 use WP_AI_Mind\Tiers\NJ_Usage_Tracker;
 

--- a/includes/Providers/AbstractProvider.php
+++ b/includes/Providers/AbstractProvider.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Tiers\NJ_Usage_Tracker;
 
 /**

--- a/includes/Providers/ClaudeProvider.php
+++ b/includes/Providers/ClaudeProvider.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Proxy\NJ_Proxy_Client;
 use WP_AI_Mind\Proxy\NJ_Site_Registration;
 use WP_AI_Mind\Tiers\NJ_Tier_Manager;

--- a/includes/Providers/CompletionRequest.php
+++ b/includes/Providers/CompletionRequest.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Captures all parameters required to make an AI completion request.
  *

--- a/includes/Providers/CompletionResponse.php
+++ b/includes/Providers/CompletionResponse.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Captures content, token counts, cost, and optional tool-call data from a provider response.
  *

--- a/includes/Providers/GeminiProvider.php
+++ b/includes/Providers/GeminiProvider.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Handles completions, streaming, and image generation for Google Gemini models.
  *

--- a/includes/Providers/OllamaProvider.php
+++ b/includes/Providers/OllamaProvider.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Handles completions via a local Ollama instance.
  *

--- a/includes/Providers/OpenAIProvider.php
+++ b/includes/Providers/OpenAIProvider.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Handles completions, streaming, and image generation for OpenAI models.
  *

--- a/includes/Providers/ProviderException.php
+++ b/includes/Providers/ProviderException.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Carries HTTP status, provider slug, and raw response alongside the error message.
  *

--- a/includes/Providers/ProviderFactory.php
+++ b/includes/Providers/ProviderFactory.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use WP_AI_Mind\Settings\ProviderSettings;
 
 /**

--- a/includes/Providers/ProviderInterface.php
+++ b/includes/Providers/ProviderInterface.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 interface ProviderInterface {
 
 	/**

--- a/includes/Settings/ProviderSettings.php
+++ b/includes/Settings/ProviderSettings.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Settings;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Stores and retrieves encrypted API keys for AI providers.
  *

--- a/includes/Tools/ToolDefinition.php
+++ b/includes/Tools/ToolDefinition.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Tools;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Immutable value object describing a single AI tool.
  */

--- a/includes/Tools/ToolExecutor.php
+++ b/includes/Tools/ToolExecutor.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Tools;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Executes tool calls on behalf of an authenticated user.
  *

--- a/includes/Tools/ToolRegistry.php
+++ b/includes/Tools/ToolRegistry.php
@@ -9,6 +9,10 @@ declare( strict_types=1 );
 
 namespace WP_AI_Mind\Tools;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Registers all available tools and formats them for each AI provider's wire format.
  */

--- a/includes/Voice/VoiceInjector.php
+++ b/includes/Voice/VoiceInjector.php
@@ -8,6 +8,10 @@
 declare( strict_types=1 );
 namespace WP_AI_Mind\Voice;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Builds AI system prompts by merging site-wide and per-user voice preferences.
  *

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === WP AI Mind ===
 Contributors: njohansson
-Tags: ai, content, seo, chatbot, openai, claude, gemini
+Tags: ai, chatbot, openai, claude, content
 Requires at least: 6.4
 Tested up to: 6.8
 Stable tag: 1.7.1
@@ -23,6 +23,13 @@ into your WordPress dashboard, giving you AI assistance without leaving the edit
 * **Frontend widget** — Embeddable chat widget via `[wp_ai_mind_chat]` shortcode
 * **Gutenberg integration** — Direct editor sidebar tools
 
+**Free vs Pro:**
+
+* **Free** — Chat assistant (50,000 tokens/month via WP AI Mind proxy, Claude only)
+* **Trial** — All features for 30 days (300,000 tokens/month via proxy)
+* **Pro Managed** — All features, 2,000,000 tokens/month via proxy
+* **Pro BYOK** — All features, unlimited tokens, your own API key sent direct to provider
+
 **Supported AI providers:** Anthropic Claude, OpenAI (GPT-4+), Google Gemini, Ollama (local/self-hosted)
 
 **External services:** This plugin sends content you submit to the AI provider of your choice
@@ -33,6 +40,10 @@ chosen provider. Review each provider's privacy policy and terms of service befo
 * OpenAI: https://openai.com/policies/privacy-policy
 * Google Gemini: https://policies.google.com/privacy
 * Ollama is self-hosted; no external transmission occurs when using Ollama.
+* **WP AI Mind Proxy** (`https://wp-ai-mind-proxy.wp-ai-mind.workers.dev`): Free and managed-pro
+  tiers route chat requests through this Cloudflare Worker service. The service receives your
+  site URL (for registration) and the chat messages you send. No messages are stored by the
+  proxy beyond the in-flight API call. See: https://wpaimind.com/privacy-policy
 
 == Installation ==
 
@@ -50,8 +61,13 @@ one or more providers and switch between them in the settings.
 
 = Does this plugin store my API keys securely? =
 
-API keys are stored in the WordPress database (wp_options). They are never transmitted to
-any server other than the AI provider you have chosen.
+**Free / Trial / Pro Managed tiers:** No API key is required — chat requests are routed
+through the WP AI Mind proxy (see External services above). Your messages are transmitted
+to that proxy, which forwards them to Claude (Anthropic) on your behalf.
+
+**Pro BYOK tier:** Your own API key is stored encrypted (AES-256-CBC) in the WordPress
+database and is transmitted directly to the AI provider you have chosen. It is never sent
+to any other server.
 
 = Is this plugin GDPR-compliant? =
 
@@ -67,6 +83,65 @@ content generation tools. Site settings require `manage_options` (Administrators
 
 == Changelog ==
 
+= 1.7.1 =
+* Fix chat post content not being read and add post-attach guard for quick actions.
+
+= 1.7.0 =
+* Chat layout improvements: collapsible sidebar, height fix, and title tooltips.
+
+= 1.6.0 =
+* Centre chat input and add suggestion chips on launch.
+
+= 1.5.0 =
+* Add generate_seo_meta tool for chat SEO optimisation.
+
+= 1.4.0 =
+* Fold usage widget into Dashboard and show percentage display.
+
+= 1.3.6 =
+* Fix context_post_id not being passed when sending messages from MiniChat in the editor.
+
+= 1.3.5 =
+* Sanitise conversation titles explicitly and remove unreachable database-error branch.
+
+= 1.3.4 =
+* Fix default provider selection, conversation title update, and inline delete errors.
+
+= 1.3.3 =
+* Add pro_byok guard in proxy Worker and clarify 401 error message.
+
+= 1.3.2 =
+* Prevent infinite loop in maybe_demote_expired_trials().
+
+= 1.3.1 =
+* Fix CI to push and close each auto-fix issue immediately after fixing.
+
+= 1.3.0 =
+* Batch auto-fix: one Claude session per PR, remove max-turns limits.
+
+= 1.2.1 =
+* Restore isPro field — revert erroneous canChat rename in settings.
+
+= 1.2.0 =
+* Consolidate PR review nits into a single issue per PR in the automated workflow.
+
+= 1.1.0 =
+* Add delete conversation with confirmation dialog and inline error state.
+
+= 1.0.3 =
+* Add @wordpress/element to devDependencies alongside peerDependencies.
+
+= 1.0.2 =
+* Return full conversation object on create; return HTTP 500 on DB failure.
+
+= 1.0.1 =
+* Guard putenv cleanup with try/finally in test suite.
+
+= 1.0.0 =
+* Full initial stable release: chat REST API, React UI, Gutenberg sidebar, SEO and Images pages.
+* Encrypted API key storage, provider abstraction (Claude, OpenAI, Gemini, Ollama), tool-calling loop.
+* Frontend chat widget shortcode, content generator wizard, and usage dashboard.
+
 = 0.2.0 =
 * Repo extraction, CI/CD pipeline, release workflow, and build script fix.
 
@@ -74,6 +149,9 @@ content generation tools. Site settings require `manage_options` (Administrators
 * Initial release.
 
 == Upgrade Notice ==
+
+= 1.7.1 =
+No breaking changes. Update safely.
 
 = 0.1.0 =
 Initial release. No upgrade steps required.

--- a/readme.txt
+++ b/readme.txt
@@ -49,7 +49,7 @@ chosen provider. Review each provider's privacy policy and terms of service befo
 
 1. Upload the `wp-ai-mind` folder to the `/wp-content/plugins/` directory.
 2. Activate the plugin through the **Plugins** menu in WordPress.
-3. Navigate to **WP AI Mind → Settings** and enter an API key for your chosen AI provider.
+3. (Optional — Pro BYOK only) Navigate to **WP AI Mind → Settings** and enter your own API key. Free and managed-plan users do not need an API key.
 4. Start using the Chat, Generator, or Usage modules from the admin menu.
 
 == Frequently Asked Questions ==

--- a/readme.txt
+++ b/readme.txt
@@ -71,9 +71,11 @@ to any other server.
 
 = Is this plugin GDPR-compliant? =
 
-The plugin transmits content you submit to the AI provider you have configured. You are
-responsible for ensuring that transmission is compliant with your applicable data protection
-regulations. Consider adding your chosen provider's data processing agreement to your
+The plugin transmits content you submit to the WP AI Mind proxy service and/or the AI
+provider you have configured (Anthropic Claude, OpenAI, Google Gemini). Both the proxy and
+the AI provider receive your chat messages. You are responsible for ensuring that
+transmission is compliant with your applicable data protection regulations. Consider adding
+the WP AI Mind privacy policy and your chosen provider's data processing agreement to your
 privacy documentation.
 
 = What WordPress roles can use the AI features? =


### PR DESCRIPTION
## Summary

Addresses all blockers and important items identified in the WordPress.org submission readiness review.

- **ABSPATH guards** added to all 36 PHP class files in `includes/` that were missing them (previously only entry-point files had them)
- **`readme.txt`** comprehensively updated: tags trimmed to 5, Free vs Pro tier table added, Cloudflare Worker proxy disclosed in External Services, misleading API key FAQ corrected, changelog populated from v1.0.0 → v1.7.1, upgrade notice added
- **`ActivationNotice.php`** rewritten with user-friendly proxy disclosure (plain English, links to `wpaimind.com/privacy-policy`)
- **`LICENSE`** file added (GPL-2.0-or-later)
- **GitHub issue #466** created to track creation of the `wpaimind.com/privacy-policy` page (required before submission)

## What still needs doing before WP.org submission

| Item | Status |
|------|--------|
| `wpaimind.com/privacy-policy` page live | ⏳ Tracked in #466 |
| Screenshots (`screenshot-1.png`, `screenshot-2.png`) in `wp-org-assets/` | ⏳ Manual — capture from localhost:8080 |
| Confirm `WPORG_USERNAME` / `WPORG_PASSWORD` secrets in GitHub repo settings | ⏳ Manual |
| Verify WordPress 6.8 tested-up-to claim against Docker environment | ⏳ Manual |

## Test plan

- [ ] `./vendor/bin/phpcs --standard=phpcs.xml.dist` — 0 errors
- [ ] `./vendor/bin/phpunit tests/Unit/ --colors=always` — all green
- [ ] Activate plugin on local Docker; confirm the activation notice appears with proxy disclosure and "Learn more" link
- [ ] Notice does not reappear on page reload

https://claude.ai/code/session_01FnRdy63jdawAHARNEWhz8v

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnRdy63jdawAHARNEWhz8v)_