### PR TITLE
fix(proxy): target top-level env explicitly in wrangler deploy

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -38,7 +38,9 @@ jobs:
           cache-dependency-path: stilus-proxy/package-lock.json
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        # npm ci silently skips optional native bindings when the lockfile was
+        # generated on a different platform (npm/cli#4828); npm install resolves them.
+        run: npm install --no-audit --no-fund
         working-directory: stilus-proxy
 
       - name: Run tests

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -38,9 +38,7 @@ jobs:
           cache-dependency-path: stilus-proxy/package-lock.json
 
       - name: Install dependencies
-        # npm ci silently skips optional native bindings when the lockfile was
-        # generated on a different platform (npm/cli#4828); npm install resolves them.
-        run: npm install --no-audit --no-fund
+        run: npm ci --no-audit --no-fund
         working-directory: stilus-proxy
 
       - name: Run tests

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '22'
+          node-version: '22' # must satisfy @rolldown/binding-linux-x64-gnu engine: ^20.19.0 || >=22.12.0
           cache: npm
           cache-dependency-path: stilus-proxy/package-lock.json
 
@@ -50,4 +50,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           workingDirectory: stilus-proxy
-          command: deploy --env=""
+          command: deploy --env="" # explicit empty string targets top-level env; omitting it triggers a warning when named envs exist

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -50,3 +50,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           workingDirectory: stilus-proxy
+          command: deploy --env=""


### PR DESCRIPTION
## Summary

Silences the wrangler warning introduced by the multi-environment `wrangler.toml`:

```
▲ [WARNING] Multiple environments are defined in the Wrangler configuration file,
  but no target environment was specified for the deploy command.
```

Passing `--env=""` tells wrangler to use the top-level (production) environment explicitly, making the intent unambiguous. Inline comments added to both non-obvious choices (`node-version: '22'` and `--env=""`) so future readers understand why.

## What changed

- Added `command: deploy --env=""` to the `wrangler-action` step in `deploy-proxy.yml`
- Added inline comments documenting the Node 22 engine constraint and the `--env=""` rationale

## Closes

Closes #689

## Note

The deploy is currently also failing due to a **token permissions** issue — the `CLOUDFLARE_API_TOKEN` needs **"Workers KV Storage: Edit"** added in the Cloudflare dashboard (the Worker uses a KV binding and the token was scoped to Worker Scripts only). That is a manual step in Cloudflare → API Tokens.

## Test plan

- [ ] Update `CLOUDFLARE_API_TOKEN` in Cloudflare dashboard to include "Workers KV Storage: Edit"
- [ ] Merge this PR — triggers the deploy workflow
- [ ] Confirm workflow goes green

https://claude.ai/code/session_01PDCxhsmJhUffmtyDgfcf1C