### PR TITLE
fix(ci): add PR closing keywords and standardise on Closes syntax

### DIFF
--- a/.github/workflows/auto-fix-review-issue.yml
+++ b/.github/workflows/auto-fix-review-issue.yml
@@ -24,8 +24,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           fetch-depth: 0
-          # PAT required: GITHUB_TOKEN cannot push workflow-file changes (lacks `workflow` scope).
-          token: ${{ secrets.GH_PAT }}
 
       # Write only the issue body to a file — body is untrusted and may contain
       # arbitrary markdown/code that could escape a YAML string if interpolated.

--- a/.github/workflows/auto-fix-review-issue.yml
+++ b/.github/workflows/auto-fix-review-issue.yml
@@ -220,7 +220,7 @@ jobs:
 
                 gh pr create \
                   --title "fix: <title matching issue>" \
-                  --body "## Summary\n\nFixes #${{ github.event.issue.number }}\n\nOriginally reported during review of PR #${{ steps.parse.outputs.pr_number }}.\n\n<description of what changed and why>\n\n## Test plan\n\n- [ ] CI passes\n- [ ] Fix verified manually" \
+                  --body "## Summary\n\nCloses #${{ github.event.issue.number }}\n\nOriginally reported during review of PR #${{ steps.parse.outputs.pr_number }}.\n\n<description of what changed and why>\n\n## Test plan\n\n- [ ] CI passes\n- [ ] Fix verified manually" \
                   --base ${{ steps.parse.outputs.base_branch }} \
                   --repo ${{ github.repository }}
 

--- a/.github/workflows/auto-fix-review-issue.yml
+++ b/.github/workflows/auto-fix-review-issue.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           fetch-depth: 0
+          # PAT required: GITHUB_TOKEN cannot push workflow-file changes (lacks `workflow` scope).
+          token: ${{ secrets.GH_PAT }}
 
       # Write only the issue body to a file — body is untrusted and may contain
       # arbitrary markdown/code that could escape a YAML string if interpolated.
@@ -116,6 +118,28 @@ jobs:
           composer install --no-interaction --prefer-dist
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
+
+      - name: Add closing keyword to PR description
+        # Safety net: put "Closes #N" in the PR body so GitHub auto-closes the issue
+        # when the PR is squash-merged, even if Claude's explicit gh issue close is missed.
+        if: |
+          steps.guard.outputs.skip != 'true' &&
+          steps.parse.outputs.pr_number != '' &&
+          steps.pr_state.outputs.state == 'OPEN' &&
+          steps.workspace.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          ISSUE="${{ github.event.issue.number }}"
+          PR="${{ steps.parse.outputs.pr_number }}"
+          REPO="${{ github.repository }}"
+          CURRENT=$(gh pr view "$PR" --repo "$REPO" --json body --jq '.body // ""')
+          if ! printf '%s' "$CURRENT" | grep -qiE "(close[sd]?|fix(e[sd])?|resolve[sd]?) #${ISSUE}([^0-9]|$)"; then
+            gh pr edit "$PR" --repo "$REPO" --body "${CURRENT}"$'\n\n'"Closes #${ISSUE}"
+            echo "Added 'Closes #${ISSUE}' to PR #${PR} body."
+          else
+            echo "PR #${PR} already references issue #${ISSUE} — no update needed."
+          fi
 
       - uses: anthropics/claude-code-action@aee99972d0cfa0c47a4563e6fca42d7a5a0cb9bd  # v1
         id: claude

--- a/.github/workflows/auto-fix-review-issue.yml
+++ b/.github/workflows/auto-fix-review-issue.yml
@@ -24,6 +24,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           fetch-depth: 0
+          # GH_PAT (with workflow scope) is required to push commits that touch
+          # .github/workflows/ files. GITHUB_TOKEN cannot push workflow file changes.
+          token: ${{ secrets.GH_PAT }}
 
       # Write only the issue body to a file — body is untrusted and may contain
       # arbitrary markdown/code that could escape a YAML string if interpolated.

--- a/.github/workflows/batch-auto-fix.yml
+++ b/.github/workflows/batch-auto-fix.yml
@@ -23,8 +23,6 @@ jobs:
         with:
           # Open PRs only need the latest commit — full history is not required.
           fetch-depth: 1
-          # PAT required: GITHUB_TOKEN cannot push workflow-file changes (lacks `workflow` scope).
-          token: ${{ secrets.GH_PAT }}
 
       - name: Fetch and checkout PR head branch
         run: |

--- a/.github/workflows/batch-auto-fix.yml
+++ b/.github/workflows/batch-auto-fix.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           # Open PRs only need the latest commit — full history is not required.
           fetch-depth: 1
+          # PAT required: GITHUB_TOKEN cannot push workflow-file changes (lacks `workflow` scope).
+          token: ${{ secrets.GH_PAT }}
 
       - name: Fetch and checkout PR head branch
         run: |
@@ -36,6 +38,29 @@ jobs:
         run: |
           npm ci
           composer install --no-interaction --prefer-dist
+
+      - name: Add closing keywords to PR description
+        # Safety net: put "Closes #N" in the PR body so GitHub auto-closes each issue
+        # when the PR is squash-merged, even if Claude's explicit gh issue close is missed.
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          ISSUES_JSON: ${{ toJson(github.event.client_payload.issue_numbers) }}
+        run: |
+          PR="${{ github.event.client_payload.pr_number }}"
+          REPO="${{ github.repository }}"
+          CURRENT=$(gh pr view "$PR" --repo "$REPO" --json body --jq '.body // ""')
+          APPENDED=""
+          for issue in $(printf '%s' "$ISSUES_JSON" | jq -r '.[]'); do
+            if ! printf '%s' "$CURRENT" | grep -qiE "(close[sd]?|fix(e[sd])?|resolve[sd]?) #${issue}([^0-9]|$)"; then
+              APPENDED="${APPENDED}"$'\n'"Closes #${issue}"
+            fi
+          done
+          if [[ -n "$APPENDED" ]]; then
+            gh pr edit "$PR" --repo "$REPO" --body "${CURRENT}${APPENDED}"
+            echo "Updated PR #${PR} body with:${APPENDED}"
+          else
+            echo "PR #${PR} already references all issues — no update needed."
+          fi
 
       - name: Write issue bodies to files
         # Pre-fetch all issue bodies so Claude can cat them without extra gh calls.

--- a/.github/workflows/batch-auto-fix.yml
+++ b/.github/workflows/batch-auto-fix.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           # Open PRs only need the latest commit — full history is not required.
           fetch-depth: 1
+          # GH_PAT (with workflow scope) is required to push commits that touch
+          # .github/workflows/ files. GITHUB_TOKEN cannot push workflow file changes.
+          token: ${{ secrets.GH_PAT }}
 
       - name: Fetch and checkout PR head branch
         run: |
@@ -40,6 +43,9 @@ jobs:
       - name: Add closing keywords to PR description
         # Safety net: put "Closes #N" in the PR body so GitHub auto-closes each issue
         # when the PR is squash-merged, even if Claude's explicit gh issue close is missed.
+        if: >-
+          github.event.client_payload.pr_number != '' &&
+          github.event.client_payload.issue_numbers != null
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           ISSUES_JSON: ${{ toJson(github.event.client_payload.issue_numbers) }}
@@ -50,7 +56,7 @@ jobs:
           APPENDED=""
           for issue in $(printf '%s' "$ISSUES_JSON" | jq -r '.[]'); do
             if ! printf '%s' "$CURRENT" | grep -qiE "(close[sd]?|fix(e[sd])?|resolve[sd]?) #${issue}([^0-9]|$)"; then
-              APPENDED="${APPENDED}"$'\n'"Closes #${issue}"
+              APPENDED="${APPENDED}"$'\n\n'"Closes #${issue}"
             fi
           done
           if [[ -n "$APPENDED" ]]; then


### PR DESCRIPTION
## Summary

Issues created by the code-review bot were not auto-closing when PRs merged to `main`. Two root causes:

- **Squash merges discard commit-message keywords** — `closes #N` in individual commit messages on feature branches is lost when the PR is squash-merged (the squash commit = PR title). GitHub only auto-closes from **PR body** keywords on squash-merge, not from feature-branch commit messages. So even correctly-phrased commit messages were silently ignored.
- **Comma-separated closing keywords only close the first issue** — `Closes #685, #686, #687` auto-closes only #685. GitHub requires a separate keyword per issue.

## Changes

**`batch-auto-fix.yml` and `auto-fix-review-issue.yml`:**

New deterministic shell step **"Add closing keywords to PR description"** runs before Claude and appends `Closes #N` (one line per issue) to the PR body for any issue not already referenced. On squash-merge, GitHub reads the PR body and auto-closes each issue — this is a reliable safety net regardless of whether Claude's explicit `gh issue close` call succeeds.

**`auto-fix-review-issue.yml`:**

PR body template for the CLOSED/MERGED case changed from `Fixes #N` to `Closes #N` to match the keyword used everywhere else.

## Test plan

- [ ] Open a PR that triggers batch auto-fix — confirm the PR body gets `Closes #N` lines appended
- [ ] Merge the PR — confirm linked issues auto-close
- [ ] Trigger `auto-fix-review-issue` on a CLOSED PR — confirm new PR body uses `Closes #N`

https://claude.ai/code/session_01QDB7yWNZcPuWv3GCyrFga4