### PR TITLE
chore(proxy): update .gitignore wrangler cache path to stilus-proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ test-results/
 .worktrees/
 .claude/worktrees/
 .artifacts/
-wp-ai-mind-proxy/.wrangler/
+stilus-proxy/.wrangler/
 
 # wp-env
 .wp-env/


### PR DESCRIPTION
## Summary

- Fixes `.gitignore` entry that still referenced `wp-ai-mind-proxy/.wrangler/` after the folder rename in #615.

## Test plan

- [ ] `stilus-proxy/.wrangler/` no longer appears as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)