### PR TITLE
fix(release): guard pre-commit PHPCS check against missing dev binary

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -10,12 +10,13 @@ fi
 
 # Run PHPCS on staged PHP files.
 STAGED_PHP=$(git diff --cached --name-only --diff-filter=ACM | grep '\.php$' | grep -v '^vendor/' | grep -v '^node_modules/')
+PHPCS_BIN="./vendor/bin/phpcs"
 if [ -n "$STAGED_PHP" ]; then
-  if [ ! -x "./vendor/bin/phpcs" ]; then
+  if [ ! -x "$PHPCS_BIN" ]; then
     echo "PHPCS not found (dev dependencies not installed) — skipping PHP lint."
   else
     echo "PHP files staged — running PHPCS..."
-    echo "$STAGED_PHP" | xargs ./vendor/bin/phpcs --standard=phpcs.xml.dist || {
+    echo "$STAGED_PHP" | xargs "$PHPCS_BIN" --standard=phpcs.xml.dist || {
       echo "PHPCS failed. Run: ./vendor/bin/phpcbf --standard=phpcs.xml.dist for auto-fixes."
       exit 1
     }

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -11,9 +11,13 @@ fi
 # Run PHPCS on staged PHP files.
 STAGED_PHP=$(git diff --cached --name-only --diff-filter=ACM | grep '\.php$' | grep -v '^vendor/' | grep -v '^node_modules/')
 if [ -n "$STAGED_PHP" ]; then
-  echo "PHP files staged — running PHPCS..."
-  echo "$STAGED_PHP" | xargs ./vendor/bin/phpcs --standard=phpcs.xml.dist || {
-    echo "PHPCS failed. Run: ./vendor/bin/phpcbf --standard=phpcs.xml.dist for auto-fixes."
-    exit 1
-  }
+  if [ ! -x "./vendor/bin/phpcs" ]; then
+    echo "PHPCS not found (dev dependencies not installed) — skipping PHP lint."
+  else
+    echo "PHP files staged — running PHPCS..."
+    echo "$STAGED_PHP" | xargs ./vendor/bin/phpcs --standard=phpcs.xml.dist || {
+      echo "PHPCS failed. Run: ./vendor/bin/phpcbf --standard=phpcs.xml.dist for auto-fixes."
+      exit 1
+    }
+  fi
 fi


### PR DESCRIPTION
## Summary

- The `release.yml` workflow was failing during the `@semantic-release/git` prepare step because `composer install --no-dev` leaves `vendor/bin/phpcs` absent
- When semantic-release staged version-bump files (`stilus.php`, `readme.txt`) and called `git commit`, the pre-commit hook detected PHP files, tried to invoke `./vendor/bin/phpcs` via `xargs`, got `No such file or directory`, and exited 1 — aborting the commit and crashing the release
- Fix adds a binary-existence check before invoking phpcs; if the binary is absent the hook emits an informational message and exits 0

## Root cause

```
PHP files staged — running PHPCS...
xargs: ./vendor/bin/phpcs: No such file or directory
PHPCS failed. Run: ./vendor/bin/phpcbf --standard=phpcs.xml.dist for auto-fixes.
```

`scripts/pre-commit` had no guard for environments where `composer install --no-dev` was used.

## Test plan

- [ ] Trigger `release.yml` via `workflow_dispatch` — confirm the "Release" step completes, `v1.9.0` tag is created, and a GitHub Release is published with the zip attached
- [ ] Locally: stage a PHP file and commit — confirm PHPCS still runs (dev deps present)
- [ ] Locally: temporarily rename `vendor/bin/phpcs` and commit a PHP file — confirm the hook prints the skip message and allows the commit

https://claude.ai/code/session_01KwDVQTQFtaf58sz67LbDrk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwDVQTQFtaf58sz67LbDrk)_

Closes #706