### PR TITLE
fix(worker): guard against undefined HMAC secret and unknown variantId fallback

### DIFF
--- a/stilus-proxy/src/signature.ts
+++ b/stilus-proxy/src/signature.ts
@@ -21,6 +21,7 @@ export async function verifyHmac(
 	secret: string
 ): Promise< boolean > {
 	try {
+		if ( ! secret ) return false;
 		if (
 			! signatureHex ||
 			signatureHex.length % 2 !== 0 ||

--- a/stilus-proxy/src/webhook.ts
+++ b/stilus-proxy/src/webhook.ts
@@ -167,7 +167,11 @@ async function handleLicenceKey(
 
 	if ( status === 'active' ) {
 		const variantId = String( ( attrs?.variant_id as unknown ) ?? '' );
-		const tier = buildVariantTierMap( env )[ variantId ] ?? 'pro_managed';
+		const tier = buildVariantTierMap( env )[ variantId ] ?? null;
+		if ( ! tier ) {
+			console.error( '[webhook] Unknown variantId, ignoring licence_key_created', { variantId } );
+			return;
+		}
 		const record: LicenceRecord = {
 			tier,
 			site_token: siteToken,

--- a/stilus-proxy/src/webhook.ts
+++ b/stilus-proxy/src/webhook.ts
@@ -169,7 +169,7 @@ async function handleLicenceKey(
 		const variantId = String( ( attrs?.variant_id as unknown ) ?? '' );
 		const tier = buildVariantTierMap( env )[ variantId ] ?? null;
 		if ( ! tier ) {
-			console.error( '[webhook] Unknown variantId, ignoring licence_key_created', { variantId } );
+			console.error( '[webhook] Unknown variantId, ignoring licence_key event', { variantId } );
 			return;
 		}
 		const record: LicenceRecord = {

--- a/stilus-proxy/test/signature.test.ts
+++ b/stilus-proxy/test/signature.test.ts
@@ -30,8 +30,16 @@ describe( 'verifyLsSignature', () => {
 	it( 'resolves false when LS_WEBHOOK_SECRET is empty', async () => {
 		const env = makeEnv( { LS_WEBHOOK_SECRET: '' } );
 		const body = '{"event":"test"}';
-		// Even a correctly formed sig with empty secret should fail importKey (zero-length key)
+		// Caught by the !secret guard
 		const sig = signBody( body, '' );
+		expect( await verifyLsSignature( body, sig, env ) ).toBe( false );
+	} );
+
+	it( 'resolves false when secret is undefined', async () => {
+		const env = makeEnv( { LS_WEBHOOK_SECRET: undefined as unknown as string } );
+		const body = '{"event":"test"}';
+		// Any signature — doesn't matter, the guard fires before HMAC computation
+		const sig = signBody( body, 'undefined' ); // what would happen without the fix
 		expect( await verifyLsSignature( body, sig, env ) ).toBe( false );
 	} );
 

--- a/stilus-proxy/test/signature.test.ts
+++ b/stilus-proxy/test/signature.test.ts
@@ -30,7 +30,7 @@ describe( 'verifyLsSignature', () => {
 	it( 'resolves false when LS_WEBHOOK_SECRET is empty', async () => {
 		const env = makeEnv( { LS_WEBHOOK_SECRET: '' } );
 		const body = '{"event":"test"}';
-		// Caught by the !secret guard
+		// Empty string coerces to falsy — same guard as undefined, different coercion path
 		const sig = signBody( body, '' );
 		expect( await verifyLsSignature( body, sig, env ) ).toBe( false );
 	} );

--- a/stilus-proxy/test/webhook.test.ts
+++ b/stilus-proxy/test/webhook.test.ts
@@ -226,6 +226,25 @@ describe( 'handleWebhook', () => {
 		expect( record?.tier ).toBe( 'pro_managed' );
 	} );
 
+	it( 'returns 200 and writes no licence:* key for an unknown variantId in licence_key_created', async () => {
+		const env = await makePrepopulatedEnv( 'free' );
+
+		const payload = licenceKeyCreatedPayload(
+			TEST_LICENCE_KEY,
+			'active',
+			'9999999', // variant ID not present in env
+			TEST_TOKEN
+		);
+		const req = makeRequest( payload );
+		const { ctx } = makeCtx();
+		const res = await handleWebhook( req, env, ctx );
+
+		expect( res.status ).toBe( 200 );
+
+		const record = await env.USAGE_KV.get( `licence:${ TEST_LICENCE_KEY }` );
+		expect( record ).toBeNull();
+	} );
+
 	it( 'returns 200 and makes no KV changes for an unknown event type', async () => {
 		const env = await makePrepopulatedEnv( 'free' );
 

--- a/stilus-proxy/test/webhook.test.ts
+++ b/stilus-proxy/test/webhook.test.ts
@@ -226,7 +226,7 @@ describe( 'handleWebhook', () => {
 		expect( record?.tier ).toBe( 'pro_managed' );
 	} );
 
-	it( 'returns 200 and writes no licence:* key for an unknown variantId in licence_key_created', async () => {
+	it( 'returns 200 and writes no licence:* key for an unknown variantId', async () => {
 		const env = await makePrepopulatedEnv( 'free' );
 		const errorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
 

--- a/stilus-proxy/test/webhook.test.ts
+++ b/stilus-proxy/test/webhook.test.ts
@@ -228,6 +228,7 @@ describe( 'handleWebhook', () => {
 
 	it( 'returns 200 and writes no licence:* key for an unknown variantId in licence_key_created', async () => {
 		const env = await makePrepopulatedEnv( 'free' );
+		const errorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
 
 		const payload = licenceKeyCreatedPayload(
 			TEST_LICENCE_KEY,
@@ -243,6 +244,41 @@ describe( 'handleWebhook', () => {
 
 		const record = await env.USAGE_KV.get( `licence:${ TEST_LICENCE_KEY }` );
 		expect( record ).toBeNull();
+		expect( errorSpy ).toHaveBeenCalledWith(
+			'[webhook] Unknown variantId, ignoring licence_key event',
+			{ variantId: '9999999' }
+		);
+	} );
+
+	it( 'returns 200 and writes no licence:* key for an unknown variantId in licence_key_updated', async () => {
+		const env = await makePrepopulatedEnv( 'free' );
+		const errorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+		const payload = {
+			meta: {
+				event_name: 'licence_key_updated',
+				custom_data: { site_token: TEST_TOKEN },
+			},
+			data: {
+				attributes: {
+					key: TEST_LICENCE_KEY,
+					status: 'active',
+					variant_id: '9999999',
+				},
+			},
+		};
+		const req = makeRequest( payload );
+		const { ctx } = makeCtx();
+		const res = await handleWebhook( req, env, ctx );
+
+		expect( res.status ).toBe( 200 );
+
+		const record = await env.USAGE_KV.get( `licence:${ TEST_LICENCE_KEY }` );
+		expect( record ).toBeNull();
+		expect( errorSpy ).toHaveBeenCalledWith(
+			'[webhook] Unknown variantId, ignoring licence_key event',
+			{ variantId: '9999999' }
+		);
 	} );
 
 	it( 'returns 200 and makes no KV changes for an unknown event type', async () => {


### PR DESCRIPTION
Closes #663, #664.

## Summary

- **#663** — `verifyHmac` now returns `false` immediately when `secret` is falsy/undefined, before any crypto operations. Without this guard, an unset `LS_WEBHOOK_SECRET` env var is coerced to the string `"undefined"` as HMAC key material, allowing a forged signature to pass verification.
- **#664** — `handleLicenceKey` now rejects unrecognised LemonSqueezy variant IDs with an early return and `console.error`, instead of silently defaulting to `pro_managed`. Aligns the function with the already-correct `handleActivation` pattern.

## WP compliance verified

Not applicable — these are TypeScript Cloudflare Worker files, not PHP. Worker-specific security verified:
- [x] No sensitive data in `console.error` output (logs only `variantId`, a non-sensitive string)
- [x] No over-granting: fallback removed; unknown variants are now rejected
- [x] Falsy-secret guard fires before any HMAC computation

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZG1WZMqzxExoVwYF2Rfan)_