### PR TITLE
fix(ci): use GITHUB_TOKEN for PR body edit in batch-auto-fix

### DIFF
--- a/.github/workflows/batch-auto-fix.yml
+++ b/.github/workflows/batch-auto-fix.yml
@@ -47,7 +47,10 @@ jobs:
           github.event.client_payload.pr_number != '' &&
           github.event.client_payload.issue_numbers != null
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          # GITHUB_TOKEN (not GH_PAT) — editing PR metadata only needs pull-requests: write,
+          # which the job-level permissions already grant. GH_PAT is a fine-grained PAT scoped
+          # for workflow-file pushes and does not carry pull-requests: write.
+          GH_TOKEN: ${{ github.token }}
           ISSUES_JSON: ${{ toJson(github.event.client_payload.issue_numbers) }}
         run: |
           PR="${{ github.event.client_payload.pr_number }}"


### PR DESCRIPTION
## Summary

- `batch-auto-fix.yml`: the "Add closing keywords to PR description" step was using `GH_TOKEN: ${{ secrets.GH_PAT }}` for `gh pr edit`, but `GH_PAT` is a fine-grained PAT scoped for workflow-file pushes — it does not carry `pull-requests: write`
- This caused `GraphQL: Resource not accessible by personal access token (updatePullRequest)` on every batch-auto-fix run
- Fix: use `${{ github.token }}` (GITHUB_TOKEN) for that step, which already has `pull-requests: write` from the job-level `permissions` block

Branch protection on `main` is unrelated — PR metadata edits are not gated by push restrictions.

## Test plan

- [ ] Trigger a batch-auto-fix run (apply `auto-fix` label to a code-review issue on an open PR) and confirm the "Add closing keywords" step completes without the GraphQL error
- [ ] Confirm the PR body is updated with `Closes #N` for each issue

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFpcTyGZtnSBFa2PxnsAwB)_