### PR TITLE
refactor(proxy): make wp-ai-mind-proxy provider-agnostic

### DIFF
--- a/includes/Providers/ClaudeProvider.php
+++ b/includes/Providers/ClaudeProvider.php
@@ -172,9 +172,17 @@ class ClaudeProvider extends AbstractProvider {
 		];
 		$options     = array_filter( $raw_options, fn( $v ) => null !== $v );
 		if ( ! empty( $request->tools ) ) {
-			$options['tools'] = $request->tools;
+			// Convert from Claude wire format (input_schema) to canonical proxy format (parameters).
+			$options['tools'] = array_map(
+				fn( array $t ) => [
+					'name'        => $t['name'],
+					'description' => $t['description'] ?? '',
+					'parameters'  => $t['input_schema'] ?? [],
+				],
+				$request->tools
+			);
 		}
-		$result = NJ_Proxy_Client::chat( $request->messages, $options );
+		$result = NJ_Proxy_Client::chat( $request->messages, $options, 'claude' );
 
 		if ( is_wp_error( $result ) ) {
 			throw new ProviderException( $result->get_error_message(), 'claude' ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped

--- a/includes/Providers/GeminiProvider.php
+++ b/includes/Providers/GeminiProvider.php
@@ -12,6 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use WP_AI_Mind\Proxy\NJ_Proxy_Client;
+use WP_AI_Mind\Proxy\NJ_Site_Registration;
+use WP_AI_Mind\Tiers\NJ_Tier_Manager;
+use WP_AI_Mind\Tools\ToolRegistry;
+
 /**
  * Handles completions, streaming, and image generation for Google Gemini models.
  *
@@ -48,10 +53,17 @@ class GeminiProvider extends AbstractProvider {
 	];
 
 	/**
+	 * Tracks whether the proxy handled logging so maybe_log() can skip double-logging.
+	 *
+	 * @var bool
+	 */
+	private bool $proxy_logged = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.0.0
-	 * @param string $api_key Google AI Studio API key.
+	 * @param string $api_key Google AI Studio API key; empty string for proxy-routed tiers.
 	 */
 	public function __construct( private readonly string $api_key ) {}
 
@@ -86,27 +98,45 @@ class GeminiProvider extends AbstractProvider {
 	}
 
 	/**
-	 * Return true when an API key is configured.
+	 * Return true if the provider can handle requests for the current user.
+	 *
+	 * Available when an API key is set, or when the site is registered and the
+	 * user's tier is eligible for proxy routing.
 	 *
 	 * @since 1.0.0
 	 * @return bool
 	 */
 	public function is_available(): bool {
-		return '' !== $this->api_key;
+		if ( '' !== $this->api_key ) {
+			return true;
+		}
+		$tier = NJ_Tier_Manager::get_user_tier( get_current_user_id() );
+		return in_array( $tier, [ 'free', 'trial', 'pro_managed' ], true )
+			&& NJ_Site_Registration::is_registered();
 	}
 
 	/**
-	 * Send a completion request to the Gemini generateContent endpoint.
+	 * Route completion by tier:
+	 *   - free / trial / pro_managed → proxy (NJ_Proxy_Client handles usage logging)
+	 *   - pro_byok                   → direct Gemini API call (AbstractProvider logs usage)
 	 *
 	 * @since 1.0.0
 	 * @param CompletionRequest $request The completion request.
 	 * @return CompletionResponse
-	 * @throws ProviderException On HTTP failure or non-2xx status.
+	 * @throws ProviderException On API or proxy failure.
 	 */
 	protected function do_complete( CompletionRequest $request ): CompletionResponse {
-		$model    = ! empty( $request->model ) ? $request->model : self::DEFAULT_MODEL;
-		$contents = $this->messages_to_contents( $request->messages );
-		$body     = [ 'contents' => $contents ];
+		$tier = NJ_Tier_Manager::get_user_tier( get_current_user_id() );
+
+		if ( in_array( $tier, [ 'free', 'trial', 'pro_managed' ], true ) ) {
+			return $this->complete_via_proxy( $request );
+		}
+
+		// pro_byok — direct Gemini API call; AbstractProvider::complete() will log usage.
+		$this->proxy_logged = false;
+		$model              = ! empty( $request->model ) ? $request->model : self::DEFAULT_MODEL;
+		$contents           = $this->messages_to_contents( $request->messages );
+		$body               = [ 'contents' => $contents ];
 		if ( '' !== $request->system ) {
 			$body['systemInstruction'] = [ 'parts' => [ [ 'text' => $request->system ] ] ];
 		}
@@ -115,6 +145,56 @@ class GeminiProvider extends AbstractProvider {
 		}
 		$raw = $this->post( "/models/{$model}:generateContent", $body );
 		return $this->parse_response( $raw, $model );
+	}
+
+	/**
+	 * Suppress AbstractProvider usage logging when the proxy already logged it.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest  $request  The original completion request.
+	 * @param CompletionResponse $response The completed response.
+	 * @return void
+	 */
+	protected function maybe_log( CompletionRequest $request, CompletionResponse $response ): void {
+		if ( $this->proxy_logged ) {
+			$this->proxy_logged = false; // Reset for re-use.
+			return;
+		}
+		parent::maybe_log( $request, $response );
+	}
+
+	/**
+	 * Send the completion request through the NJ proxy client.
+	 *
+	 * The proxy receives messages in standard user/assistant roles; the Worker
+	 * translates them to Gemini's user/model convention before forwarding.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request The completion request.
+	 * @return CompletionResponse
+	 * @throws ProviderException When the proxy returns a WP_Error.
+	 */
+	private function complete_via_proxy( CompletionRequest $request ): CompletionResponse {
+		$model       = ! empty( $request->model ) ? $request->model : self::DEFAULT_MODEL;
+		$raw_options = [
+			'model'      => $model,
+			'max_tokens' => $request->max_tokens,
+			'system'     => '' !== $request->system ? $request->system : null,
+		];
+		$options     = array_filter( $raw_options, fn( $v ) => null !== $v );
+		if ( ! empty( $request->tools ) ) {
+			// Re-format to canonical proxy format; $request->tools carries Gemini wire format.
+			$options['tools'] = ( new ToolRegistry() )->get_for_provider( 'proxy' );
+		}
+		$result = NJ_Proxy_Client::chat( $request->messages, $options, 'gemini' );
+
+		if ( is_wp_error( $result ) ) {
+			throw new ProviderException( $result->get_error_message(), 'gemini' ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		// NJ_Proxy_Client::chat() already called NJ_Usage_Tracker::log_usage() — flag to suppress parent logging.
+		$this->proxy_logged = true;
+		return $this->parse_response( $result, $model );
 	}
 
 	/**

--- a/includes/Providers/GeminiProvider.php
+++ b/includes/Providers/GeminiProvider.php
@@ -183,7 +183,10 @@ class GeminiProvider extends AbstractProvider {
 		];
 		$options     = array_filter( $raw_options, fn( $v ) => null !== $v );
 		if ( ! empty( $request->tools ) ) {
-			// Re-format to canonical proxy format; $request->tools carries Gemini wire format.
+			// Re-instantiate ToolRegistry to obtain the canonical proxy format.
+			// $request->tools carries Gemini wire format so we cannot forward it directly.
+			// TODO: have the caller pass tools in canonical proxy format so providers do not
+			// need to re-register on every proxied request (SRP concern, tracked in #485).
 			$options['tools'] = ( new ToolRegistry() )->get_for_provider( 'proxy' );
 		}
 		$result = NJ_Proxy_Client::chat( $request->messages, $options, 'gemini' );

--- a/includes/Providers/GeminiProvider.php
+++ b/includes/Providers/GeminiProvider.php
@@ -55,6 +55,10 @@ class GeminiProvider extends AbstractProvider {
 	/**
 	 * Tracks whether the proxy handled logging so maybe_log() can skip double-logging.
 	 *
+	 * Mutable flag reset in do_complete() (pro_byok path) and maybe_log() (proxy path).
+	 * PHP does not run concurrent requests on the same instance, so there is no race risk
+	 * in practice; a future async runtime should replace this with a tagged return value.
+	 *
 	 * @var bool
 	 */
 	private bool $proxy_logged = false;
@@ -175,6 +179,8 @@ class GeminiProvider extends AbstractProvider {
 	 * @throws ProviderException When the proxy returns a WP_Error.
 	 */
 	private function complete_via_proxy( CompletionRequest $request ): CompletionResponse {
+		// The model sent here is a hint only — the Worker's getModelForTier() may override
+		// it to enforce the tier's allowed model list.
 		$model       = ! empty( $request->model ) ? $request->model : self::DEFAULT_MODEL;
 		$raw_options = [
 			'model'      => $model,

--- a/includes/Providers/GeminiProvider.php
+++ b/includes/Providers/GeminiProvider.php
@@ -194,7 +194,27 @@ class GeminiProvider extends AbstractProvider {
 
 		// NJ_Proxy_Client::chat() already called NJ_Usage_Tracker::log_usage() — flag to suppress parent logging.
 		$this->proxy_logged = true;
-		return $this->parse_response( $result, $model );
+
+		// Build CompletionResponse directly from the proxy's normalised shape { content, usage, tool_call? }.
+		// parse_response() expects the upstream Gemini wire format and cannot handle the normalised response.
+		$in_tokens  = (int) ( $result['usage']['input_tokens'] ?? 0 );
+		$out_tokens = (int) ( $result['usage']['output_tokens'] ?? 0 );
+		$pricing    = self::PRICING[ $model ] ?? self::PRICING[ self::DEFAULT_MODEL ];
+		$cost       = ( $in_tokens / 1_000_000 * $pricing['in'] ) + ( $out_tokens / 1_000_000 * $pricing['out'] );
+
+		if ( ! empty( $result['tool_call'] ) ) {
+			return new CompletionResponse(
+				content: '',
+				model: $model,
+				prompt_tokens: $in_tokens,
+				completion_tokens: $out_tokens,
+				cost_usd: $cost,
+				raw: $result,
+				tool_call: $result['tool_call'],
+			);
+		}
+
+		return new CompletionResponse( $result['content'] ?? '', $model, $in_tokens, $out_tokens, $cost, $result );
 	}
 
 	/**

--- a/includes/Providers/OpenAIProvider.php
+++ b/includes/Providers/OpenAIProvider.php
@@ -12,8 +12,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use WP_AI_Mind\Proxy\NJ_Proxy_Client;
+use WP_AI_Mind\Proxy\NJ_Site_Registration;
+use WP_AI_Mind\Tiers\NJ_Tier_Manager;
+use WP_AI_Mind\Tools\ToolRegistry;
+
 /**
  * Handles completions, streaming, and image generation for OpenAI models.
+ *
+ * Free, trial, and pro_managed tiers route through the NJ proxy client so that
+ * usage is logged centrally. The pro_byok tier calls the OpenAI API directly.
  *
  * @since 1.0.0
  */
@@ -49,10 +57,17 @@ class OpenAIProvider extends AbstractProvider {
 	];
 
 	/**
+	 * Tracks whether the proxy handled logging so maybe_log() can skip double-logging.
+	 *
+	 * @var bool
+	 */
+	private bool $proxy_logged = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.0.0
-	 * @param string $api_key OpenAI API key.
+	 * @param string $api_key OpenAI API key; empty string for proxy-routed tiers.
 	 */
 	public function __construct( private readonly string $api_key ) {}
 
@@ -87,25 +102,43 @@ class OpenAIProvider extends AbstractProvider {
 	}
 
 	/**
-	 * Return true when an API key is configured.
+	 * Return true if the provider can handle requests for the current user.
+	 *
+	 * Available when an API key is set, or when the site is registered and the
+	 * user's tier is eligible for proxy routing.
 	 *
 	 * @since 1.0.0
 	 * @return bool
 	 */
 	public function is_available(): bool {
-		return '' !== $this->api_key;
+		if ( '' !== $this->api_key ) {
+			return true;
+		}
+		$tier = NJ_Tier_Manager::get_user_tier( get_current_user_id() );
+		return in_array( $tier, [ 'free', 'trial', 'pro_managed' ], true )
+			&& NJ_Site_Registration::is_registered();
 	}
 
 	/**
-	 * Send a completion request to the OpenAI Chat Completions endpoint.
+	 * Route completion by tier:
+	 *   - free / trial / pro_managed → proxy (NJ_Proxy_Client handles usage logging)
+	 *   - pro_byok                   → direct OpenAI API call (AbstractProvider logs usage)
 	 *
 	 * @since 1.0.0
 	 * @param CompletionRequest $request The completion request.
 	 * @return CompletionResponse
-	 * @throws ProviderException On HTTP failure or non-2xx status.
+	 * @throws ProviderException On API or proxy failure.
 	 */
 	protected function do_complete( CompletionRequest $request ): CompletionResponse {
-		$messages = $request->messages;
+		$tier = NJ_Tier_Manager::get_user_tier( get_current_user_id() );
+
+		if ( in_array( $tier, [ 'free', 'trial', 'pro_managed' ], true ) ) {
+			return $this->complete_via_proxy( $request );
+		}
+
+		// pro_byok — direct OpenAI API call; AbstractProvider::complete() will log usage.
+		$this->proxy_logged = false;
+		$messages           = $request->messages;
 		if ( '' !== $request->system ) {
 			array_unshift(
 				$messages,
@@ -128,6 +161,53 @@ class OpenAIProvider extends AbstractProvider {
 		}
 		$raw = $this->post( '/chat/completions', $body );
 		return $this->parse_response( $raw, $model );
+	}
+
+	/**
+	 * Suppress AbstractProvider usage logging when the proxy already logged it.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest  $request  The original completion request.
+	 * @param CompletionResponse $response The completed response.
+	 * @return void
+	 */
+	protected function maybe_log( CompletionRequest $request, CompletionResponse $response ): void {
+		if ( $this->proxy_logged ) {
+			$this->proxy_logged = false; // Reset for re-use.
+			return;
+		}
+		parent::maybe_log( $request, $response );
+	}
+
+	/**
+	 * Send the completion request through the NJ proxy client.
+	 *
+	 * @since 1.0.0
+	 * @param CompletionRequest $request The completion request.
+	 * @return CompletionResponse
+	 * @throws ProviderException When the proxy returns a WP_Error.
+	 */
+	private function complete_via_proxy( CompletionRequest $request ): CompletionResponse {
+		$model       = ! empty( $request->model ) ? $request->model : self::DEFAULT_MODEL;
+		$raw_options = [
+			'model'      => $model,
+			'max_tokens' => $request->max_tokens,
+			'system'     => '' !== $request->system ? $request->system : null,
+		];
+		$options     = array_filter( $raw_options, fn( $v ) => null !== $v );
+		if ( ! empty( $request->tools ) ) {
+			// Re-format to canonical proxy format; $request->tools carries OpenAI wire format.
+			$options['tools'] = ( new ToolRegistry() )->get_for_provider( 'proxy' );
+		}
+		$result = NJ_Proxy_Client::chat( $request->messages, $options, 'openai' );
+
+		if ( is_wp_error( $result ) ) {
+			throw new ProviderException( $result->get_error_message(), 'openai' ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		// NJ_Proxy_Client::chat() already called NJ_Usage_Tracker::log_usage() — flag to suppress parent logging.
+		$this->proxy_logged = true;
+		return $this->parse_response( $result, $model );
 	}
 
 	/**

--- a/includes/Providers/OpenAIProvider.php
+++ b/includes/Providers/OpenAIProvider.php
@@ -196,7 +196,10 @@ class OpenAIProvider extends AbstractProvider {
 		];
 		$options     = array_filter( $raw_options, fn( $v ) => null !== $v );
 		if ( ! empty( $request->tools ) ) {
-			// Re-format to canonical proxy format; $request->tools carries OpenAI wire format.
+			// Re-instantiate ToolRegistry to obtain the canonical proxy format.
+			// $request->tools carries OpenAI wire format so we cannot forward it directly.
+			// TODO: have the caller pass tools in canonical proxy format so providers do not
+			// need to re-register on every proxied request (SRP concern, tracked in #485).
 			$options['tools'] = ( new ToolRegistry() )->get_for_provider( 'proxy' );
 		}
 		$result = NJ_Proxy_Client::chat( $request->messages, $options, 'openai' );

--- a/includes/Providers/OpenAIProvider.php
+++ b/includes/Providers/OpenAIProvider.php
@@ -59,6 +59,10 @@ class OpenAIProvider extends AbstractProvider {
 	/**
 	 * Tracks whether the proxy handled logging so maybe_log() can skip double-logging.
 	 *
+	 * Mutable flag reset in do_complete() (pro_byok path) and maybe_log() (proxy path).
+	 * PHP does not run concurrent requests on the same instance, so there is no race risk
+	 * in practice; a future async runtime should replace this with a tagged return value.
+	 *
 	 * @var bool
 	 */
 	private bool $proxy_logged = false;

--- a/includes/Providers/OpenAIProvider.php
+++ b/includes/Providers/OpenAIProvider.php
@@ -207,7 +207,27 @@ class OpenAIProvider extends AbstractProvider {
 
 		// NJ_Proxy_Client::chat() already called NJ_Usage_Tracker::log_usage() — flag to suppress parent logging.
 		$this->proxy_logged = true;
-		return $this->parse_response( $result, $model );
+
+		// Build CompletionResponse directly from the proxy's normalised shape { content, usage, tool_call? }.
+		// parse_response() expects the upstream OpenAI wire format and cannot handle the normalised response.
+		$in_tokens  = (int) ( $result['usage']['input_tokens'] ?? 0 );
+		$out_tokens = (int) ( $result['usage']['output_tokens'] ?? 0 );
+		$pricing    = self::PRICING[ $model ] ?? self::PRICING[ self::DEFAULT_MODEL ];
+		$cost       = ( $in_tokens / 1_000_000 * $pricing['in'] ) + ( $out_tokens / 1_000_000 * $pricing['out'] );
+
+		if ( ! empty( $result['tool_call'] ) ) {
+			return new CompletionResponse(
+				content: '',
+				model: $model,
+				prompt_tokens: $in_tokens,
+				completion_tokens: $out_tokens,
+				cost_usd: $cost,
+				raw: $result,
+				tool_call: $result['tool_call'],
+			);
+		}
+
+		return new CompletionResponse( $result['content'] ?? '', $model, $in_tokens, $out_tokens, $cost, $result );
 	}
 
 	/**

--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -31,11 +31,12 @@ class NJ_Proxy_Client {
 	 * Send a chat request through the Cloudflare proxy.
 	 *
 	 * @since 1.2.0
-	 * @param array<array{role: string, content: string}> $messages Chat message history.
-	 * @param array<string, mixed>                        $options  Supports 'model', 'max_tokens', 'system', 'tools'.
+	 * @param array<array{role: string, content: string}> $messages  Chat message history.
+	 * @param array<string, mixed>                        $options   Supports 'model', 'max_tokens', 'system', 'tools'.
+	 * @param string                                      $provider  Provider slug: 'claude', 'openai', or 'gemini'. Defaults to 'claude'.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	public static function chat( array $messages, array $options = [] ): array|WP_Error {
+	public static function chat( array $messages, array $options = [], string $provider = 'claude' ): array|WP_Error {
 		$token = NJ_Site_Registration::get_site_token();
 		if ( empty( $token ) ) {
 			return new WP_Error( 'not_registered', __( 'Site not registered with AI proxy.', 'wp-ai-mind' ) );
@@ -50,6 +51,7 @@ class NJ_Proxy_Client {
 
 		$payload = [
 			'messages' => $messages,
+			'provider' => $provider,
 		];
 
 		if ( isset( $options['model'] ) ) {

--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -107,7 +107,11 @@ class NJ_Proxy_Client {
 			return new WP_Error( 'proxy_error', $body['error'] ?? sprintf( 'Proxy returned HTTP %d', $code ) );
 		}
 
-		// Mirror usage locally for dashboard display only. KV is authoritative for enforcement.
+		// Mirror usage locally for dashboard display only — KV is authoritative for quota enforcement.
+		// The proxy stores weighted tokens (raw × model weight), so the KV quota and local counter
+		// will diverge for high-weight models (e.g. Claude Opus at ×15). This is intentional:
+		// the dashboard shows raw API tokens consumed while quota enforcement operates on
+		// weighted tokens in KV to keep billing proportional across providers and models.
 		if ( isset( $body['usage']['input_tokens'], $body['usage']['output_tokens'] ) ) {
 			$tokens = (int) $body['usage']['input_tokens'] + (int) $body['usage']['output_tokens'];
 			NJ_Usage_Tracker::log_usage( $tokens, $user_id );

--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -20,8 +20,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Sends Bearer-token-authenticated requests to the Cloudflare Worker proxy.
  *
- * Free/Trial/Pro Managed users are routed through this class.
- * Pro BYOK tier bypasses this class entirely and routes via ClaudeProvider.
+ * Free/Trial/Pro Managed users are routed through this class for all providers
+ * (Claude, OpenAI, Gemini). The Pro BYOK tier bypasses this class entirely and
+ * calls the provider's own API directly.
  *
  * @since 1.2.0
  */

--- a/includes/Tools/ToolRegistry.php
+++ b/includes/Tools/ToolRegistry.php
@@ -63,6 +63,7 @@ class ToolRegistry {
 			'claude' => $this->format_claude( array_values( $tools ) ),
 			'openai' => $this->format_openai( array_values( $tools ) ),
 			'gemini' => $this->format_gemini( array_values( $tools ) ),
+			'proxy'  => $this->format_proxy( array_values( $tools ) ),
 			default  => [],  // ollama and unknown providers.
 		};
 	}
@@ -398,5 +399,33 @@ class ToolRegistry {
 		);
 
 		return [ [ 'functionDeclarations' => $declarations ] ];
+	}
+
+	/**
+	 * Format tools in the canonical provider-neutral format for the proxy.
+	 *
+	 * The Worker (wp-ai-mind-proxy) receives this format and translates it to the
+	 * wire format required by the target provider. Using a single canonical shape
+	 * here keeps the PHP side decoupled from provider-specific schema conventions.
+	 *
+	 * @since 1.0.0
+	 * @param ToolDefinition[] $tools Tool definitions to format.
+	 * @return array<int, array<string, mixed>> Canonical tool definitions.
+	 */
+	private function format_proxy( array $tools ): array {
+		return array_map(
+			static function ( ToolDefinition $tool ): array {
+				return [
+					'name'        => $tool->name,
+					'description' => $tool->description,
+					'parameters'  => [
+						'type'       => 'object',
+						'properties' => ! empty( $tool->parameters['properties'] ) ? $tool->parameters['properties'] : new \stdClass(),
+						'required'   => $tool->parameters['required'] ?? [],
+					],
+				];
+			},
+			$tools
+		);
 	}
 }

--- a/tests/Unit/Providers/ClaudeProviderTest.php
+++ b/tests/Unit/Providers/ClaudeProviderTest.php
@@ -258,6 +258,7 @@ class ClaudeProviderTest extends TestCase {
 		Functions\when( 'is_wp_error' )->alias( fn( $v ) => $v instanceof \WP_Error );
 		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
 
+		// Tools in Claude wire format (input_schema); proxy receives canonical format (parameters).
 		$tools    = [ [ 'name' => 'get_post_content', 'description' => 'Get post content.', 'input_schema' => [ 'type' => 'object', 'properties' => [ 'post_id' => [ 'type' => 'integer' ] ], 'required' => [ 'post_id' ] ] ] ];
 		$provider = new ClaudeProvider( '' ); // No API key — routes via proxy.
 		$request  = new CompletionRequest(
@@ -271,7 +272,10 @@ class ClaudeProviderTest extends TestCase {
 		$this->assertNotNull( $captured_body );
 		$this->assertArrayHasKey( 'tools', $captured_body );
 		$this->assertSame( 'get_post_content', $captured_body['tools'][0]['name'] );
-		$this->assertSame( $tools, $captured_body['tools'] );
+		// Proxy body must carry canonical format (parameters), not Claude wire format (input_schema).
+		$this->assertArrayHasKey( 'parameters', $captured_body['tools'][0] );
+		$this->assertArrayNotHasKey( 'input_schema', $captured_body['tools'][0] );
+		$this->assertSame( $tools[0]['input_schema'], $captured_body['tools'][0]['parameters'] );
 	}
 
 	public function test_tools_injected_in_request_body(): void {

--- a/tests/Unit/Providers/GeminiProviderTest.php
+++ b/tests/Unit/Providers/GeminiProviderTest.php
@@ -24,6 +24,8 @@ class GeminiProviderTest extends TestCase {
 			public function query( string $sql ): int { return 1; }
 		};
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		// Return 'pro_byok' so do_complete() routes direct — preserving existing test behaviour.
+		Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
 		Functions\when( 'sanitize_key' )->alias( fn($v) => $v );
 		Functions\when( 'sanitize_text_field' )->alias( fn($v) => $v );
 	}
@@ -33,6 +35,8 @@ class GeminiProviderTest extends TestCase {
 	}
 
 	public function test_is_available_false_without_key(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
 		$this->assertFalse( ( new GeminiProvider( '' ) )->is_available() );
 	}
 
@@ -59,6 +63,8 @@ class GeminiProviderTest extends TestCase {
 	}
 
 	public function test_complete_throws_on_api_error(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
 		Functions\when( 'wp_remote_post' )->justReturn( [
 			'response' => [ 'code' => 403 ],
 			'body'     => json_encode( [ 'error' => [ 'message' => 'API key invalid' ] ] ),

--- a/tests/Unit/Providers/GeminiProviderTest.php
+++ b/tests/Unit/Providers/GeminiProviderTest.php
@@ -120,6 +120,142 @@ class GeminiProviderTest extends TestCase {
 		$this->assertSame( '', $response->content );
 	}
 
+	// ── Proxy path tests ─────────────────────────────────────────────────────
+
+	private function mock_free_tier_proxy(): void {
+		global $wpdb;
+		$wpdb = new class extends \stdClass {
+			public string $usermeta      = 'wp_usermeta';
+			public int    $rows_affected = 1;
+			public string $prefix        = 'wpaim_';
+			public function insert(): int { return 1; }
+			public function prepare( string $sql, ...$args ): string { return $sql; }
+			public function query( string $sql ): int { return 1; }
+		};
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		// First call returns the tier ('free'), subsequent calls return 0 for usage count.
+		Functions\when( 'get_user_meta' )->justReturn( 'free' );
+		Functions\when( 'get_option' )->justReturn( 'test-site-token' );
+		Functions\when( 'sanitize_key' )->alias( fn( $v ) => $v );
+		Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+	}
+
+	public function test_is_available_true_for_free_tier_when_registered(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'free' );
+		Functions\when( 'get_option' )->justReturn( 'test-site-token' );
+		$this->assertTrue( ( new GeminiProvider( '' ) )->is_available() );
+	}
+
+	public function test_complete_via_proxy_happy_path(): void {
+		$this->mock_free_tier_proxy();
+		Functions\when( 'wp_remote_post' )->justReturn( [
+			'response' => [ 'code' => 200 ],
+			'body'     => json_encode( [
+				'content' => 'Gemini proxy says hi',
+				'usage'   => [ 'input_tokens' => 5, 'output_tokens' => 3 ],
+			] ),
+		] );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->alias( fn( $r ) => $r['body'] );
+
+		$provider = new GeminiProvider( '' );
+		$request  = new CompletionRequest( [ [ 'role' => 'user', 'content' => 'hi' ] ] );
+		$response = $provider->complete( $request );
+
+		$this->assertSame( 'Gemini proxy says hi', $response->content );
+		$this->assertSame( 5, $response->prompt_tokens );
+		$this->assertSame( 3, $response->completion_tokens );
+		$this->assertFalse( $response->is_tool_call() );
+	}
+
+	public function test_complete_via_proxy_tool_call(): void {
+		$this->mock_free_tier_proxy();
+		Functions\when( 'wp_remote_post' )->justReturn( [
+			'response' => [ 'code' => 200 ],
+			'body'     => json_encode( [
+				'content'   => '',
+				'usage'     => [ 'input_tokens' => 10, 'output_tokens' => 4 ],
+				'tool_call' => [ 'id' => 'gemini_123', 'name' => 'get_posts', 'arguments' => [ 'count' => 3 ] ],
+			] ),
+		] );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->alias( fn( $r ) => $r['body'] );
+
+		$provider = new GeminiProvider( '' );
+		$request  = new CompletionRequest( [ [ 'role' => 'user', 'content' => 'list posts' ] ] );
+		$response = $provider->complete( $request );
+
+		$this->assertTrue( $response->is_tool_call() );
+		$this->assertSame( 'get_posts', $response->tool_call['name'] );
+		$this->assertSame( [ 'count' => 3 ], $response->tool_call['arguments'] );
+	}
+
+	public function test_complete_via_proxy_wp_error_throws_provider_exception(): void {
+		global $wpdb;
+		$wpdb = new class extends \stdClass {
+			public string $usermeta      = 'wp_usermeta';
+			public int    $rows_affected = 1;
+			public string $prefix        = 'wpaim_';
+			public function insert(): int { return 1; }
+			public function prepare( string $sql, ...$args ): string { return $sql; }
+			public function query( string $sql ): int { return 1; }
+		};
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'free' );
+		Functions\when( 'get_option' )->justReturn( 'test-site-token' );
+		Functions\when( 'sanitize_key' )->alias( fn( $v ) => $v );
+		Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+		// Simulate wp_remote_post returning a WP_Error (e.g. connection refused).
+		Functions\when( 'wp_remote_post' )->justReturn( new \WP_Error( 'http_request_failed', 'Connection refused' ) );
+		Functions\when( 'is_wp_error' )->justReturn( true );
+
+		$provider = new GeminiProvider( '' );
+		$this->expectException( ProviderException::class );
+		$provider->complete( new CompletionRequest( [ [ 'role' => 'user', 'content' => 'hi' ] ] ) );
+	}
+
+	public function test_proxy_logged_suppresses_parent_log(): void {
+		$query_count = 0;
+		global $wpdb;
+		$wpdb = new class( $query_count ) extends \stdClass {
+			public string $usermeta      = 'wp_usermeta';
+			public int    $rows_affected = 1;
+			public string $prefix        = 'wpaim_';
+			public int    $query_calls   = 0;
+			public function __construct( int $dummy ) {}
+			public function insert(): int { return 1; }
+			public function prepare( string $sql, ...$args ): string { return $sql; }
+			public function query( string $sql ): int { $this->query_calls++; return 1; }
+		};
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'free' );
+		Functions\when( 'get_option' )->justReturn( 'test-site-token' );
+		Functions\when( 'sanitize_key' )->alias( fn( $v ) => $v );
+		Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_post' )->justReturn( [
+			'response' => [ 'code' => 200 ],
+			'body'     => json_encode( [
+				'content' => 'ok',
+				'usage'   => [ 'input_tokens' => 2, 'output_tokens' => 1 ],
+			] ),
+		] );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->alias( fn( $r ) => $r['body'] );
+
+		$provider = new GeminiProvider( '' );
+		$provider->complete( new CompletionRequest( [ [ 'role' => 'user', 'content' => 'hi' ] ] ) );
+
+		// NJ_Proxy_Client::chat() logs usage once (one wpdb->query call).
+		// proxy_logged flag must prevent parent::maybe_log() from logging a second time.
+		$this->assertSame( 1, $wpdb->query_calls );
+	}
+
 	public function test_normal_response_not_tool_call(): void {
 		$this->mock_wpdb();
 		Functions\when( 'wp_remote_post' )->justReturn( [

--- a/tests/Unit/Providers/OpenAIProviderTest.php
+++ b/tests/Unit/Providers/OpenAIProviderTest.php
@@ -124,6 +124,140 @@ class OpenAIProviderTest extends TestCase {
 		$this->assertSame( '', $response->content );
 	}
 
+	// ── Proxy path tests ─────────────────────────────────────────────────────
+
+	private function mock_free_tier_proxy(): void {
+		global $wpdb;
+		$wpdb = new class extends \stdClass {
+			public string $usermeta      = 'wp_usermeta';
+			public int    $rows_affected = 1;
+			public string $prefix        = 'wpaim_';
+			public function insert(): int { return 1; }
+			public function prepare( string $sql, ...$args ): string { return $sql; }
+			public function query( string $sql ): int { return 1; }
+		};
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'free' );
+		Functions\when( 'get_option' )->justReturn( 'test-site-token' );
+		Functions\when( 'sanitize_key' )->alias( fn( $v ) => $v );
+		Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+	}
+
+	public function test_is_available_true_for_free_tier_when_registered(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'free' );
+		Functions\when( 'get_option' )->justReturn( 'test-site-token' );
+		$this->assertTrue( ( new OpenAIProvider( '' ) )->is_available() );
+	}
+
+	public function test_complete_via_proxy_happy_path(): void {
+		$this->mock_free_tier_proxy();
+		Functions\when( 'wp_remote_post' )->justReturn( [
+			'response' => [ 'code' => 200 ],
+			'body'     => json_encode( [
+				'content' => 'OpenAI proxy says hi',
+				'usage'   => [ 'input_tokens' => 8, 'output_tokens' => 4 ],
+			] ),
+		] );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->alias( fn( $r ) => $r['body'] );
+
+		$provider = new OpenAIProvider( '' );
+		$request  = new CompletionRequest( [ [ 'role' => 'user', 'content' => 'hi' ] ] );
+		$response = $provider->complete( $request );
+
+		$this->assertSame( 'OpenAI proxy says hi', $response->content );
+		$this->assertSame( 8, $response->prompt_tokens );
+		$this->assertSame( 4, $response->completion_tokens );
+		$this->assertFalse( $response->is_tool_call() );
+	}
+
+	public function test_complete_via_proxy_tool_call(): void {
+		$this->mock_free_tier_proxy();
+		Functions\when( 'wp_remote_post' )->justReturn( [
+			'response' => [ 'code' => 200 ],
+			'body'     => json_encode( [
+				'content'   => '',
+				'usage'     => [ 'input_tokens' => 15, 'output_tokens' => 6 ],
+				'tool_call' => [ 'id' => 'call_abc123', 'name' => 'get_posts', 'arguments' => [ 'count' => 5 ] ],
+			] ),
+		] );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->alias( fn( $r ) => $r['body'] );
+
+		$provider = new OpenAIProvider( '' );
+		$request  = new CompletionRequest( [ [ 'role' => 'user', 'content' => 'list posts' ] ] );
+		$response = $provider->complete( $request );
+
+		$this->assertTrue( $response->is_tool_call() );
+		$this->assertSame( 'get_posts', $response->tool_call['name'] );
+		$this->assertSame( 'call_abc123', $response->tool_call['id'] );
+		$this->assertSame( [ 'count' => 5 ], $response->tool_call['arguments'] );
+	}
+
+	public function test_complete_via_proxy_wp_error_throws_provider_exception(): void {
+		global $wpdb;
+		$wpdb = new class extends \stdClass {
+			public string $usermeta      = 'wp_usermeta';
+			public int    $rows_affected = 1;
+			public string $prefix        = 'wpaim_';
+			public function insert(): int { return 1; }
+			public function prepare( string $sql, ...$args ): string { return $sql; }
+			public function query( string $sql ): int { return 1; }
+		};
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'free' );
+		Functions\when( 'get_option' )->justReturn( 'test-site-token' );
+		Functions\when( 'sanitize_key' )->alias( fn( $v ) => $v );
+		Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+		Functions\when( 'wp_remote_post' )->justReturn( new \WP_Error( 'http_request_failed', 'Connection refused' ) );
+		Functions\when( 'is_wp_error' )->justReturn( true );
+
+		$provider = new OpenAIProvider( '' );
+		$this->expectException( ProviderException::class );
+		$provider->complete( new CompletionRequest( [ [ 'role' => 'user', 'content' => 'hi' ] ] ) );
+	}
+
+	public function test_proxy_logged_suppresses_parent_log(): void {
+		global $wpdb;
+		$wpdb = new class extends \stdClass {
+			public string $usermeta      = 'wp_usermeta';
+			public int    $rows_affected = 1;
+			public string $prefix        = 'wpaim_';
+			public int    $query_calls   = 0;
+			public function __construct() {}
+			public function insert(): int { return 1; }
+			public function prepare( string $sql, ...$args ): string { return $sql; }
+			public function query( string $sql ): int { $this->query_calls++; return 1; }
+		};
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'free' );
+		Functions\when( 'get_option' )->justReturn( 'test-site-token' );
+		Functions\when( 'sanitize_key' )->alias( fn( $v ) => $v );
+		Functions\when( 'sanitize_text_field' )->alias( fn( $v ) => $v );
+		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_post' )->justReturn( [
+			'response' => [ 'code' => 200 ],
+			'body'     => json_encode( [
+				'content' => 'ok',
+				'usage'   => [ 'input_tokens' => 2, 'output_tokens' => 1 ],
+			] ),
+		] );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->alias( fn( $r ) => $r['body'] );
+
+		$provider = new OpenAIProvider( '' );
+		$provider->complete( new CompletionRequest( [ [ 'role' => 'user', 'content' => 'hi' ] ] ) );
+
+		// NJ_Proxy_Client::chat() logs usage once (one wpdb->query call).
+		// proxy_logged flag must prevent parent::maybe_log() from logging a second time.
+		$this->assertSame( 1, $wpdb->query_calls );
+	}
+
 	public function test_normal_response_not_tool_call(): void {
 		$this->mock_wpdb();
 		Functions\when( 'wp_remote_post' )->justReturn( [

--- a/tests/Unit/Providers/OpenAIProviderTest.php
+++ b/tests/Unit/Providers/OpenAIProviderTest.php
@@ -24,6 +24,8 @@ class OpenAIProviderTest extends TestCase {
 			public function query( string $sql ): int { return 1; }
 		};
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		// Return 'pro_byok' so do_complete() routes direct — preserving existing test behaviour.
+		Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
 		Functions\when( 'sanitize_key' )->alias( fn($v) => $v );
 		Functions\when( 'sanitize_text_field' )->alias( fn($v) => $v );
 	}
@@ -34,6 +36,8 @@ class OpenAIProviderTest extends TestCase {
 	}
 
 	public function test_is_available_false_without_key(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
 		$this->assertFalse( ( new OpenAIProvider( '' ) )->is_available() );
 	}
 
@@ -60,6 +64,8 @@ class OpenAIProviderTest extends TestCase {
 	}
 
 	public function test_complete_throws_on_api_error(): void {
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( 'pro_byok' );
 		Functions\when( 'wp_remote_post' )->justReturn( [
 			'response' => [ 'code' => 401 ],
 			'body'     => json_encode( [ 'error' => [ 'message' => 'Invalid API key' ] ] ),

--- a/wp-ai-mind-proxy/src/index.ts
+++ b/wp-ai-mind-proxy/src/index.ts
@@ -1,12 +1,198 @@
 // src/index.ts
 
-import { Env, ProxyRequest, ProxyTier, SiteRecord } from './types';
+import { Env, ModelConfig, NormalizedResponse, ProxyRequest, ProxyTier, SiteRecord, ToolParam } from './types';
 import { authenticateRequest } from './auth';
 import { handleActivationChallenge, handleRegistration } from './registration';
 import { handleWebhook } from './webhook';
 import { TRIAL_PERIOD_MS } from './constants';
 
 const MAX_BODY_BYTES = 1_048_576; // 1 MB
+
+type Provider = 'claude' | 'openai' | 'gemini';
+
+// Fallback model lists used when no config:models entry exists in USAGE_KV.
+const DEFAULT_TIER_MODELS: Record< Provider, Record< ProxyTier, string[] > > = {
+	claude: {
+		free:        [ 'claude-haiku-4-5-20251001' ],
+		trial:       [ 'claude-haiku-4-5-20251001' ],
+		pro_managed: [ 'claude-haiku-4-5-20251001', 'claude-sonnet-4-6', 'claude-opus-4-6' ],
+	},
+	openai: {
+		free:        [ 'gpt-4o-mini' ],
+		trial:       [ 'gpt-4o-mini' ],
+		pro_managed: [ 'gpt-4o-mini', 'gpt-4o' ],
+	},
+	gemini: {
+		free:        [ 'gemini-2.5-flash' ],
+		trial:       [ 'gemini-2.5-flash' ],
+		pro_managed: [ 'gemini-2.5-flash', 'gemini-2.5-pro' ],
+	},
+};
+
+// Fallback token weights — relative cost multipliers applied to raw token counts
+// before storing in the usage KV, so quota enforcement is provider/model-agnostic.
+const DEFAULT_MODEL_TOKEN_WEIGHT: Record< string, number > = {
+	'claude-haiku-4-5-20251001': 1,
+	'claude-sonnet-4-6':          3,
+	'claude-opus-4-6':            15,
+	'gpt-4o-mini':                1,
+	'gpt-4o':                     10,
+	'gemini-2.5-flash':           1,
+	'gemini-2.5-pro':             5,
+};
+
+/**
+ * Load model config from USAGE_KV (`config:models`).
+ * Falls back to compiled defaults if the key is absent or unparseable.
+ * Both `tier_models` and `model_token_weight` can be overridden independently.
+ */
+async function getModelConfig( env: Env ): Promise< {
+	tierModels: Record< string, Record< string, string[] > >;
+	tokenWeights: Record< string, number >;
+} > {
+	try {
+		const raw = await env.USAGE_KV.get( 'config:models' );
+		if ( raw ) {
+			const parsed = JSON.parse( raw ) as ModelConfig;
+			return {
+				tierModels:   parsed.tier_models        ?? DEFAULT_TIER_MODELS,
+				tokenWeights: parsed.model_token_weight ?? DEFAULT_MODEL_TOKEN_WEIGHT,
+			};
+		}
+	} catch {
+		// Corrupt KV entry — fall through to defaults.
+	}
+	return { tierModels: DEFAULT_TIER_MODELS, tokenWeights: DEFAULT_MODEL_TOKEN_WEIGHT };
+}
+
+function toClaudeTools( tools: ToolParam[] ) {
+	return tools.map( t => ( { name: t.name, description: t.description, input_schema: t.parameters } ) );
+}
+
+function toOpenAITools( tools: ToolParam[] ) {
+	return tools.map( t => ( { type: 'function', function: { name: t.name, description: t.description, parameters: t.parameters } } ) );
+}
+
+function toGeminiTools( tools: ToolParam[] ) {
+	return [ { functionDeclarations: tools.map( t => ( { name: t.name, description: t.description, parameters: { ...t.parameters, type: 'OBJECT' } } ) ) } ];
+}
+
+async function callClaude(
+	body: ProxyRequest,
+	resolvedModel: string,
+	clampedMaxTokens: number,
+	env: Env
+): Promise< NormalizedResponse > {
+	const claudeBody: Record< string, unknown > = {
+		model: resolvedModel,
+		max_tokens: clampedMaxTokens,
+		messages: body.messages,
+	};
+	if ( body.system ) {
+		claudeBody.system = body.system;
+	}
+	if ( body.tools && body.tools.length > 0 ) {
+		claudeBody.tools = toClaudeTools( body.tools );
+	}
+
+	const response = await fetch( 'https://api.anthropic.com/v1/messages', {
+		method: 'POST',
+		headers: {
+			'x-api-key': env.ANTHROPIC_API_KEY,
+			'anthropic-version': '2023-06-01',
+			'content-type': 'application/json',
+		},
+		body: JSON.stringify( claudeBody ),
+	} );
+
+	const result = ( await response.json() ) as Record< string, unknown >;
+
+	if ( ! response.ok ) {
+		throw Object.assign( new Error( 'Claude API error' ), { status: response.status, body: result } );
+	}
+
+	const contentArr = result.content as Array< { type: string; text: string } >;
+	const usage = result.usage as { input_tokens: number; output_tokens: number };
+
+	return {
+		content: contentArr[ 0 ]?.text ?? '',
+		usage: { input_tokens: usage.input_tokens, output_tokens: usage.output_tokens },
+	};
+}
+
+async function callOpenAI(
+	body: ProxyRequest,
+	resolvedModel: string,
+	clampedMaxTokens: number,
+	env: Env
+): Promise< NormalizedResponse > {
+	const openaiBody: Record< string, unknown > = {
+		model: resolvedModel,
+		max_tokens: clampedMaxTokens,
+		messages: body.messages,
+	};
+	if ( body.tools && body.tools.length > 0 ) {
+		openaiBody.tools = toOpenAITools( body.tools );
+	}
+
+	const response = await fetch( 'https://api.openai.com/v1/chat/completions', {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${ env.OPENAI_API_KEY }`,
+			'content-type': 'application/json',
+		},
+		body: JSON.stringify( openaiBody ),
+	} );
+
+	const result = ( await response.json() ) as Record< string, unknown >;
+
+	if ( ! response.ok ) {
+		throw Object.assign( new Error( 'OpenAI API error' ), { status: response.status, body: result } );
+	}
+
+	const choices = result.choices as Array< { message: { content: string } } >;
+	const usage = result.usage as { prompt_tokens: number; completion_tokens: number };
+
+	return {
+		content: choices[ 0 ]?.message?.content ?? '',
+		usage: { input_tokens: usage.prompt_tokens, output_tokens: usage.completion_tokens },
+	};
+}
+
+async function callGemini(
+	body: ProxyRequest,
+	resolvedModel: string,
+	env: Env
+): Promise< NormalizedResponse > {
+	const contents = body.messages.map( m => ( { role: m.role, parts: [ { text: m.content } ] } ) );
+	const geminiBody: Record< string, unknown > = { contents };
+	if ( body.tools && body.tools.length > 0 ) {
+		geminiBody.tools = toGeminiTools( body.tools );
+	}
+
+	const response = await fetch(
+		`https://generativelanguage.googleapis.com/v1beta/models/${ resolvedModel }:generateContent?key=${ env.GEMINI_API_KEY }`,
+		{
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify( geminiBody ),
+		}
+	);
+
+	const result = ( await response.json() ) as Record< string, unknown >;
+
+	if ( ! response.ok ) {
+		throw Object.assign( new Error( 'Gemini API error' ), { status: response.status, body: result } );
+	}
+
+	const candidates = result.candidates as Array< { content: { parts: Array< { text: string } > } } >;
+	const usageMeta = result.usageMetadata as { promptTokenCount: number; candidatesTokenCount: number };
+
+	return {
+		content: candidates[ 0 ]?.content?.parts[ 0 ]?.text ?? '',
+		usage: { input_tokens: usageMeta.promptTokenCount, output_tokens: usageMeta.candidatesTokenCount },
+	};
+}
 
 export default {
 	async fetch( request: Request, env: Env ): Promise< Response > {
@@ -64,6 +250,11 @@ async function handleChatProxy(
 		const { messages, model, max_tokens: maxTokens, system, tools } = body;
 		const { site_token: siteToken, tier } = auth;
 
+		const provider: Provider = body.provider ?? 'claude';
+		if ( provider !== 'claude' && provider !== 'openai' && provider !== 'gemini' ) {
+			return jsonResponse( { error: 'Unknown provider' }, 400 );
+		}
+
 		// BYOK sites call Anthropic directly via ClaudeProvider and must never reach here.
 		if ( tier === 'pro_byok' ) {
 			return jsonResponse(
@@ -99,61 +290,30 @@ async function handleChatProxy(
 			);
 		}
 
-		const selectedModel = getModelForTier( effectiveTier, model );
+		const { tierModels, tokenWeights } = await getModelConfig( env );
+		const selectedModel = getModelForTier( provider, effectiveTier, tierModels, model );
 		const clampedMaxTokens = Math.min(
 			maxTokens ?? ( effectiveTier === 'free' ? 1000 : 4000 ),
 			MAX_TOKENS[ effectiveTier ]
 		);
 
-		const anthropicBody: Record< string, unknown > = {
-			model: selectedModel,
-			max_tokens: clampedMaxTokens,
-			messages,
-		};
-		if ( system ) {
-			anthropicBody.system = system;
-		}
-		if ( tools && tools.length > 0 ) {
-			anthropicBody.tools = tools;
-		}
+		// Suppress unused-var warnings — destructured above for validation but passed via body.
+		void messages; void system; void tools;
 
-		const anthropicResponse = await fetch(
-			'https://api.anthropic.com/v1/messages',
-			{
-				method: 'POST',
-				headers: {
-					'x-api-key': env.ANTHROPIC_API_KEY,
-					'anthropic-version': '2023-06-01',
-					'content-type': 'application/json',
-				},
-				body: JSON.stringify( anthropicBody ),
-			}
-		);
-
-		const result = ( await anthropicResponse.json() ) as Record<
-			string,
-			unknown
-		>;
-
-		// Tokens are only tracked for successful (2xx) responses. A non-2xx
-		// Anthropic response with a usage block (e.g. 429 with partial tokens)
-		// is intentionally not counted to avoid billing complexity.
-		if ( anthropicResponse.ok && result.usage ) {
-			const usage = result.usage as {
-				input_tokens: number;
-				output_tokens: number;
-			};
-			await updateUsage(
-				siteToken,
-				usage.input_tokens + usage.output_tokens,
-				env
-			);
+		let normalized: NormalizedResponse;
+		if ( provider === 'claude' ) {
+			normalized = await callClaude( body, selectedModel, clampedMaxTokens, env );
+		} else if ( provider === 'openai' ) {
+			normalized = await callOpenAI( body, selectedModel, clampedMaxTokens, env );
+		} else {
+			normalized = await callGemini( body, selectedModel, env );
 		}
 
-		return new Response( JSON.stringify( result ), {
-			status: anthropicResponse.status,
-			headers: { 'Content-Type': 'application/json' },
-		} );
+		const weight = tokenWeights[ selectedModel ] ?? 1;
+		const rawTokens = normalized.usage.input_tokens + normalized.usage.output_tokens;
+		await updateUsage( siteToken, rawTokens * weight, env );
+
+		return jsonResponse( { content: normalized.content, usage: normalized.usage } );
 	} catch ( error ) {
 		// eslint-disable-next-line no-console
 		console.error( 'Proxy error:', error );
@@ -202,19 +362,13 @@ async function updateUsage(
 	} );
 }
 
-// Mirrors ClaudeProvider::MODELS (PHP). Keep in sync.
-const TIER_MODELS: Record< ProxyTier, string[] > = {
-	free: [ 'claude-haiku-4-5-20251001' ],
-	trial: [ 'claude-haiku-4-5-20251001' ],
-	pro_managed: [
-		'claude-haiku-4-5-20251001',
-		'claude-sonnet-4-6',
-		'claude-opus-4-6',
-	],
-};
-
-function getModelForTier( tier: ProxyTier, requestedModel?: string ): string {
-	const allowed = TIER_MODELS[ tier ];
+function getModelForTier(
+	provider: Provider,
+	tier: ProxyTier,
+	tierModels: Record< string, Record< string, string[] > >,
+	requestedModel?: string
+): string {
+	const allowed = tierModels[ provider ]?.[ tier ] ?? DEFAULT_TIER_MODELS[ provider ][ tier ];
 	if ( requestedModel && allowed.includes( requestedModel ) ) {
 		return requestedModel;
 	}

--- a/wp-ai-mind-proxy/src/index.ts
+++ b/wp-ai-mind-proxy/src/index.ts
@@ -76,7 +76,19 @@ function toOpenAITools( tools: ToolParam[] ) {
 }
 
 function toGeminiTools( tools: ToolParam[] ) {
-	return [ { functionDeclarations: tools.map( t => ( { name: t.name, description: t.description, parameters: { ...t.parameters, type: 'OBJECT' } } ) ) } ];
+	return [ {
+		functionDeclarations: tools.map( t => ( {
+			name: t.name,
+			description: t.description,
+			// Gemini requires uppercase 'OBJECT'; list each field explicitly so future
+			// additions to ToolParam.parameters do not accidentally bleed into the output.
+			parameters: {
+				type: 'OBJECT',
+				properties: t.parameters.properties,
+				required: t.parameters.required,
+			},
+		} ) ),
+	} ];
 }
 
 async function callClaude(
@@ -295,7 +307,7 @@ async function handleChatProxy(
 		}
 
 		const body = JSON.parse( bodyText ) as ProxyRequest;
-		const { messages, model, max_tokens: maxTokens, system, tools } = body;
+		const { model, max_tokens: maxTokens } = body;
 		const { site_token: siteToken, tier } = auth;
 
 		const provider: Provider = body.provider ?? 'claude';
@@ -344,9 +356,6 @@ async function handleChatProxy(
 			maxTokens ?? ( effectiveTier === 'free' ? 1000 : 4000 ),
 			MAX_TOKENS[ effectiveTier ]
 		);
-
-		// Suppress unused-var warnings — destructured above for validation but passed via body.
-		void messages; void system; void tools;
 
 		let normalized: NormalizedResponse;
 		if ( provider === 'claude' ) {

--- a/wp-ai-mind-proxy/src/index.ts
+++ b/wp-ai-mind-proxy/src/index.ts
@@ -153,12 +153,31 @@ async function callOpenAI(
 		throw Object.assign( new Error( 'OpenAI API error' ), { status: response.status, body: result } );
 	}
 
-	const choices = result.choices as Array< { message: { content: string } } >;
+	const choices = result.choices as Array< {
+		message: { content: string; tool_calls?: Array< { id: string; function: { name: string; arguments: string } } > };
+		finish_reason: string;
+	} >;
 	const usage = result.usage as { prompt_tokens: number; completion_tokens: number };
+	const normalizedUsage = { input_tokens: usage.prompt_tokens, output_tokens: usage.completion_tokens };
+
+	if ( choices[ 0 ]?.finish_reason === 'tool_calls' ) {
+		const tc = choices[ 0 ].message.tool_calls?.[ 0 ];
+		if ( tc ) {
+			return {
+				content: '',
+				usage: normalizedUsage,
+				tool_call: {
+					id: tc.id,
+					name: tc.function.name,
+					arguments: JSON.parse( tc.function.arguments ?? '{}' ) as Record< string, unknown >,
+				},
+			};
+		}
+	}
 
 	return {
 		content: choices[ 0 ]?.message?.content ?? '',
-		usage: { input_tokens: usage.prompt_tokens, output_tokens: usage.completion_tokens },
+		usage: normalizedUsage,
 	};
 }
 
@@ -195,12 +214,29 @@ async function callGemini(
 		throw Object.assign( new Error( 'Gemini API error' ), { status: response.status, body: result } );
 	}
 
-	const candidates = result.candidates as Array< { content: { parts: Array< { text: string } > } } >;
+	const candidates = result.candidates as Array< {
+		content: { parts: Array< { text?: string; functionCall?: { name: string; args?: Record< string, unknown > } } > };
+	} >;
 	const usageMeta = result.usageMetadata as { promptTokenCount: number; candidatesTokenCount: number };
+	const normalizedUsage = { input_tokens: usageMeta.promptTokenCount, output_tokens: usageMeta.candidatesTokenCount };
+
+	for ( const part of ( candidates[ 0 ]?.content?.parts ?? [] ) ) {
+		if ( part.functionCall ) {
+			return {
+				content: '',
+				usage: normalizedUsage,
+				tool_call: {
+					id: `gemini_${ Date.now() }`,
+					name: part.functionCall.name,
+					arguments: part.functionCall.args ?? {},
+				},
+			};
+		}
+	}
 
 	return {
 		content: candidates[ 0 ]?.content?.parts[ 0 ]?.text ?? '',
-		usage: { input_tokens: usageMeta.promptTokenCount, output_tokens: usageMeta.candidatesTokenCount },
+		usage: normalizedUsage,
 	};
 }
 

--- a/wp-ai-mind-proxy/src/index.ts
+++ b/wp-ai-mind-proxy/src/index.ts
@@ -165,10 +165,17 @@ async function callOpenAI(
 async function callGemini(
 	body: ProxyRequest,
 	resolvedModel: string,
+	clampedMaxTokens: number,
 	env: Env
 ): Promise< NormalizedResponse > {
 	const contents = body.messages.map( m => ( { role: m.role, parts: [ { text: m.content } ] } ) );
-	const geminiBody: Record< string, unknown > = { contents };
+	const geminiBody: Record< string, unknown > = {
+		contents,
+		generationConfig: { maxOutputTokens: clampedMaxTokens },
+	};
+	if ( body.system ) {
+		geminiBody.systemInstruction = { parts: [ { text: body.system } ] };
+	}
 	if ( body.tools && body.tools.length > 0 ) {
 		geminiBody.tools = toGeminiTools( body.tools );
 	}
@@ -309,7 +316,7 @@ async function handleChatProxy(
 		} else if ( provider === 'openai' ) {
 			normalized = await callOpenAI( body, selectedModel, clampedMaxTokens, env );
 		} else {
-			normalized = await callGemini( body, selectedModel, env );
+			normalized = await callGemini( body, selectedModel, clampedMaxTokens, env );
 		}
 
 		const weight = tokenWeights[ selectedModel ] ?? 1;

--- a/wp-ai-mind-proxy/src/index.ts
+++ b/wp-ai-mind-proxy/src/index.ts
@@ -55,8 +55,10 @@ async function getModelConfig( env: Env ): Promise< {
 		if ( raw ) {
 			const parsed = JSON.parse( raw ) as ModelConfig;
 			return {
-				tierModels:   parsed.tier_models        ?? DEFAULT_TIER_MODELS,
-				tokenWeights: parsed.model_token_weight ?? DEFAULT_MODEL_TOKEN_WEIGHT,
+				// Deep-merge so a partial KV config (e.g. only claude block) does not
+				// discard the defaults for unmentioned providers or model weights.
+				tierModels:   { ...DEFAULT_TIER_MODELS,        ...parsed.tier_models },
+				tokenWeights: { ...DEFAULT_MODEL_TOKEN_WEIGHT, ...parsed.model_token_weight },
 			};
 		}
 	} catch {

--- a/wp-ai-mind-proxy/src/index.ts
+++ b/wp-ai-mind-proxy/src/index.ts
@@ -126,10 +126,13 @@ async function callOpenAI(
 	clampedMaxTokens: number,
 	env: Env
 ): Promise< NormalizedResponse > {
+	const messages = body.system
+		? [ { role: 'system', content: body.system }, ...body.messages ]
+		: body.messages;
 	const openaiBody: Record< string, unknown > = {
 		model: resolvedModel,
 		max_tokens: clampedMaxTokens,
-		messages: body.messages,
+		messages,
 	};
 	if ( body.tools && body.tools.length > 0 ) {
 		openaiBody.tools = toOpenAITools( body.tools );

--- a/wp-ai-mind-proxy/src/types.ts
+++ b/wp-ai-mind-proxy/src/types.ts
@@ -3,6 +3,8 @@
 export interface Env {
 	USAGE_KV: KVNamespace;
 	ANTHROPIC_API_KEY: string;
+	OPENAI_API_KEY: string;
+	GEMINI_API_KEY: string;
 	LS_WEBHOOK_SECRET: string;
 	LS_PRO_MONTHLY_VARIANT_ID: string;
 	LS_PRO_ANNUAL_VARIANT_ID: string;
@@ -32,11 +34,16 @@ export interface LicenceRecord {
 export interface ToolParam {
 	name: string;
 	description: string;
-	input_schema: {
+	parameters: {
 		type: 'object';
 		properties: Record< string, unknown >;
 		required?: string[];
 	};
+}
+
+export interface NormalizedResponse {
+	content: string;
+	usage: { input_tokens: number; output_tokens: number };
 }
 
 export interface ProxyRequest {
@@ -45,9 +52,19 @@ export interface ProxyRequest {
 	max_tokens?: number;
 	system?: string;
 	tools?: ToolParam[];
+	provider?: 'claude' | 'openai' | 'gemini';
 }
 
 export interface MessageParam {
 	role: 'user' | 'assistant';
 	content: string;
+}
+
+/**
+ * Model configuration stored in USAGE_KV under the key `config:models`.
+ * Both fields are optional — absent fields fall back to the compiled defaults in index.ts.
+ */
+export interface ModelConfig {
+	tier_models?: Record< string, Record< string, string[] > >;
+	model_token_weight?: Record< string, number >;
 }

--- a/wp-ai-mind-proxy/src/types.ts
+++ b/wp-ai-mind-proxy/src/types.ts
@@ -44,6 +44,7 @@ export interface ToolParam {
 export interface NormalizedResponse {
 	content: string;
 	usage: { input_tokens: number; output_tokens: number };
+	tool_call?: { id: string; name: string; arguments: Record< string, unknown > };
 }
 
 export interface ProxyRequest {

--- a/wp-ai-mind-proxy/test/chat-proxy.test.ts
+++ b/wp-ai-mind-proxy/test/chat-proxy.test.ts
@@ -14,6 +14,7 @@ const TEST_TOKEN =
 
 const VALID_BODY = JSON.stringify( {
 	messages: [ { role: 'user', content: 'Hello' } ],
+	provider: 'claude',
 } );
 
 async function makeEnvWithSiteToken(
@@ -31,16 +32,26 @@ async function makeEnvWithSiteToken(
 	return env;
 }
 
-function makeChatRequest() {
+function makeChatRequest( body = VALID_BODY ) {
 	return new Request( 'https://worker.example.com/v1/chat', {
 		method: 'POST',
 		headers: {
 			Authorization: `Bearer ${ TEST_TOKEN }`,
 			'Content-Type': 'application/json',
 		},
-		body: VALID_BODY,
+		body,
 	} );
 }
+
+const mockTool: ToolParam = {
+	name: 'get_post_content',
+	description: 'Get post content',
+	parameters: {
+		type: 'object',
+		properties: { post_id: { type: 'integer' } },
+		required: [ 'post_id' ],
+	},
+};
 
 describe( 'handleChatProxy', () => {
 	it( 'returns 403 for pro_byok tier', async () => {
@@ -59,15 +70,11 @@ describe( 'handleChatProxy', () => {
 		const thirtyOneDaysAgo = Date.now() - 31 * 24 * 60 * 60 * 1000;
 		const env = await makeEnvWithSiteToken( 'trial', thirtyOneDaysAgo );
 
-		// Stub fetch so the Anthropic call returns a rate-limit (429) — the
+		// Stub fetch so the upstream call returns a non-2xx — the
 		// important thing is that the demote path runs before the upstream call.
 		vi.stubGlobal(
 			'fetch',
-			vi.fn().mockResolvedValue(
-				new Response( JSON.stringify( { error: 'rate limited' } ), {
-					status: 429,
-				} )
-			)
+			vi.fn().mockRejectedValue( new Error( 'upstream error' ) )
 		);
 
 		await worker.fetch( makeChatRequest(), env );
@@ -80,67 +87,12 @@ describe( 'handleChatProxy', () => {
 		expect( updated.tier ).toBe( 'free' );
 	} );
 
-	it( 'forwards tools to the Anthropic API', async () => {
-		const env = await makeEnvWithSiteToken( 'trial' );
-
-		const mockTool: ToolParam = {
-			name: 'get_post_content',
-			description: 'Get post content',
-			input_schema: {
-				type: 'object',
-				properties: { post_id: { type: 'integer' } },
-				required: [ 'post_id' ],
-			},
-		};
-
-		let capturedBody: Record< string, unknown > | null = null;
-		vi.stubGlobal(
-			'fetch',
-			vi.fn().mockImplementation( async ( _url: string, init: RequestInit ) => {
-				capturedBody = JSON.parse( init.body as string );
-				return new Response(
-					JSON.stringify( {
-						content: [ { type: 'text', text: 'Summary' } ],
-						model: 'claude-haiku-4-5-20251001',
-						usage: { input_tokens: 10, output_tokens: 5 },
-					} ),
-					{ status: 200 }
-				);
-			} )
-		);
-
-		const body = JSON.stringify( {
-			messages: [ { role: 'user', content: 'Summarise post 140' } ],
-			tools: [ mockTool ],
-		} );
-
-		const req = new Request( 'https://worker.example.com/v1/chat', {
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${ TEST_TOKEN }`,
-				'Content-Type': 'application/json',
-			},
-			body,
-		} );
-
-		const response = await worker.fetch( req, env );
-		expect( response.status ).toBe( 200 );
-		expect( capturedBody ).not.toBeNull();
-		expect( ( capturedBody as Record< string, unknown > ).tools ).toEqual( [
-			mockTool,
-		] );
-	} );
-
 	it( 'does not demote an active trial (< 30 days)', async () => {
 		const env = await makeEnvWithSiteToken( 'trial' ); // trial_started_at = now
 
 		vi.stubGlobal(
 			'fetch',
-			vi.fn().mockResolvedValue(
-				new Response( JSON.stringify( { error: 'rate limited' } ), {
-					status: 429,
-				} )
-			)
+			vi.fn().mockRejectedValue( new Error( 'upstream error' ) )
 		);
 
 		await worker.fetch( makeChatRequest(), env );
@@ -150,5 +102,304 @@ describe( 'handleChatProxy', () => {
 			'json'
 		) as SiteRecord;
 		expect( record.tier ).toBe( 'trial' );
+	} );
+
+	it( 'Claude adapter: sends input_schema in upstream request', async () => {
+		const env = await makeEnvWithSiteToken( 'trial' );
+
+		let capturedBody: Record< string, unknown > | null = null;
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async ( _url: string, init: RequestInit ) => {
+				capturedBody = JSON.parse( init.body as string );
+				return new Response(
+					JSON.stringify( {
+						content: [ { type: 'text', text: 'Summary' } ],
+						usage: { input_tokens: 10, output_tokens: 5 },
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Summarise post 140' } ],
+			provider: 'claude',
+			tools: [ mockTool ],
+		} );
+
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		expect( response.status ).toBe( 200 );
+		expect( capturedBody ).not.toBeNull();
+
+		const sentTools = ( capturedBody as Record< string, unknown > ).tools as Array< Record< string, unknown > >;
+		expect( sentTools ).toHaveLength( 1 );
+		expect( sentTools[ 0 ] ).toEqual( {
+			name: 'get_post_content',
+			description: 'Get post content',
+			input_schema: {
+				type: 'object',
+				properties: { post_id: { type: 'integer' } },
+				required: [ 'post_id' ],
+			},
+		} );
+	} );
+
+	it( 'OpenAI adapter: sends correct OpenAI-format body and returns normalised response', async () => {
+		const env = await makeEnvWithSiteToken( 'trial' );
+
+		let capturedUrl: string | null = null;
+		let capturedBody: Record< string, unknown > | null = null;
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async ( url: string, init: RequestInit ) => {
+				capturedUrl = url;
+				capturedBody = JSON.parse( init.body as string );
+				return new Response(
+					JSON.stringify( {
+						choices: [ { message: { content: 'OpenAI reply' } } ],
+						usage: { prompt_tokens: 8, completion_tokens: 4 },
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Hello OpenAI' } ],
+			provider: 'openai',
+			tools: [ mockTool ],
+		} );
+
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		expect( response.status ).toBe( 200 );
+
+		expect( capturedUrl ).toBe( 'https://api.openai.com/v1/chat/completions' );
+
+		const sentTools = ( capturedBody as Record< string, unknown > ).tools as Array< Record< string, unknown > >;
+		expect( sentTools ).toHaveLength( 1 );
+		expect( sentTools[ 0 ] ).toEqual( {
+			type: 'function',
+			function: {
+				name: 'get_post_content',
+				description: 'Get post content',
+				parameters: {
+					type: 'object',
+					properties: { post_id: { type: 'integer' } },
+					required: [ 'post_id' ],
+				},
+			},
+		} );
+
+		const json = ( await response.json() ) as { content: string; usage: { input_tokens: number; output_tokens: number } };
+		expect( json.content ).toBe( 'OpenAI reply' );
+		expect( json.usage ).toEqual( { input_tokens: 8, output_tokens: 4 } );
+	} );
+
+	it( 'Gemini adapter: sends correct Gemini-format body and returns normalised response', async () => {
+		const env = await makeEnvWithSiteToken( 'trial' );
+
+		let capturedUrl: string | null = null;
+		let capturedBody: Record< string, unknown > | null = null;
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async ( url: string, init: RequestInit ) => {
+				capturedUrl = url as string;
+				capturedBody = JSON.parse( init.body as string );
+				return new Response(
+					JSON.stringify( {
+						candidates: [ { content: { parts: [ { text: 'Gemini reply' } ] } } ],
+						usageMetadata: { promptTokenCount: 6, candidatesTokenCount: 3 },
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Hello Gemini' } ],
+			provider: 'gemini',
+			tools: [ mockTool ],
+		} );
+
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		expect( response.status ).toBe( 200 );
+
+		expect( capturedUrl ).toMatch( /generativelanguage\.googleapis\.com/ );
+
+		const contents = ( capturedBody as Record< string, unknown > ).contents as Array< { role: string; parts: Array< { text: string } > } >;
+		expect( contents ).toEqual( [ { role: 'user', parts: [ { text: 'Hello Gemini' } ] } ] );
+
+		const sentTools = ( capturedBody as Record< string, unknown > ).tools as Array< Record< string, unknown > >;
+		expect( sentTools ).toHaveLength( 1 );
+		const decls = ( sentTools[ 0 ] as { functionDeclarations: Array< Record< string, unknown > > } ).functionDeclarations;
+		expect( decls[ 0 ].name ).toBe( 'get_post_content' );
+		expect( ( decls[ 0 ].parameters as Record< string, unknown > ).type ).toBe( 'OBJECT' );
+
+		const json = ( await response.json() ) as { content: string; usage: { input_tokens: number; output_tokens: number } };
+		expect( json.content ).toBe( 'Gemini reply' );
+		expect( json.usage ).toEqual( { input_tokens: 6, output_tokens: 3 } );
+	} );
+
+	it( 'returns 400 for unknown provider', async () => {
+		const env = await makeEnvWithSiteToken( 'trial' );
+
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Hello' } ],
+			provider: 'groq',
+		} );
+
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		expect( response.status ).toBe( 400 );
+		const json = ( await response.json() ) as { error: string };
+		expect( json.error ).toBe( 'Unknown provider' );
+	} );
+
+	it( 'returns 403 when a higher-tier OpenAI model is requested by a free site', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async () => {
+				return new Response(
+					JSON.stringify( {
+						choices: [ { message: { content: 'ok' } } ],
+						usage: { prompt_tokens: 5, completion_tokens: 2 },
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Hello' } ],
+			provider: 'openai',
+			model: 'gpt-4o',
+		} );
+
+		// Free tier does not include gpt-4o — worker should fall back to gpt-4o-mini
+		// and succeed (200), not 403. The tier check silently falls back rather than
+		// rejecting, which matches the existing Claude behaviour.
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		expect( response.status ).toBe( 200 );
+
+		// Verify it fell back to the allowed model, not gpt-4o
+		const sentBody = JSON.parse(
+			( vi.mocked( globalThis.fetch ).mock.calls[ 0 ][ 1 ] as RequestInit ).body as string
+		) as Record< string, unknown >;
+		expect( sentBody.model ).toBe( 'gpt-4o-mini' );
+	} );
+
+	it( 'returns 200 when a higher-tier Gemini model is requested by a free site — falls back to default', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async () => {
+				return new Response(
+					JSON.stringify( {
+						candidates: [ { content: { parts: [ { text: 'ok' } ] } } ],
+						usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2 },
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Hello' } ],
+			provider: 'gemini',
+			model: 'gemini-2.5-pro',
+		} );
+
+		// Free tier does not include gemini-2.5-pro — worker falls back to gemini-2.5-flash.
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		expect( response.status ).toBe( 200 );
+
+		const calledUrl = vi.mocked( globalThis.fetch ).mock.calls[ 0 ][ 0 ] as string;
+		expect( calledUrl ).toContain( 'gemini-2.5-flash' );
+	} );
+
+	it( 'uses KV model config override when config:models is set in USAGE_KV', async () => {
+		const env = await makeEnvWithSiteToken( 'pro_managed' );
+
+		// Override: add a custom model to pro_managed for claude
+		await env.USAGE_KV.put(
+			'config:models',
+			JSON.stringify( {
+				tier_models: {
+					claude: {
+						free:        [ 'claude-haiku-4-5-20251001' ],
+						trial:       [ 'claude-haiku-4-5-20251001' ],
+						pro_managed: [ 'claude-haiku-4-5-20251001', 'claude-opus-4-7' ],
+					},
+				},
+				model_token_weight: { 'claude-opus-4-7': 20 },
+			} )
+		);
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async () => {
+				return new Response(
+					JSON.stringify( {
+						content: [ { type: 'text', text: 'ok' } ],
+						usage: { input_tokens: 10, output_tokens: 5 },
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Hello' } ],
+			provider: 'claude',
+			model: 'claude-opus-4-7',
+		} );
+
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		expect( response.status ).toBe( 200 );
+
+		// Verify the KV-specified model was used
+		const sentBody = JSON.parse(
+			( vi.mocked( globalThis.fetch ).mock.calls[ 0 ][ 1 ] as RequestInit ).body as string
+		) as Record< string, unknown >;
+		expect( sentBody.model ).toBe( 'claude-opus-4-7' );
+
+		// Verify the KV-specified token weight (10+5=15 raw, ×20 = 300 effective)
+		const month = new Date().getFullYear() + '-' + String( new Date().getMonth() + 1 ).padStart( 2, '0' );
+		const stored = await env.USAGE_KV.get( `usage:${ TEST_TOKEN }:${ month }` );
+		expect( Number( stored ) ).toBe( 300 );
+	} );
+
+	it( 'token weight: effective tokens stored in KV equal raw tokens × weight for a heavy model', async () => {
+		const env = await makeEnvWithSiteToken( 'pro_managed' );
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async () => {
+				return new Response(
+					JSON.stringify( {
+						content: [ { type: 'text', text: 'response' } ],
+						usage: { input_tokens: 100, output_tokens: 50 },
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+
+		// claude-opus-4-6 has weight 15
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Hello' } ],
+			provider: 'claude',
+			model: 'claude-opus-4-6',
+		} );
+
+		await worker.fetch( makeChatRequest( body ), env );
+
+		const month = new Date().getFullYear() + '-' + String( new Date().getMonth() + 1 ).padStart( 2, '0' );
+		const stored = await env.USAGE_KV.get( `usage:${ TEST_TOKEN }:${ month }` );
+		// raw = 150, weight = 15, effective = 2250
+		expect( Number( stored ) ).toBe( 2250 );
 	} );
 } );

--- a/wp-ai-mind-proxy/test/helpers/kv-mock.ts
+++ b/wp-ai-mind-proxy/test/helpers/kv-mock.ts
@@ -42,6 +42,8 @@ export function makeEnv( overrides: Partial< Env > = {} ): Env {
 	return {
 		USAGE_KV: makeKV(),
 		ANTHROPIC_API_KEY: 'sk-test',
+		OPENAI_API_KEY: 'sk-openai-test',
+		GEMINI_API_KEY: 'gemini-test',
 		LS_WEBHOOK_SECRET: 'test-secret',
 		LS_PRO_MONTHLY_VARIANT_ID: '1550505',
 		LS_PRO_ANNUAL_VARIANT_ID: '1550477',


### PR DESCRIPTION
## Summary

- **Canonical `ToolParam` format** — renames `input_schema` → `parameters` (JSON Schema standard). The `ProxyRequest` gains a `provider` field (`'claude' | 'openai' | 'gemini'`).
- **Per-provider Worker adapters** — `callClaude`, `callOpenAI`, `callGemini` each build the correct upstream request and normalise the response to a shared `NormalizedResponse` shape.
- **Wire-format adapters** — `toClaudeTools` / `toOpenAITools` / `toGeminiTools` convert canonical `ToolParam[]` to each provider's wire format before forwarding.
- **KV-stored model config** — `TIER_MODELS` and `MODEL_TOKEN_WEIGHT` are loaded from `USAGE_KV` (`config:models` key) with compiled defaults as fallback. Model lists and quota weights can be updated without a Worker redeployment by writing to KV from the admin panel.
- **Token quota weighting** — quota is charged as `raw_tokens × model_weight`, so expensive models (Opus, GPT-4o) count proportionally toward monthly limits.
- **OpenAI + Gemini proxy routing** — both providers now route `free / trial / pro_managed` tiers through the proxy, gaining rate limiting, tier enforcement, and usage tracking.
- **`NJ_Proxy_Client::chat()`** — gains a `$provider` parameter (default `'claude'`).
- **`ToolRegistry::format_proxy()`** — new canonical formatter used by all proxy-routed providers.
- **`ClaudeProvider::complete_via_proxy()`** — converts `input_schema` → `parameters` inline instead of fetching all tools from `ToolRegistry`.

Closes #479 (duplicate #475 closed).

## Test plan

- [ ] All 46 TypeScript Worker tests pass (`npm test` in `wp-ai-mind-proxy/`)
- [ ] All 244 PHP unit tests pass (`./vendor/bin/phpunit tests/Unit/`)
- [ ] PHPCS clean on all changed PHP files
- [ ] KV config override: write `config:models` to `USAGE_KV`, verify Worker uses the overridden model list and token weights
- [ ] Manual smoke test: chat request via ClaudeProvider (managed tier) still routes through proxy correctly
- [ ] Manual smoke test: chat request via OpenAIProvider (managed tier) routes through proxy
- [ ] Manual smoke test: chat request via GeminiProvider (managed tier) routes through proxy

https://claude.ai/code/session_01EpZ8QudXznBMyKWso9fDxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpZ8QudXznBMyKWso9fDxJ)_