### PR TITLE
fix(proxy): bump Node to 22, restore npm ci

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -38,7 +38,9 @@ jobs:
           cache-dependency-path: stilus-proxy/package-lock.json
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        # npm ci silently skips optional native bindings when the lockfile was
+        # generated on a different platform (npm/cli#4828); npm install resolves them.
+        run: npm install --no-audit --no-fund
         working-directory: stilus-proxy
 
       - name: Run tests

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -33,14 +33,12 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20.12'
+          node-version: '22'
           cache: npm
           cache-dependency-path: stilus-proxy/package-lock.json
 
       - name: Install dependencies
-        # npm ci silently skips optional native bindings when the lockfile was
-        # generated on a different platform (npm/cli#4828); npm install resolves them.
-        run: npm install --no-audit --no-fund
+        run: npm ci --no-audit --no-fund
         working-directory: stilus-proxy
 
       - name: Run tests


### PR DESCRIPTION
## Summary

Fixes the deploy-proxy workflow failure introduced in #677.

**Root cause:** `@rolldown/binding-linux-x64-gnu` has an engine requirement of `^20.19.0 || >=22.12.0`. The workflow pinned `node-version: '20.12'`, which doesn't satisfy that range — so npm correctly skips the optional binding, and vitest crashes at startup with `Cannot find native binding`.

**Fix:** Bump to Node 22 (matching `stilus-proxy/.nvmrc`). This satisfies the engine constraint, `npm ci` installs the binding, and lockfile integrity is preserved.

## What changed

- `node-version: '20.12'` → `'22'` in `deploy-proxy.yml` (aligns with `.nvmrc`)
- `npm install` → `npm ci` restored (now that Node version is correct)

## Closes

Closes #685, #686, #687

## Test plan

- [ ] Merge this PR — the push to `main` will touch `.github/workflows/deploy-proxy.yml`, triggering the deploy workflow
- [ ] Confirm the workflow run goes green (tests pass, Worker deploys successfully)

https://claude.ai/code/session_01PDCxhsmJhUffmtyDgfcf1C