### PR TITLE
chore(proxy): rename Worker from wp-ai-mind-proxy to stilus-proxy

### DIFF
--- a/wp-ai-mind-proxy/wrangler.toml
+++ b/wp-ai-mind-proxy/wrangler.toml
@@ -1,4 +1,4 @@
-name = "wp-ai-mind-proxy"
+name = "stilus-proxy"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
 
@@ -36,7 +36,7 @@ preview_id = "38975852f1bc4c838da456ea9a21e789"
 #      → Cloudflare will print the dev Worker URL (e.g. wp-ai-mind-proxy-dev.<account>.workers.dev)
 #   4. Set that URL as the proxy endpoint in your localhost + staging WP installs
 [env.dev]
-name = "wp-ai-mind-proxy-dev"
+name = "stilus-proxy-dev"
 
 [env.dev.vars]
 DEV_ENDPOINTS_ENABLED = "1"


### PR DESCRIPTION
## Summary

- Renames the Cloudflare Worker from `wp-ai-mind-proxy` to `stilus-proxy` in `wrangler.toml`
- Renames the dev environment from `wp-ai-mind-proxy-dev` to `stilus-proxy-dev`
- Aligns with the Stilus rebrand and the account subdomain rename to `stilus.workers.dev`

Deployed URLs after this change:
- Production: `https://stilus-proxy.stilus.workers.dev`
- Dev: `https://stilus-proxy-dev.stilus.workers.dev`

## Test plan

- [ ] Verify `wrangler deploy` targets `stilus-proxy` (not `wp-ai-mind-proxy`)
- [ ] Confirm `https://stilus-proxy.stilus.workers.dev` responds (already verified — 200 OK with existing site token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)