### PR TITLE
feat(tiers): add wp_ai_mind_proxy_url option to get_proxy_url()

### DIFF
--- a/includes/Tiers/NJ_Tier_Config.php
+++ b/includes/Tiers/NJ_Tier_Config.php
@@ -88,7 +88,14 @@ class NJ_Tier_Config {
 	 * @return string Base URL without trailing slash.
 	 */
 	public static function get_proxy_url(): string {
-		return rtrim( defined( 'WP_AI_MIND_PROXY_URL' ) ? WP_AI_MIND_PROXY_URL : 'https://wp-ai-mind-proxy.wp-ai-mind.workers.dev', '/' );
+		if ( defined( 'WP_AI_MIND_PROXY_URL' ) ) {
+			return rtrim( WP_AI_MIND_PROXY_URL, '/' );
+		}
+		$option = (string) get_option( 'wp_ai_mind_proxy_url', '' );
+		if ( '' !== $option ) {
+			return rtrim( $option, '/' );
+		}
+		return 'https://wp-ai-mind-proxy.wp-ai-mind.workers.dev';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- `NJ_Tier_Config::get_proxy_url()` now checks a `wp_ai_mind_proxy_url` WordPress option as a middle-priority override between the `WP_AI_MIND_PROXY_URL` constant and the hard-coded production default.
- Priority order: constant > WP option > hard-coded default.
- No behaviour change for existing installs (option is unset → fallback unchanged).

## Why

The Cloudflare Worker proxy was split into separate production (`wp-ai-mind-proxy`) and dev (`wp-ai-mind-proxy-dev`) deployments. Dev environments (localhost, staging4) need to point at the dev Worker. Previously this required adding `WP_AI_MIND_PROXY_URL` to `wp-config.php`; now it can be done via WP-CLI without touching server files:

```bash
wp option update wp_ai_mind_proxy_url https://wp-ai-mind-proxy-dev.<account>.workers.dev
```

## Test plan

- [ ] On a dev install: set the option via WP-CLI, trigger a devtools action (set-tier / reset-usage / set-ceiling), confirm `worker_synced: true` in the response.
- [ ] On production: leave option unset, confirm normal proxy calls continue to reach `wp-ai-mind-proxy.wp-ai-mind.workers.dev`.
- [ ] With `WP_AI_MIND_PROXY_URL` defined in `wp-config.php` and the option also set, confirm the constant wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)