### PR TITLE
fix(chat): forward tools through proxy for free/trial/pro_managed tiers

### DIFF
--- a/includes/Providers/ClaudeProvider.php
+++ b/includes/Providers/ClaudeProvider.php
@@ -165,17 +165,18 @@ class ClaudeProvider extends AbstractProvider {
 	 * @throws ProviderException When the proxy returns a WP_Error.
 	 */
 	private function complete_via_proxy( CompletionRequest $request ): CompletionResponse {
-		$result = NJ_Proxy_Client::chat(
-			$request->messages,
-			array_filter(
-				[
-					'model'      => ! empty( $request->model ) ? $request->model : null,
-					'max_tokens' => $request->max_tokens,
-					'system'     => '' !== $request->system ? $request->system : null,
-				],
-				fn( $v ) => null !== $v
-			)
+		$options = array_filter(
+			[
+				'model'      => ! empty( $request->model ) ? $request->model : null,
+				'max_tokens' => $request->max_tokens,
+				'system'     => '' !== $request->system ? $request->system : null,
+			],
+			fn( $v ) => null !== $v
 		);
+		if ( ! empty( $request->tools ) ) {
+			$options['tools'] = $request->tools;
+		}
+		$result = NJ_Proxy_Client::chat( $request->messages, $options );
 
 		if ( is_wp_error( $result ) ) {
 			throw new ProviderException( $result->get_error_message(), 'claude' ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped

--- a/includes/Providers/ClaudeProvider.php
+++ b/includes/Providers/ClaudeProvider.php
@@ -165,14 +165,12 @@ class ClaudeProvider extends AbstractProvider {
 	 * @throws ProviderException When the proxy returns a WP_Error.
 	 */
 	private function complete_via_proxy( CompletionRequest $request ): CompletionResponse {
-		$options = array_filter(
-			[
-				'model'      => ! empty( $request->model ) ? $request->model : null,
-				'max_tokens' => $request->max_tokens,
-				'system'     => '' !== $request->system ? $request->system : null,
-			],
-			fn( $v ) => null !== $v
-		);
+		$raw_options = [
+			'model'      => ! empty( $request->model ) ? $request->model : null,
+			'max_tokens' => $request->max_tokens,
+			'system'     => '' !== $request->system ? $request->system : null,
+		];
+		$options     = array_filter( $raw_options, fn( $v ) => null !== $v );
 		if ( ! empty( $request->tools ) ) {
 			$options['tools'] = $request->tools;
 		}

--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -31,7 +31,7 @@ class NJ_Proxy_Client {
 	 * Send a chat request through the Cloudflare proxy.
 	 *
 	 * @param array<array{role: string, content: string}> $messages Chat message history.
-	 * @param array<string, mixed>                        $options  Supports 'model', 'max_tokens', 'system'.
+	 * @param array<string, mixed>                        $options  Supports 'model', 'max_tokens', 'system', 'tools'.
 	 * @return array<string, mixed>|WP_Error
 	 */
 	public static function chat( array $messages, array $options = [] ): array|WP_Error {
@@ -59,6 +59,9 @@ class NJ_Proxy_Client {
 		}
 		if ( isset( $options['system'] ) ) {
 			$payload['system'] = $options['system'];
+		}
+		if ( ! empty( $options['tools'] ) ) {
+			$payload['tools'] = $options['tools'];
 		}
 
 		$body_json = wp_json_encode( $payload );

--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -30,6 +30,7 @@ class NJ_Proxy_Client {
 	/**
 	 * Send a chat request through the Cloudflare proxy.
 	 *
+	 * @since 1.2.0
 	 * @param array<array{role: string, content: string}> $messages Chat message history.
 	 * @param array<string, mixed>                        $options  Supports 'model', 'max_tokens', 'system', 'tools'.
 	 * @return array<string, mixed>|WP_Error

--- a/tests/Unit/Providers/ClaudeProviderTest.php
+++ b/tests/Unit/Providers/ClaudeProviderTest.php
@@ -232,6 +232,58 @@ class ClaudeProviderTest extends TestCase {
 		$this->assertSame( 'Direct API response', $response->content );
 	}
 
+	public function test_complete_via_proxy_forwards_tools(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		// 'free' for NJ_Tier_Manager::get_user_tier(); cast to int 0 for usage key → within limit.
+		Functions\when( 'get_user_meta' )->justReturn( 'free' );
+		// NJ_Site_Registration::get_site_token() reads this option.
+		Functions\when( 'get_option' )->justReturn( 'mock-site-token' );
+		Functions\when( 'sanitize_key' )->alias( fn( $v ) => $v );
+		Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+		Functions\stubs( [ '__' => fn( $str ) => $str ] );
+
+		global $wpdb;
+		$wpdb = new class extends \stdClass {
+			public string $usermeta      = 'wp_usermeta';
+			public int    $rows_affected = 1;
+			public string $prefix        = 'wpaim_';
+			public function prepare( string $sql, ...$args ): string { return $sql; }
+			public function query( string $sql ): int { return 1; }
+			public function insert(): int { return 1; }
+		};
+
+		$captured_body = null;
+		Functions\when( 'wp_remote_post' )->alias( function ( $url, $args ) use ( &$captured_body ) {
+			$captured_body = json_decode( $args['body'], true );
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [
+					'content' => [ [ 'type' => 'text', 'text' => 'Here is a summary.' ] ],
+					'model'   => 'claude-haiku-4-5-20251001',
+					'usage'   => [ 'input_tokens' => 50, 'output_tokens' => 20 ],
+				] ),
+			];
+		} );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->alias( fn( $r ) => $r['body'] );
+		Functions\when( 'is_wp_error' )->alias( fn( $v ) => $v instanceof \WP_Error );
+		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+
+		$tools    = [ [ 'name' => 'get_post_content', 'description' => 'Get post content.', 'input_schema' => [ 'type' => 'object', 'properties' => [ 'post_id' => [ 'type' => 'integer' ] ], 'required' => [ 'post_id' ] ] ] ];
+		$provider = new ClaudeProvider( '' ); // No API key — routes via proxy.
+		$request  = new CompletionRequest(
+			messages: [ [ 'role' => 'user', 'content' => 'Summarise post 140' ] ],
+			system:   'You MUST call get_post_content with post_id=140.',
+			tools:    $tools,
+		);
+
+		$provider->complete( $request );
+
+		$this->assertNotNull( $captured_body );
+		$this->assertArrayHasKey( 'tools', $captured_body );
+		$this->assertSame( 'get_post_content', $captured_body['tools'][0]['name'] );
+	}
+
 	public function test_tools_injected_in_request_body(): void {
 		$captured_body = null;
 		Functions\when( 'wp_remote_post' )->alias( function( $url, $args ) use ( &$captured_body ) {

--- a/tests/Unit/Providers/ClaudeProviderTest.php
+++ b/tests/Unit/Providers/ClaudeProviderTest.php
@@ -233,24 +233,13 @@ class ClaudeProviderTest extends TestCase {
 	}
 
 	public function test_complete_via_proxy_forwards_tools(): void {
-		Functions\when( 'get_current_user_id' )->justReturn( 1 );
-		// 'free' for NJ_Tier_Manager::get_user_tier(); cast to int 0 for usage key → within limit.
+		// Sets up $wpdb, get_current_user_id, sanitize_key, sanitize_text_field (defaults get_user_meta to 'pro_byok').
+		$this->mock_wpdb();
+		// Override to 'free' so routing goes via proxy instead of direct.
 		Functions\when( 'get_user_meta' )->justReturn( 'free' );
 		// NJ_Site_Registration::get_site_token() reads this option.
 		Functions\when( 'get_option' )->justReturn( 'mock-site-token' );
-		Functions\when( 'sanitize_key' )->alias( fn( $v ) => $v );
-		Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
 		Functions\stubs( [ '__' => fn( $str ) => $str ] );
-
-		global $wpdb;
-		$wpdb = new class extends \stdClass {
-			public string $usermeta      = 'wp_usermeta';
-			public int    $rows_affected = 1;
-			public string $prefix        = 'wpaim_';
-			public function prepare( string $sql, ...$args ): string { return $sql; }
-			public function query( string $sql ): int { return 1; }
-			public function insert(): int { return 1; }
-		};
 
 		$captured_body = null;
 		Functions\when( 'wp_remote_post' )->alias( function ( $url, $args ) use ( &$captured_body ) {
@@ -282,6 +271,7 @@ class ClaudeProviderTest extends TestCase {
 		$this->assertNotNull( $captured_body );
 		$this->assertArrayHasKey( 'tools', $captured_body );
 		$this->assertSame( 'get_post_content', $captured_body['tools'][0]['name'] );
+		$this->assertSame( $tools, $captured_body['tools'] );
 	}
 
 	public function test_tools_injected_in_request_body(): void {

--- a/wp-ai-mind-proxy/src/index.ts
+++ b/wp-ai-mind-proxy/src/index.ts
@@ -61,7 +61,7 @@ async function handleChatProxy(
 		}
 
 		const body = JSON.parse( bodyText ) as ProxyRequest;
-		const { messages, model, max_tokens: maxTokens, system } = body;
+		const { messages, model, max_tokens: maxTokens, system, tools } = body;
 		const { site_token: siteToken, tier } = auth;
 
 		// BYOK sites call Anthropic directly via ClaudeProvider and must never reach here.
@@ -112,6 +112,9 @@ async function handleChatProxy(
 		};
 		if ( system ) {
 			anthropicBody.system = system;
+		}
+		if ( tools && tools.length > 0 ) {
+			anthropicBody.tools = tools;
 		}
 
 		const anthropicResponse = await fetch(

--- a/wp-ai-mind-proxy/src/types.ts
+++ b/wp-ai-mind-proxy/src/types.ts
@@ -29,11 +29,22 @@ export interface LicenceRecord {
 	activated_at: number;
 }
 
+export interface ToolParam {
+	name: string;
+	description: string;
+	input_schema: {
+		type: 'object';
+		properties: Record< string, unknown >;
+		required: string[];
+	};
+}
+
 export interface ProxyRequest {
 	messages: MessageParam[];
 	model?: string;
 	max_tokens?: number;
 	system?: string;
+	tools?: ToolParam[];
 }
 
 export interface MessageParam {

--- a/wp-ai-mind-proxy/src/types.ts
+++ b/wp-ai-mind-proxy/src/types.ts
@@ -35,7 +35,7 @@ export interface ToolParam {
 	input_schema: {
 		type: 'object';
 		properties: Record< string, unknown >;
-		required: string[];
+		required?: string[];
 	};
 }
 

--- a/wp-ai-mind-proxy/test/chat-proxy.test.ts
+++ b/wp-ai-mind-proxy/test/chat-proxy.test.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import worker from '../src/index';
 import { makeEnv } from './helpers/kv-mock';
-import type { SiteRecord } from '../src/types';
+import type { SiteRecord, ToolParam } from '../src/types';
 
 afterEach( () => {
 	vi.restoreAllMocks();
@@ -78,6 +78,57 @@ describe( 'handleChatProxy', () => {
 			'json'
 		) as SiteRecord;
 		expect( updated.tier ).toBe( 'free' );
+	} );
+
+	it( 'forwards tools to the Anthropic API', async () => {
+		const env = await makeEnvWithSiteToken( 'trial' );
+
+		const mockTool: ToolParam = {
+			name: 'get_post_content',
+			description: 'Get post content',
+			input_schema: {
+				type: 'object',
+				properties: { post_id: { type: 'integer' } },
+				required: [ 'post_id' ],
+			},
+		};
+
+		let capturedBody: Record< string, unknown > | null = null;
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async ( _url: string, init: RequestInit ) => {
+				capturedBody = JSON.parse( init.body as string );
+				return new Response(
+					JSON.stringify( {
+						content: [ { type: 'text', text: 'Summary' } ],
+						model: 'claude-haiku-4-5-20251001',
+						usage: { input_tokens: 10, output_tokens: 5 },
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Summarise post 140' } ],
+			tools: [ mockTool ],
+		} );
+
+		const req = new Request( 'https://worker.example.com/v1/chat', {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${ TEST_TOKEN }`,
+				'Content-Type': 'application/json',
+			},
+			body,
+		} );
+
+		const response = await worker.fetch( req, env );
+		expect( response.status ).toBe( 200 );
+		expect( capturedBody ).not.toBeNull();
+		expect( ( capturedBody as Record< string, unknown > ).tools ).toEqual( [
+			mockTool,
+		] );
 	} );
 
 	it( 'does not demote an active trial (< 30 days)', async () => {


### PR DESCRIPTION
## Summary

- **Root cause of #473** (and why #434 regressed): Tools were silently dropped at every layer of the proxy chain. Every free/trial/pro_managed user goes through the Cloudflare proxy — but `ClaudeProvider::complete_via_proxy()` never passed `$request->tools` to `NJ_Proxy_Client::chat()`, the client didn't support a `tools` option, and the proxy Worker never forwarded tools to the Anthropic API. Only `pro_byok` users (direct API via `build_body()`) worked correctly.
- PR #436 (which "fixed" #434) only changed the system prompt language to `MUST call get_post_content` — the AI correctly saw the instruction but had no tool definitions in its context, so it reported *"I don't have access to a get_post_content function."*

## Changes

| File | Change |
|------|--------|
| `wp-ai-mind-proxy/src/types.ts` | Add `ToolParam` interface (mirrors `MessageParam` naming); add `tools?: ToolParam[]` to `ProxyRequest` |
| `wp-ai-mind-proxy/src/index.ts` | Destructure `tools` from request body; forward to `anthropicBody` when non-empty |
| `includes/Proxy/NJ_Proxy_Client.php` | Accept `tools` in `$options`; include in proxy payload |
| `includes/Providers/ClaudeProvider.php` | Pass `$request->tools` into `complete_via_proxy()` options |
| `tests/Unit/Providers/ClaudeProviderTest.php` | New test: `test_complete_via_proxy_forwards_tools` — stubs free-tier routing and asserts tools appear in the captured proxy payload |
| `wp-ai-mind-proxy/test/chat-proxy.test.ts` | New test: `forwards tools to the Anthropic API` — asserts `tools` in the request body are included in the upstream Anthropic call |

## Test plan

- [ ] 244/244 PHP unit tests pass (`./vendor/bin/phpunit tests/Unit/`)
- [ ] 39/39 TypeScript tests pass (`cd wp-ai-mind-proxy && npm test`)
- [ ] TypeScript type check clean (`npx tsc --noEmit`)
- [ ] Manual (Docker, free/trial tier): attach a post in Chat → ask "Please summarise the current post" → AI calls `get_post_content` and returns a content-based summary instead of the "I don't have access" message

Closes #473

https://claude.ai/code/session_01KeKVmdsLPHn43C8Y5vdbKA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeKVmdsLPHn43C8Y5vdbKA)_