### PR TITLE
fix(worker): use UUID for Gemini tool call IDs and abort tierSync retry on 4xx

### DIFF
--- a/stilus-proxy/src/index.ts
+++ b/stilus-proxy/src/index.ts
@@ -354,7 +354,7 @@ async function callGemini(
 				content: '',
 				usage: normalizedUsage,
 				tool_call: {
-					id: `gemini_${ Date.now() }`,
+					id: `gemini_${ crypto.randomUUID() }`,
 					name: part.functionCall.name,
 					arguments: part.functionCall.args ?? {},
 				},

--- a/stilus-proxy/src/tierSync.ts
+++ b/stilus-proxy/src/tierSync.ts
@@ -92,6 +92,11 @@ export async function pushTierUpdate(
 			if ( res.ok ) {
 				return;
 			}
+
+			if ( res.status >= 400 && res.status < 500 ) {
+				console.error( '[tierSync] Terminal error, not retrying', { status: res.status, siteUrl } );
+				return;
+			}
 		} catch {
 			// Connection error — fall through to backoff.
 		}

--- a/stilus-proxy/src/tierSync.ts
+++ b/stilus-proxy/src/tierSync.ts
@@ -94,7 +94,7 @@ export async function pushTierUpdate(
 			}
 
 			if ( res.status >= 400 && res.status < 500 ) {
-				console.error( '[tierSync] Terminal error, not retrying', { status: res.status, siteUrl } );
+				console.error( '[tierSync] Terminal error, not retrying:', { status: res.status, siteUrl } );
 				return;
 			}
 		} catch {

--- a/stilus-proxy/test/chat-proxy.test.ts
+++ b/stilus-proxy/test/chat-proxy.test.ts
@@ -373,6 +373,66 @@ describe( 'handleChatProxy', () => {
 		expect( json.usage ).toEqual( { input_tokens: 6, output_tokens: 3 } );
 	} );
 
+	it( 'Gemini adapter: tool_call id matches UUID format when functionCall part returned', async () => {
+		const env = await makeEnvWithSiteToken( 'trial' );
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async () => {
+				return new Response(
+					JSON.stringify( {
+						candidates: [
+							{
+								content: {
+									parts: [
+										{
+											functionCall: {
+												name: 'get_post_content',
+												args: { post_id: 7 },
+											},
+										},
+									],
+								},
+							},
+						],
+						usageMetadata: {
+							promptTokenCount: 10,
+							candidatesTokenCount: 5,
+						},
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Fetch post 7' } ],
+			provider: 'gemini',
+			tools: [ mockTool ],
+		} );
+
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		expect( response.status ).toBe( 200 );
+
+		const json = ( await response.json() ) as {
+			content: string;
+			usage: { input_tokens: number; output_tokens: number };
+			tool_call?: {
+				id: string;
+				name: string;
+				arguments: Record< string, unknown >;
+			};
+		};
+
+		expect( json.tool_call ).toBeDefined();
+		const toolCall = json.tool_call!;
+		expect( toolCall.id ).toMatch(
+			/^gemini_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+		);
+		expect( toolCall.name ).toBe( 'get_post_content' );
+		expect( toolCall.arguments ).toEqual( { post_id: 7 } );
+	} );
+
 	it( 'returns 400 for unknown provider', async () => {
 		const env = await makeEnvWithSiteToken( 'trial' );
 

--- a/stilus-proxy/test/chat-proxy.test.ts
+++ b/stilus-proxy/test/chat-proxy.test.ts
@@ -373,7 +373,7 @@ describe( 'handleChatProxy', () => {
 		expect( json.usage ).toEqual( { input_tokens: 6, output_tokens: 3 } );
 	} );
 
-	it( 'Gemini adapter: tool_call id matches UUID format when functionCall part returned', async () => {
+	it( 'returns a UUID-format tool_call id when Gemini functionCall part is returned', async () => {
 		const env = await makeEnvWithSiteToken( 'trial' );
 
 		vi.stubGlobal(

--- a/stilus-proxy/test/tierSync.test.ts
+++ b/stilus-proxy/test/tierSync.test.ts
@@ -1,0 +1,36 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { pushTierUpdate } from '../src/tierSync';
+
+afterEach( () => {
+	vi.restoreAllMocks();
+} );
+
+describe( 'pushTierUpdate', () => {
+	it( 'aborts after one attempt on 4xx', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response( null, { status: 403 } )
+		);
+		vi.stubGlobal( 'fetch', fetchMock );
+
+		await pushTierUpdate( 'https://example.com', 'secret', 'pro_managed' );
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'retries on 5xx and succeeds on second attempt', async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce( new Response( null, { status: 503 } ) )
+			.mockResolvedValueOnce( new Response( null, { status: 200 } ) );
+		vi.stubGlobal( 'fetch', fetchMock );
+
+		// Override the backoff delay so the test does not wait 1 second.
+		vi.stubGlobal( 'setTimeout', ( fn: () => void ) => fn() );
+
+		await pushTierUpdate( 'https://example.com', 'secret', 'pro_managed' );
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/stilus-proxy/test/tierSync.test.ts
+++ b/stilus-proxy/test/tierSync.test.ts
@@ -34,4 +34,18 @@ describe( 'pushTierUpdate', () => {
 
 		expect( fetchMock ).toHaveBeenCalledTimes( 2 );
 	} );
+
+	it( 'gives up silently after all three 5xx attempts', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response( null, { status: 503 } )
+		);
+		vi.stubGlobal( 'fetch', fetchMock );
+		vi.stubGlobal( 'setTimeout', ( fn: () => void ) => fn() );
+
+		await expect(
+			pushTierUpdate( 'https://example.com', 'secret', 'pro_managed' )
+		).resolves.toBeUndefined();
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 3 );
+	} );
 } );

--- a/stilus-proxy/test/tierSync.test.ts
+++ b/stilus-proxy/test/tierSync.test.ts
@@ -5,6 +5,7 @@ import { pushTierUpdate } from '../src/tierSync';
 
 afterEach( () => {
 	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
 } );
 
 describe( 'pushTierUpdate', () => {

--- a/stilus-proxy/test/tierSync.test.ts
+++ b/stilus-proxy/test/tierSync.test.ts
@@ -48,4 +48,16 @@ describe( 'pushTierUpdate', () => {
 
 		expect( fetchMock ).toHaveBeenCalledTimes( 3 );
 	} );
+
+	it( 'aborts without fetching when signing fails', async () => {
+		vi.spyOn( crypto.subtle, 'sign' ).mockRejectedValue( new Error( 'sign failed' ) );
+		const fetchMock = vi.fn();
+		vi.stubGlobal( 'fetch', fetchMock );
+
+		await expect(
+			pushTierUpdate( 'https://example.com', 'secret', 'pro_managed' )
+		).resolves.toBeUndefined();
+
+		expect( fetchMock ).not.toHaveBeenCalled();
+	} );
 } );

--- a/stilus-proxy/test/tierSync.test.ts
+++ b/stilus-proxy/test/tierSync.test.ts
@@ -28,7 +28,7 @@ describe( 'pushTierUpdate', () => {
 		vi.stubGlobal( 'fetch', fetchMock );
 
 		// Override the backoff delay so the test does not wait 1 second.
-		vi.stubGlobal( 'setTimeout', ( fn: () => void ) => fn() );
+		vi.stubGlobal( 'setTimeout', ( fn: () => void, _delay?: number ) => fn() );
 
 		await pushTierUpdate( 'https://example.com', 'secret', 'pro_managed' );
 
@@ -40,7 +40,7 @@ describe( 'pushTierUpdate', () => {
 			new Response( null, { status: 503 } )
 		);
 		vi.stubGlobal( 'fetch', fetchMock );
-		vi.stubGlobal( 'setTimeout', ( fn: () => void ) => fn() );
+		vi.stubGlobal( 'setTimeout', ( fn: () => void, _delay?: number ) => fn() );
 
 		await expect(
 			pushTierUpdate( 'https://example.com', 'secret', 'pro_managed' )


### PR DESCRIPTION
Closes #669, #668.

## Summary

- **#669** — Gemini tool-call response IDs now use `crypto.randomUUID()` instead of `Date.now()`. Two concurrent responses arriving within the same millisecond previously produced identical IDs, breaking tool-result correlation in multi-tool conversations. `crypto.randomUUID()` is available natively in the Cloudflare Workers runtime.
- **#668** — `pushTierUpdate` now treats 4xx responses as terminal and returns immediately without retrying. A WP site returning 403 (misconfigured endpoint) or 404 (outdated plugin) previously triggered 3 outbound requests over ~13 s per webhook event under burst load. 5xx and connection errors still trigger the full backoff retry.

## WP compliance verified

TypeScript Cloudflare Worker files — PHP WP compliance items do not apply.
- [x] No sensitive data in `console.error` (logs only HTTP status integer and site URL already stored in KV)
- [x] `crypto.randomUUID()` is cryptographically random — no collision risk

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZG1WZMqzxExoVwYF2Rfan)_