### PR TITLE
fix(proxy): schedule re-registration on shutdown when site token is absent

### DIFF
--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -107,6 +107,9 @@ class NJ_Proxy_Client {
 			// Re-registration is async; the current request cannot be retried transparently.
 			// TODO #326: inline register() + retry once to avoid user-visible auth errors.
 			delete_option( NJ_Site_Registration::OPTION_TOKEN );
+			if ( ! has_action( 'shutdown', [ NJ_Site_Registration::class, 'maybe_register' ] ) ) {
+				add_action( 'shutdown', [ NJ_Site_Registration::class, 'maybe_register' ] );
+			}
 			return new WP_Error( 'proxy_auth_failed', __( 'Proxy authentication failed. Please reload the page and try again.', 'wp-ai-mind' ) );
 		}
 

--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -40,6 +40,12 @@ class NJ_Proxy_Client {
 	public static function chat( array $messages, array $options = [], string $provider = 'claude' ): array|WP_Error {
 		$token = NJ_Site_Registration::get_site_token();
 		if ( empty( $token ) ) {
+			// Schedule re-registration after the current response is sent. Inline registration
+			// risks a loopback deadlock on single-worker setups because the Worker's challenge
+			// callback is a fresh HTTP request that would queue behind the in-flight request.
+			if ( ! has_action( 'shutdown', [ NJ_Site_Registration::class, 'maybe_register' ] ) ) {
+				add_action( 'shutdown', [ NJ_Site_Registration::class, 'maybe_register' ] );
+			}
 			return new WP_Error( 'not_registered', __( 'Site not registered with AI proxy.', 'wp-ai-mind' ) );
 		}
 

--- a/includes/Proxy/NJ_Proxy_Client.php
+++ b/includes/Proxy/NJ_Proxy_Client.php
@@ -40,9 +40,9 @@ class NJ_Proxy_Client {
 	public static function chat( array $messages, array $options = [], string $provider = 'claude' ): array|WP_Error {
 		$token = NJ_Site_Registration::get_site_token();
 		if ( empty( $token ) ) {
-			// Schedule re-registration after the current response is sent. Inline registration
-			// risks a loopback deadlock on single-worker setups because the Worker's challenge
-			// callback is a fresh HTTP request that would queue behind the in-flight request.
+			// Inline registration risks a loopback deadlock on single-worker setups because
+			// the Worker's challenge callback is a fresh HTTP request that would queue behind
+			// the in-flight request.
 			if ( ! has_action( 'shutdown', [ NJ_Site_Registration::class, 'maybe_register' ] ) ) {
 				add_action( 'shutdown', [ NJ_Site_Registration::class, 'maybe_register' ] );
 			}

--- a/tests/Unit/Proxy/NJProxyClientTest.php
+++ b/tests/Unit/Proxy/NJProxyClientTest.php
@@ -78,6 +78,13 @@ class NJProxyClientTest extends TestCase {
 		Functions\expect( 'delete_option' )
 			->once()
 			->with( NJ_Site_Registration::OPTION_TOKEN );
+		Functions\expect( 'has_action' )
+			->once()
+			->with( 'shutdown', [ NJ_Site_Registration::class, 'maybe_register' ] )
+			->andReturn( false );
+		Functions\expect( 'add_action' )
+			->once()
+			->with( 'shutdown', [ NJ_Site_Registration::class, 'maybe_register' ] );
 		Functions\when( '__' )->alias( fn( $s ) => $s );
 
 		$result = NJ_Proxy_Client::chat( [ [ 'role' => 'user', 'content' => 'hi' ] ] );

--- a/tests/Unit/Proxy/NJProxyClientTest.php
+++ b/tests/Unit/Proxy/NJProxyClientTest.php
@@ -25,13 +25,50 @@ class NJProxyClientTest extends TestCase {
 		Functions\expect( 'get_option' )
 			->with( NJ_Site_Registration::OPTION_TOKEN, '' )
 			->andReturn( '' );
-
+		Functions\when( 'has_action' )->justReturn( false );
+		Functions\when( 'add_action' )->justReturn( null );
 		Functions\when( '__' )->alias( fn( $s ) => $s );
 
 		$result = NJ_Proxy_Client::chat( [] );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'not_registered', $result->code );
+	}
+
+	public function test_chat_schedules_shutdown_hook_when_not_registered_and_no_existing_action(): void {
+		Functions\expect( 'get_option' )
+			->with( NJ_Site_Registration::OPTION_TOKEN, '' )
+			->andReturn( '' );
+		Functions\expect( 'has_action' )
+			->once()
+			->with( 'shutdown', [ NJ_Site_Registration::class, 'maybe_register' ] )
+			->andReturn( false );
+		Functions\expect( 'add_action' )
+			->once()
+			->with( 'shutdown', [ NJ_Site_Registration::class, 'maybe_register' ] );
+		Functions\when( '__' )->alias( fn( $s ) => $s );
+
+		$result = NJ_Proxy_Client::chat( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'not_registered', $result->get_error_code() );
+	}
+
+	public function test_chat_does_not_schedule_duplicate_shutdown_hook_when_already_registered(): void {
+		Functions\expect( 'get_option' )
+			->with( NJ_Site_Registration::OPTION_TOKEN, '' )
+			->andReturn( '' );
+		Functions\expect( 'has_action' )
+			->once()
+			->with( 'shutdown', [ NJ_Site_Registration::class, 'maybe_register' ] )
+			->andReturn( true );
+		Functions\expect( 'add_action' )->never();
+		Functions\when( '__' )->alias( fn( $s ) => $s );
+
+		$result = NJ_Proxy_Client::chat( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'not_registered', $result->get_error_code() );
 	}
 
 	public function test_chat_returns_error_when_usage_limit_exceeded(): void {


### PR DESCRIPTION
## Summary

- Fixes the 502 loop that REST callers fall into after a site token is cleared by a stale-401 response from the proxy
- Re-registration is scheduled via a `shutdown` action rather than inline, avoiding a loopback deadlock on single-worker setups

## Problem

When `NJ_Proxy_Client::chat()` receives a 401 from the proxy it deletes the site token and returns `proxy_auth_failed`. On the next REST request `get_site_token()` returns empty, so every call immediately returns `not_registered` → `ProviderException` → HTTP 502. The site previously only self-healed when an **admin page** was loaded (firing `admin_init` → `maybe_register()`). REST-only callers (e.g. the SEO generate endpoint called from the block editor) had no recovery path.

## Solution

When the token is found empty, register a `shutdown` action for `NJ_Site_Registration::maybe_register()` **before** returning the error. After the current response is sent PHP's shutdown fires, registration completes, and the next request succeeds.

Inline registration is intentionally avoided: the Worker uses a two-step challenge/callback handshake — the callback is a fresh loopback HTTP request that would block behind the in-flight request on single-worker setups, causing a deadlock.

## Test plan

- [ ] Clear site token manually (`delete_option('wp_ai_mind_site_token')`) on a local install
- [ ] Call the SEO generate REST endpoint — expect 502 on first call, then confirm token is re-issued in the background (check `get_option('wp_ai_mind_site_token')`)
- [ ] Second call should succeed without loading any admin page
- [ ] Confirm no regression: normal requests with a valid token are unaffected (shutdown action is only added when token is empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)