### PR TITLE
fix(chat): show connection error for proxy-tier users when registration fails

### DIFF
--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -310,6 +310,7 @@ class ChatRestController {
 
 				if ( $is_proxy_tier ) {
 					// Site token absent — schedule re-registration so the next page load succeeds.
+					// Guard against double-scheduling: add_action does not deduplicate identical callbacks on the same hook.
 					if ( ! has_action( 'shutdown', [ SiteRegistration::class, 'maybe_register' ] ) ) {
 						add_action( 'shutdown', [ SiteRegistration::class, 'maybe_register' ] );
 					}

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -21,6 +21,7 @@ use Stilus\Settings\ProviderSettings;
 use Stilus\Tools\ToolRegistry;
 use Stilus\Tools\ToolExecutor;
 use Stilus\Voice\VoiceInjector;
+use Stilus\Proxy\SiteRegistration;
 use Stilus\Tiers\TierManager;
 use Stilus\Tiers\UsageTracker;
 
@@ -302,10 +303,26 @@ class ChatRestController {
 			$provider = $factory->make( $provider_slug );
 
 			if ( ! $provider->is_available() ) {
+				$tier        = TierManager::get_user_tier( get_current_user_id() );
+				$proxy_tiers = [ 'free', 'trial', 'pro_managed' ];
+
+				if ( in_array( $tier, $proxy_tiers, true ) ) {
+					// Site token absent — schedule re-registration so the next page load succeeds.
+					if ( ! has_action( 'shutdown', [ SiteRegistration::class, 'maybe_register' ] ) ) {
+						add_action( 'shutdown', [ SiteRegistration::class, 'maybe_register' ] );
+					}
+					return new \WP_REST_Response(
+						[
+							'message' => __( 'Could not connect to Stilus — Write and Design. Please reload the page and try again.', 'stilus' ),
+						],
+						503
+					);
+				}
+
 				return new \WP_REST_Response(
 					[
 						'message' => sprintf(
-												/* translators: %s: provider slug */
+							/* translators: %s: provider slug */
 							__( 'No API key configured for "%s". Please add one in Stilus → Settings.', 'stilus' ),
 							$provider_slug
 						),

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -266,11 +266,12 @@ class ChatRestController {
 		$provider_slug  = ! empty( $provider_param ) ? $provider_param : \get_option( 'stilus_default_provider', 'claude' );
 		$model          = $request->get_param( 'model' );
 
-		$store = $this->make_store();
+		$user_id = \get_current_user_id();
+		$store   = $this->make_store();
 
 		// Ownership guard.
 		$conv = $store->get_conversation( $conv_id );
-		if ( ! $conv || \get_current_user_id() !== (int) $conv['user_id'] ) {
+		if ( ! $conv || $user_id !== (int) $conv['user_id'] ) {
 			return new \WP_REST_Response( [ 'message' => 'Forbidden.' ], 403 );
 		}
 
@@ -286,7 +287,7 @@ class ChatRestController {
 		);
 
 		$injector = $this->make_voice_injector();
-		$system   = $injector->build_system_prompt( '', \get_current_user_id() );
+		$system   = $injector->build_system_prompt( '', $user_id );
 
 		$context_post_id = absint( $request->get_param( 'context_post_id' ) );
 		if ( $context_post_id > 0 ) {
@@ -303,7 +304,7 @@ class ChatRestController {
 			$provider = $factory->make( $provider_slug );
 
 			if ( ! $provider->is_available() ) {
-				$tier        = TierManager::get_user_tier( get_current_user_id() );
+				$tier        = TierManager::get_user_tier( $user_id );
 				$proxy_tiers = [ 'free', 'trial', 'pro_managed' ];
 
 				if ( in_array( $tier, $proxy_tiers, true ) ) {
@@ -392,7 +393,7 @@ class ChatRestController {
 					$tool_results[ $tu['id'] ] = $this->tool_executor->execute(
 						$tu['name'],
 						$arguments,
-						\get_current_user_id()
+						$user_id
 					);
 				}
 

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -305,7 +305,7 @@ class ChatRestController {
 			$provider = $factory->make( $provider_slug );
 
 			if ( ! $provider->is_available() ) {
-				$tier          = TierManager::get_user_tier( $user_id );
+				$tier          = $this->get_user_tier( $user_id );
 				$is_proxy_tier = ! TierConfig::get_feature( $tier, 'own_api_key' );
 
 				if ( $is_proxy_tier ) {
@@ -616,6 +616,20 @@ class ChatRestController {
 	 */
 	protected function user_within_quota( int $user_id ): bool {
 		return UsageTracker::check_limit( $user_id );
+	}
+
+	/**
+	 * Returns the tier slug for a user.
+	 *
+	 * Isolated as a protected method so tests can override without stubbing
+	 * static calls on TierManager.
+	 *
+	 * @since 1.8.0
+	 * @param int $user_id WordPress user ID.
+	 * @return string Tier slug.
+	 */
+	protected function get_user_tier( int $user_id ): string {
+		return TierManager::get_user_tier( $user_id );
 	}
 
 	// ── Overridable factory methods (for testing) ─────────────────────────────

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -22,6 +22,7 @@ use Stilus\Tools\ToolRegistry;
 use Stilus\Tools\ToolExecutor;
 use Stilus\Voice\VoiceInjector;
 use Stilus\Proxy\SiteRegistration;
+use Stilus\Tiers\TierConfig;
 use Stilus\Tiers\TierManager;
 use Stilus\Tiers\UsageTracker;
 
@@ -304,10 +305,10 @@ class ChatRestController {
 			$provider = $factory->make( $provider_slug );
 
 			if ( ! $provider->is_available() ) {
-				$tier        = TierManager::get_user_tier( $user_id );
-				$proxy_tiers = [ 'free', 'trial', 'pro_managed' ];
+				$tier          = TierManager::get_user_tier( $user_id );
+				$is_proxy_tier = ! TierConfig::get_feature( $tier, 'own_api_key' );
 
-				if ( in_array( $tier, $proxy_tiers, true ) ) {
+				if ( $is_proxy_tier ) {
 					// Site token absent — schedule re-registration so the next page load succeeds.
 					if ( ! has_action( 'shutdown', [ SiteRegistration::class, 'maybe_register' ] ) ) {
 						add_action( 'shutdown', [ SiteRegistration::class, 'maybe_register' ] );

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -744,6 +744,182 @@ class ChatRestControllerTest extends TestCase {
         $this->assertStringContainsString( 'limit', $response->data['message'] );
     }
 
+    // ── Provider unavailability — 503 / 422 branching ─────────────────────────
+
+    /**
+     * Helper: extend make_controller() with a fixed tier for the unavailability branch.
+     *
+     * @param \Stilus\DB\ConversationStore    $store
+     * @param \Stilus\Providers\ProviderFactory $factory
+     * @param \Stilus\Voice\VoiceInjector      $voice
+     * @param string                           $tier    Tier slug returned by get_user_tier().
+     * @return ChatRestController
+     */
+    private function make_controller_with_tier(
+        \Stilus\DB\ConversationStore $store,
+        \Stilus\Providers\ProviderFactory $factory,
+        \Stilus\Voice\VoiceInjector $voice,
+        string $tier
+    ): ChatRestController {
+        return new class(
+            $this->tool_registry,
+            $this->tool_executor,
+            $store,
+            $factory,
+            $voice,
+            $tier
+        ) extends ChatRestController {
+            private \Stilus\DB\ConversationStore $store_override;
+            private \Stilus\Providers\ProviderFactory $factory_override;
+            private \Stilus\Voice\VoiceInjector $voice_override;
+            private string $tier_override;
+
+            public function __construct(
+                ToolRegistry $tr,
+                ToolExecutor $te,
+                \Stilus\DB\ConversationStore $store,
+                \Stilus\Providers\ProviderFactory $factory,
+                \Stilus\Voice\VoiceInjector $voice,
+                string $tier
+            ) {
+                parent::__construct( $tr, $te );
+                $this->store_override   = $store;
+                $this->factory_override = $factory;
+                $this->voice_override   = $voice;
+                $this->tier_override    = $tier;
+            }
+            protected function make_store(): \Stilus\DB\ConversationStore {
+                return $this->store_override;
+            }
+            protected function make_provider_factory(): \Stilus\Providers\ProviderFactory {
+                return $this->factory_override;
+            }
+            protected function make_voice_injector(): \Stilus\Voice\VoiceInjector {
+                return $this->voice_override;
+            }
+            protected function get_user_tier( int $user_id ): string {
+                return $this->tier_override;
+            }
+        };
+    }
+
+    /**
+     * A proxy-tier user whose provider is unavailable must receive a 503.
+     */
+    public function test_send_message_returns_503_for_proxy_tier_when_provider_unavailable(): void {
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );
+        Functions\when( 'get_option' )->justReturn( 'claude' );
+        Functions\when( '__' )->alias( fn( $s ) => $s );
+        Functions\when( 'has_action' )->justReturn( false );
+        Functions\when( 'add_action' )->justReturn( null );
+
+        $store_mock = $this->createMock( \Stilus\DB\ConversationStore::class );
+        $store_mock->method( 'get_conversation' )->willReturn( [ 'user_id' => 1 ] );
+        $store_mock->method( 'get_messages' )->willReturn( [] );
+
+        $provider_mock = $this->createMock( \Stilus\Providers\ProviderInterface::class );
+        $provider_mock->method( 'is_available' )->willReturn( false );
+
+        $factory_mock = $this->createMock( \Stilus\Providers\ProviderFactory::class );
+        $factory_mock->method( 'make' )->willReturn( $provider_mock );
+
+        $voice_mock = $this->createMock( \Stilus\Voice\VoiceInjector::class );
+        $voice_mock->method( 'build_system_prompt' )->willReturn( '' );
+
+        $controller = $this->make_controller_with_tier( $store_mock, $factory_mock, $voice_mock, 'free' );
+
+        $request = new \WP_REST_Request( 'POST' );
+        $request->set_url_params( [ 'id' => '1' ] );
+        $request->set_body_params( [ 'content' => 'Hi', 'provider' => 'claude', 'model' => '' ] );
+
+        $response = $controller->send_message( $request );
+
+        $this->assertInstanceOf( \WP_REST_Response::class, $response );
+        $this->assertSame( 503, $response->get_status(), 'Proxy-tier users must receive 503 when the provider is unavailable.' );
+        $this->assertArrayHasKey( 'message', $response->data );
+        $this->assertStringContainsString( 'Could not connect', $response->data['message'] );
+    }
+
+    /**
+     * The re-registration shutdown hook must be scheduled exactly once when the
+     * provider is unavailable for a proxy-tier user.
+     */
+    public function test_send_message_schedules_registration_on_shutdown_for_proxy_tier(): void {
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );
+        Functions\when( 'get_option' )->justReturn( 'claude' );
+        Functions\when( '__' )->alias( fn( $s ) => $s );
+        // has_action returns false — hook has not been registered yet this request.
+        Functions\when( 'has_action' )->justReturn( false );
+
+        $add_action_calls = 0;
+        Functions\when( 'add_action' )->alias(
+            function ( $hook, $callback ) use ( &$add_action_calls ) {
+                if ( 'shutdown' === $hook ) {
+                    ++$add_action_calls;
+                }
+            }
+        );
+
+        $store_mock = $this->createMock( \Stilus\DB\ConversationStore::class );
+        $store_mock->method( 'get_conversation' )->willReturn( [ 'user_id' => 1 ] );
+        $store_mock->method( 'get_messages' )->willReturn( [] );
+
+        $provider_mock = $this->createMock( \Stilus\Providers\ProviderInterface::class );
+        $provider_mock->method( 'is_available' )->willReturn( false );
+
+        $factory_mock = $this->createMock( \Stilus\Providers\ProviderFactory::class );
+        $factory_mock->method( 'make' )->willReturn( $provider_mock );
+
+        $voice_mock = $this->createMock( \Stilus\Voice\VoiceInjector::class );
+        $voice_mock->method( 'build_system_prompt' )->willReturn( '' );
+
+        $controller = $this->make_controller_with_tier( $store_mock, $factory_mock, $voice_mock, 'free' );
+
+        $request = new \WP_REST_Request( 'POST' );
+        $request->set_url_params( [ 'id' => '1' ] );
+        $request->set_body_params( [ 'content' => 'Hi', 'provider' => 'claude', 'model' => '' ] );
+
+        $controller->send_message( $request );
+
+        $this->assertSame( 1, $add_action_calls, 'Shutdown hook must be registered exactly once.' );
+    }
+
+    /**
+     * A BYOK-tier user with an unavailable provider must still receive 422, not 503.
+     */
+    public function test_send_message_returns_422_for_byok_tier_when_provider_unavailable(): void {
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );
+        Functions\when( 'get_option' )->justReturn( 'claude' );
+        Functions\when( '__' )->alias( fn( $s ) => $s );
+
+        $store_mock = $this->createMock( \Stilus\DB\ConversationStore::class );
+        $store_mock->method( 'get_conversation' )->willReturn( [ 'user_id' => 1 ] );
+        $store_mock->method( 'get_messages' )->willReturn( [] );
+
+        $provider_mock = $this->createMock( \Stilus\Providers\ProviderInterface::class );
+        $provider_mock->method( 'is_available' )->willReturn( false );
+
+        $factory_mock = $this->createMock( \Stilus\Providers\ProviderFactory::class );
+        $factory_mock->method( 'make' )->willReturn( $provider_mock );
+
+        $voice_mock = $this->createMock( \Stilus\Voice\VoiceInjector::class );
+        $voice_mock->method( 'build_system_prompt' )->willReturn( '' );
+
+        $controller = $this->make_controller_with_tier( $store_mock, $factory_mock, $voice_mock, 'pro_byok' );
+
+        $request = new \WP_REST_Request( 'POST' );
+        $request->set_url_params( [ 'id' => '1' ] );
+        $request->set_body_params( [ 'content' => 'Hi', 'provider' => 'claude', 'model' => '' ] );
+
+        $response = $controller->send_message( $request );
+
+        $this->assertInstanceOf( \WP_REST_Response::class, $response );
+        $this->assertSame( 422, $response->get_status(), 'BYOK-tier users must receive 422 (missing API key), not 503.' );
+    }
+
     // ── context_post_id system-prompt injection ───────────────────────────────
 
     /**


### PR DESCRIPTION
## Summary

- Replaces the single generic `is_available()` failure response in `ChatRestController::send_message()` with a tier-aware branch
- Proxy-tier users (free/trial/pro_managed) now receive a 503 "Could not connect to Stilus — Write and Design. Please reload the page and try again." instead of the misleading 422 "No API key configured" message
- A `shutdown` hook is scheduled to trigger `SiteRegistration::maybe_register()` so the next page load re-attempts registration automatically
- API-key users (pro_byok) continue to receive the original 422 "No API key configured for …" message unchanged
- Adds `use Stilus\Proxy\SiteRegistration;` to the controller's import block

## Test plan

- [ ] PHPCS clean: `./vendor/bin/phpcs --standard=phpcs.xml.dist includes/Modules/Chat/ChatRestController.php` → no errors
- [ ] Unit tests green: `./vendor/bin/phpunit tests/Unit/ --colors=always` → 327/327 pass
- [ ] Manual: proxy-tier user with no site token → chat REST returns 503 with "Could not connect" message
- [ ] Manual: pro_byok user with no API key → chat REST returns 422 with "No API key configured" message

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWwQrLivdVyTXZQDc1i7iv)_