### PR TITLE
ci(plugin-check): show PR-vs-base deltas in diagnostic summary

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -183,29 +183,101 @@ jobs:
           include-low-severity-warnings: true
           ignore-warnings: true
 
+      # Build the base ref (target branch) into a sibling dir so we can show
+      # PR-vs-main deltas in the sticky comment. Failure here is non-fatal —
+      # the comment falls back to totals-only when no baseline is available.
+      - name: Checkout base ref for diff
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: base-checkout
+          fetch-depth: 1
+
+      - name: Build base payload (for diff)
+        if: always() && github.event_name == 'pull_request'
+        id: base-build
+        continue-on-error: true
+        working-directory: base-checkout
+        run: |
+          npm ci --no-audit --no-fund
+          bash bin/build-wporg.sh
+
       - name: Compute diagnostic metrics
         if: always()
         id: metrics
         env:
           PLUGIN_DIR: dist/wp-ai-mind
+          BASE_DIR: base-checkout/dist/wp-ai-mind
         run: |
           if [ ! -d "$PLUGIN_DIR" ]; then
             echo "build_present=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # Helpers — count files / measure size for any payload dir.
+          count_php_plugin() { find "$1" -name "*.php" -not -path "*/vendor/*" | wc -l | tr -d ' '; }
+          count_php_vendor() { find "$1/vendor" -name "*.php" 2>/dev/null | wc -l | tr -d ' '; }
+          count_js()         { find "$1" -name "*.js"  | wc -l | tr -d ' '; }
+          count_css()        { find "$1" -name "*.css" | wc -l | tr -d ' '; }
+          size_bytes()       { du -sb "$1" | awk '{print $1}'; }
+
+          # Format an integer delta as "(+N)" / "(-N)" / "" — empty when zero
+          # so unchanged rows stay visually quiet.
+          fmt_int_delta() {
+            if [ "$1" -gt 0 ]; then echo "(+$1)";
+            elif [ "$1" -lt 0 ]; then echo "($1)";
+            else echo ""; fi
+          }
+          # Format a byte delta as "(+1.2K)" / "(-512B)" / "".
+          fmt_size_delta() {
+            if [ "$1" -eq 0 ]; then echo ""; return; fi
+            local sign abs
+            if [ "$1" -gt 0 ]; then sign="+"; abs="$1"; else sign="-"; abs="$(( -$1 ))"; fi
+            echo "(${sign}$(numfmt --to=iec --suffix=B "$abs"))"
+          }
+
           PLUGIN_VERSION=$(grep "Version:" "$PLUGIN_DIR/wp-ai-mind.php" | head -1 | sed 's/.*Version:[[:space:]]*//' | tr -d '[:space:]')
           BUILD_SIZE=$(du -sh "$PLUGIN_DIR" | awk '{print $1}')
-          PHP_COUNT=$(find "$PLUGIN_DIR" -name "*.php" -not -path "*/vendor/*" | wc -l | tr -d ' ')
-          VENDOR_PHP=$(find "$PLUGIN_DIR/vendor" -name "*.php" 2>/dev/null | wc -l | tr -d ' ')
-          JS_COUNT=$(find "$PLUGIN_DIR" -name "*.js" | wc -l | tr -d ' ')
-          CSS_COUNT=$(find "$PLUGIN_DIR" -name "*.css" | wc -l | tr -d ' ')
-          echo "build_present=true" >> "$GITHUB_OUTPUT"
-          echo "plugin_version=$PLUGIN_VERSION" >> "$GITHUB_OUTPUT"
-          echo "build_size=$BUILD_SIZE" >> "$GITHUB_OUTPUT"
-          echo "php_count=$PHP_COUNT" >> "$GITHUB_OUTPUT"
-          echo "vendor_php=$VENDOR_PHP" >> "$GITHUB_OUTPUT"
-          echo "js_count=$JS_COUNT" >> "$GITHUB_OUTPUT"
-          echo "css_count=$CSS_COUNT" >> "$GITHUB_OUTPUT"
+          PHP_COUNT=$(count_php_plugin "$PLUGIN_DIR")
+          VENDOR_PHP=$(count_php_vendor "$PLUGIN_DIR")
+          JS_COUNT=$(count_js "$PLUGIN_DIR")
+          CSS_COUNT=$(count_css "$PLUGIN_DIR")
+
+          BUILD_SIZE_DELTA=""
+          PHP_DELTA=""
+          VENDOR_PHP_DELTA=""
+          JS_DELTA=""
+          CSS_DELTA=""
+          BASE_AVAILABLE="false"
+          BASE_REF=""
+
+          if [ -d "$BASE_DIR" ]; then
+            BASE_AVAILABLE="true"
+            BASE_REF="${{ github.base_ref }}"
+            BUILD_SIZE_DELTA=$(fmt_size_delta "$(( $(size_bytes "$PLUGIN_DIR") - $(size_bytes "$BASE_DIR") ))")
+            PHP_DELTA=$(fmt_int_delta        "$(( PHP_COUNT  - $(count_php_plugin "$BASE_DIR") ))")
+            VENDOR_PHP_DELTA=$(fmt_int_delta "$(( VENDOR_PHP - $(count_php_vendor "$BASE_DIR") ))")
+            JS_DELTA=$(fmt_int_delta         "$(( JS_COUNT   - $(count_js         "$BASE_DIR") ))")
+            CSS_DELTA=$(fmt_int_delta        "$(( CSS_COUNT  - $(count_css        "$BASE_DIR") ))")
+          fi
+
+          {
+            echo "build_present=true"
+            echo "plugin_version=$PLUGIN_VERSION"
+            echo "build_size=$BUILD_SIZE"
+            echo "php_count=$PHP_COUNT"
+            echo "vendor_php=$VENDOR_PHP"
+            echo "js_count=$JS_COUNT"
+            echo "css_count=$CSS_COUNT"
+            echo "base_available=$BASE_AVAILABLE"
+            echo "base_ref=$BASE_REF"
+            echo "build_size_delta=$BUILD_SIZE_DELTA"
+            echo "php_delta=$PHP_DELTA"
+            echo "vendor_php_delta=$VENDOR_PHP_DELTA"
+            echo "js_delta=$JS_DELTA"
+            echo "css_delta=$CSS_DELTA"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Post diagnostic summary (sticky — updates in place)
         if: always() && steps.metrics.outputs.build_present == 'true'
@@ -218,14 +290,16 @@ jobs:
             **Audited shipping payload** built by `bin/build-wporg.sh` → `dist/wp-ai-mind/`
             (matches the production zip uploaded to GitHub Releases.)
 
-            | Metric | Value |
-            |---|---|
-            | Plugin version | `${{ steps.metrics.outputs.plugin_version }}` |
-            | Build size | ${{ steps.metrics.outputs.build_size }} |
-            | PHP files (plugin) | ${{ steps.metrics.outputs.php_count }} |
-            | PHP files (vendor) | ${{ steps.metrics.outputs.vendor_php }} |
-            | JS files | ${{ steps.metrics.outputs.js_count }} |
-            | CSS files | ${{ steps.metrics.outputs.css_count }} |
+            | Metric | Value | Δ vs `${{ steps.metrics.outputs.base_ref || 'main' }}` |
+            |---|---|---|
+            | Plugin version | `${{ steps.metrics.outputs.plugin_version }}` | — |
+            | Build size | ${{ steps.metrics.outputs.build_size }} | ${{ steps.metrics.outputs.build_size_delta || '—' }} |
+            | PHP files (plugin) | ${{ steps.metrics.outputs.php_count }} | ${{ steps.metrics.outputs.php_delta || '—' }} |
+            | PHP files (vendor) | ${{ steps.metrics.outputs.vendor_php }} | ${{ steps.metrics.outputs.vendor_php_delta || '—' }} |
+            | JS files | ${{ steps.metrics.outputs.js_count }} | ${{ steps.metrics.outputs.js_delta || '—' }} |
+            | CSS files | ${{ steps.metrics.outputs.css_count }} | ${{ steps.metrics.outputs.css_delta || '—' }} |
+
+            ${{ steps.metrics.outputs.base_available == 'true' && '_Empty Δ cells mean unchanged. Baseline rebuilt from the target branch on each run._' || '_Baseline build for the target branch was unavailable, so deltas are not shown. Totals reflect the PR head only._' }}
 
             **Categories:** `general` · `security` · `performance` · `accessibility` · `plugin_repo`
             **Experimental checks:** enabled

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -206,9 +206,13 @@ jobs:
       - name: Compute diagnostic metrics
         if: always()
         id: metrics
+        # github.base_ref is user-controlled (PR target branch), so it must
+        # be passed through env to avoid run-shell-injection (Semgrep
+        # yaml.github-actions.security.run-shell-injection).
         env:
           PLUGIN_DIR: dist/wp-ai-mind
           BASE_DIR: base-checkout/dist/wp-ai-mind
+          BASE_REF: ${{ github.base_ref }}
         run: |
           if [ ! -d "$PLUGIN_DIR" ]; then
             echo "build_present=false" >> "$GITHUB_OUTPUT"
@@ -250,11 +254,11 @@ jobs:
           JS_DELTA=""
           CSS_DELTA=""
           BASE_AVAILABLE="false"
-          BASE_REF=""
+          REPORTED_BASE_REF=""
 
           if [ -d "$BASE_DIR" ]; then
             BASE_AVAILABLE="true"
-            BASE_REF="${{ github.base_ref }}"
+            REPORTED_BASE_REF="$BASE_REF"
             BUILD_SIZE_DELTA=$(fmt_size_delta "$(( $(size_bytes "$PLUGIN_DIR") - $(size_bytes "$BASE_DIR") ))")
             PHP_DELTA=$(fmt_int_delta        "$(( PHP_COUNT  - $(count_php_plugin "$BASE_DIR") ))")
             VENDOR_PHP_DELTA=$(fmt_int_delta "$(( VENDOR_PHP - $(count_php_vendor "$BASE_DIR") ))")
@@ -271,7 +275,7 @@ jobs:
             echo "js_count=$JS_COUNT"
             echo "css_count=$CSS_COUNT"
             echo "base_available=$BASE_AVAILABLE"
-            echo "base_ref=$BASE_REF"
+            echo "base_ref=$REPORTED_BASE_REF"
             echo "build_size_delta=$BUILD_SIZE_DELTA"
             echo "php_delta=$PHP_DELTA"
             echo "vendor_php_delta=$VENDOR_PHP_DELTA"


### PR DESCRIPTION
## Summary

Adds a Δ column to the sticky **Plugin Check — Diagnostic Summary** comment so reviewers can see how a PR moves the shipping payload at a glance, without diffing line-by-line.

The job now:

1. Builds the PR head into `dist/wp-ai-mind/` (unchanged behaviour).
2. Checks out the target branch (`github.base_ref`) into `base-checkout/` and runs the same `bin/build-wporg.sh` there.
3. Computes deltas (file counts + total size in bytes) and renders them next to each total.

If the baseline build fails (e.g. base ref unavailable), the comment falls back to totals-only with a note.

Example rendered table:

| Metric | Value | Δ vs `main` |
|---|---|---|
| Plugin version | `1.8.0` | — |
| Build size | 1.2M | (+12KB) |
| PHP files (plugin) | 60 | (+1) |
| PHP files (vendor) | 10 |  |
| JS files | 7 |  |
| CSS files | 15 |  |

Empty Δ cells mean unchanged.

## Trade-off

The job builds the plugin twice (PR head + base ref), adding roughly 2–3 minutes to the `plugin-check` job. The user opted for full-build accuracy over a source-only diff because vendor/ and built JS/CSS only show up in the real payload.

## Test Plan

- [ ] CI runs on this PR; sticky comment posts with Δ column populated against `main`.
- [ ] All Δ cells show empty (no changes to plugin payload — only `.github/workflows/pr-checks.yml` changed).
- [ ] Plugin Check job stays green; no new findings introduced by the workflow change.