### PR TITLE
fix(ci): post-rebrand CI fixes and code review improvements

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
     paths-ignore:
       - "package-lock.json"
       - "composer.lock"
@@ -31,15 +31,18 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Guard — skip if workflow files changed
+      - name: Guard — skip if this review workflow itself changed
         id: guard
         run: |
+          # Only skip when claude-code-review.yml itself is modified — that is the
+          # file claude-code-action integrity-checks against main. Changes to other
+          # workflow files (pr-checks.yml, release.yml, etc.) do not affect this.
           count=$(gh api \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '[.[] | select(.filename | startswith(".github/workflows/"))] | length')
+            --jq '[.[] | select(.filename == ".github/workflows/claude-code-review.yml")] | length')
           if [[ "$count" -gt 0 ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping Claude Code Review — this PR modifies workflow files. The claude-code-action security check would fail because the workflow on this branch differs from main."
+            echo "::notice::Skipping Claude Code Review — this PR modifies claude-code-review.yml itself. The claude-code-action integrity check would fail because the workflow on this branch differs from main."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -128,7 +128,7 @@ jobs:
           tools: composer:v2
 
       - name: Composer security audit
-        run: composer audit
+        run: composer audit --locked
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -214,6 +214,18 @@ jobs:
       - name: Build production plugin payload (dist/wp-ai-mind/)
         run: bash bin/build-wporg.sh
 
+      - name: Configure wp-env to load built plugin
+        run: |
+          cat > .wp-env.override.json << 'EOF'
+          {
+            "plugins": ["./dist/stilus"],
+            "config": { "WP_DEBUG": false, "SCRIPT_DEBUG": false }
+          }
+          EOF
+
+      - name: Start wp-env
+        run: npx wp-env start
+
       - name: Run WP Plugin Check
         uses: WordPress/plugin-check-action@v1
         with:
@@ -225,6 +237,10 @@ jobs:
           include-low-severity-errors: true
           include-low-severity-warnings: true
           ignore-warnings: true
+
+      - name: Stop wp-env
+        if: always()
+        run: npx wp-env stop || true
 
       # Build the base ref (target branch) into a sibling dir so we can show
       # PR-vs-main deltas in the sticky comment. Failure here is non-fatal —

--- a/bin/build-wporg.sh
+++ b/bin/build-wporg.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PLUGIN_SLUG="wp-ai-mind"
+PLUGIN_SLUG="stilus"
 VERSION=""
 SKIP_BUILD=false
 
@@ -19,7 +19,7 @@ done
 
 # Fall back to version from main plugin file
 if [[ -z "$VERSION" ]]; then
-    VERSION=$(grep "Version:" "${PLUGIN_DIR}/wp-ai-mind.php" | head -1 | sed 's/.*Version:[[:space:]]*//' | tr -d '[:space:]')
+    VERSION=$(grep "Version:" "${PLUGIN_DIR}/stilus.php" | head -1 | sed 's/.*Version:[[:space:]]*//' | tr -d '[:space:]')
 fi
 
 DIST_DIR="${PLUGIN_DIR}/dist"
@@ -46,7 +46,7 @@ rsync -a \
     --include='languages/***' \
     --include='vendor/***' \
     --include='assets/***' \
-    --include='wp-ai-mind.php' \
+    --include='stilus.php' \
     --include='readme.txt' \
     --include='uninstall.php' \
     --include='CHANGELOG.md' \


### PR DESCRIPTION
## Summary

Three CI fixes that unblocked failing PR checks after the Stilus rename, plus an improvement to the Claude Code Review guard — split from #596 so the review workflow is clean on main before the rebrand lands.

- **`bin/build-wporg.sh`**: rename `PLUGIN_SLUG` `wp-ai-mind` → `stilus`, update `grep` path from `wp-ai-mind.php` → `stilus.php`, update rsync allowlist
- **`pr-checks.yml`**: `composer audit` → `composer audit --locked` (no `vendor/` in the security job), pre-start `wp-env` before `plugin-check-action@v1` (the action fails to initialise its own environment; pre-starting matches the pattern already used by Lighthouse and E2E jobs)
- **`claude-code-review.yml`**: narrow the workflow-change guard from _any_ `.github/workflows/` file to _only_ `claude-code-review.yml` itself (the integrity check only cares about this file, not other workflows); add `synchronize` trigger temporarily so that merging `main` into #596 fires a review run — a follow-up commit will revert to `opened` only once the review has run

## After this merges

1. Merge `main` into `chore/rebrand-to-stilus` (PR #596) — the `synchronize` event fires the Claude Code Review automatically, since `claude-code-review.yml` will no longer be in #596's diff
2. Open a small follow-up PR to revert `synchronize` → `opened` only

## Test plan

- [ ] `bin/build-wporg.sh` runs locally: `bash bin/build-wporg.sh --skip-build` creates `dist/stilus/`
- [ ] Lighthouse and WP Plugin Check pass in CI
- [ ] Security audit passes (composer audit --locked)
- [ ] Claude Code Review fires on the next PR that doesn't modify `claude-code-review.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)