### PR TITLE
chore(deps): bump @playwright/test from 1.59.1 to 1.60.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.0.0",
         "@commitlint/config-conventional": "^19.0.0",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.60.0",
         "@semantic-release/changelog": "^6.0.0",
         "@semantic-release/commit-analyzer": "^13.0.0",
         "@semantic-release/exec": "^6.0.0",
@@ -6866,12 +6866,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -25628,13 +25629,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -25647,9 +25648,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.60.0",
     "@semantic-release/changelog": "^6.0.0",
     "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/exec": "^6.0.0",


### PR DESCRIPTION
## Root cause

`@playwright/test` versions below 1.60.0 hang indefinitely during `playwright install` when run on **Node 24.16.0+**. The browser zip downloads successfully (reaching 100%), then the extraction worker process dies silently, leaving the parent waiting on a stale IPC pipe — no error, no output, just a process that never exits.

This is the root cause of:
- The 6-hour CI burn in PR #721 (hit GitHub's default job limit)
- The deterministic 5-minute step timeouts seen in subsequent e2e runs after PR #728 added the timeout guard

PR #699 set `node-version: '24'` in workflows. When the runner image recently updated to include Node **24.16.0** in its toolcache, the e2e install step started hanging on every single run. The fix shipped in Playwright 1.60.0 via [microsoft/playwright#40747](https://github.com/microsoft/playwright/pull/40747).

Refs: [microsoft/playwright#40998](https://github.com/microsoft/playwright/issues/40998), [microsoft/playwright#41092](https://github.com/microsoft/playwright/issues/41092)

## Change

- `package.json`: `^1.59.1` → `^1.60.0`
- `package-lock.json`: regenerated (resolves to `1.60.0`)

No workflow changes needed — the Playwright browser cache key (from PR #728) is invalidated automatically because it's keyed on `package-lock.json`.

## Test plan

- [ ] CI e2e job on this PR: `playwright install --with-deps chromium` completes and exits instead of hanging
- [ ] Once merged, re-run e2e on PR #721 — should now go green

https://claude.ai/code/session_01XWAnkoYtvbBDPAPUzawp6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWAnkoYtvbBDPAPUzawp6Z)_

Closes #735