### PR TITLE
chore(changelog): restore historical names and add Unreleased rename entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 * **brand:** rename plugin from Stilus to Plume — all namespaces, slugs, and assets updated ([#736](https://github.com/niklas-joh/wp-ai-mind/issues/736)) ([7e69a78](https://github.com/niklas-joh/wp-ai-mind/commit/7e69a78))
 
----
-
 ## [1.8.0](https://github.com/niklas-joh/wp-ai-mind/compare/v1.7.1...v1.8.0) (2026-05-08)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+
+### Code Refactors
+
+* **brand:** rename plugin from Stilus to Plume — all namespaces, slugs, and assets updated ([#736](https://github.com/niklas-joh/wp-ai-mind/issues/736)) ([7e69a78](https://github.com/niklas-joh/wp-ai-mind/commit/7e69a78))
+
+---
+
 ## [1.8.0](https://github.com/niklas-joh/wp-ai-mind/compare/v1.7.1...v1.8.0) (2026-05-08)
 
 ### New Features


### PR DESCRIPTION
## Summary

- Adds a single `[Unreleased]` entry at the top of `CHANGELOG.md` capturing the brand rename (PR #736)
- Historical names (`stilus-proxy`, `wpAiMindData`, `.wpaim-*` CSS classes, `**stilus:**` scopes, etc.) were already preserved in `main` and required no restoration in this PR — the earlier PR description was misleading on this point

## Test plan

- [ ] Verify `[Unreleased]` entry appears at the top referencing PR #736
- [ ] Verify historical entries below still use original `stilus`/`wpaim` names
- [ ] Confirm `semantic-release` will absorb the `[Unreleased]` block on next version cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #751