### PR TITLE
chore(docs): automate @since tag stamping via semantic-release

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -135,3 +135,18 @@ without explicit user instruction.
 
 - All work (features, fixes, chores): PR targets `main`
 - There is no `develop` branch
+
+---
+
+## Code Documentation — @since Tags
+
+The `@since` PHPDoc tag marks the version in which a method or class was introduced.
+**The next release version is unknown until `semantic-release` runs**, so agents must
+never guess it. Use the following rules without exception:
+
+- **New or unreleased code**: always write `@since NEXT_VERSION` (the exact literal string).
+  `semantic-release` runs `bin/stamp-since-tags.sh` during the release pipeline, which
+  replaces every `@since NEXT_VERSION` with the real version (e.g., `@since 1.9.0`)
+  before the release commit is created.
+- **Already-released code**: leave the existing `@since x.y.z` unchanged. Never alter it.
+- **Never write `@since 1.0.0`** (or any other guessed version) for new code.

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -43,7 +43,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "sed -i 's/ \\* Version:.*/ * Version:           ${nextRelease.version}/' plume.php && sed -i \"s/define( 'PLUME_VERSION', '[^']*' )/define( 'PLUME_VERSION', '${nextRelease.version}' )/\" plume.php && sed -i 's/^Stable tag:.*/Stable tag: ${nextRelease.version}/' readme.txt && ./bin/build-wporg.sh --version ${nextRelease.version} --skip-build"
+        "prepareCmd": "sed -i 's/ \\* Version:.*/ * Version:           ${nextRelease.version}/' plume.php && sed -i \"s/define( 'PLUME_VERSION', '[^']*' )/define( 'PLUME_VERSION', '${nextRelease.version}' )/\" plume.php && sed -i 's/^Stable tag:.*/Stable tag: ${nextRelease.version}/' readme.txt && ./bin/stamp-since-tags.sh ${nextRelease.version} && ./bin/build-wporg.sh --version ${nextRelease.version} --skip-build"
       }
     ],
     [
@@ -60,7 +60,8 @@
           "package.json",
           "package-lock.json",
           "plume.php",
-          "readme.txt"
+          "readme.txt",
+          "includes/**/*.php"
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]"
       }

--- a/bin/stamp-since-tags.sh
+++ b/bin/stamp-since-tags.sh
@@ -8,15 +8,23 @@ VERSION="${1:?Usage: stamp-since-tags.sh <version>}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-# grep exits 1 on no matches — || true prevents set -e from killing the script.
+# Distinguish no-match (exit 1, expected) from a real grep error (exit 2, abort).
+set +e
 MATCHED_FILES=$(
   grep -rl --include="*.php" \
     --exclude-dir=vendor \
     --exclude-dir=assets \
     --exclude-dir=dist \
     "@since NEXT_VERSION" \
-    "${REPO_ROOT}" || true
+    "${REPO_ROOT}"
 )
+GREP_EXIT=$?
+set -e
+
+if [[ $GREP_EXIT -eq 2 ]]; then
+  echo "stamp-since-tags: grep error — aborting." >&2
+  exit 1
+fi
 
 if [[ -z "$MATCHED_FILES" ]]; then
   echo "stamp-since-tags: no @since NEXT_VERSION placeholders found — nothing to stamp."
@@ -24,7 +32,11 @@ if [[ -z "$MATCHED_FILES" ]]; then
 fi
 
 FILE_COUNT=$(echo "$MATCHED_FILES" | wc -l | tr -d ' ')
-echo "$MATCHED_FILES" | xargs sed -i "s/@since NEXT_VERSION/@since ${VERSION}/g"
 
-echo "stamp-since-tags: stamped @since NEXT_VERSION → @since ${VERSION} in ${FILE_COUNT} file(s):"
+# -d '\n' splits on newlines only — safe for filenames containing spaces.
+# GNU sed: -i without a suffix argument; CI runner is ubuntu-latest (GNU sed only).
+echo "$MATCHED_FILES" | xargs -d '\n' sed -i "s/@since NEXT_VERSION/@since ${VERSION}/g"
+
+echo "stamp-since-tags: updated files:"
 echo "$MATCHED_FILES" | sed "s|${REPO_ROOT}/||"
+echo "stamp-since-tags: stamped @since NEXT_VERSION → @since ${VERSION} in ${FILE_COUNT} file(s)."

--- a/bin/stamp-since-tags.sh
+++ b/bin/stamp-since-tags.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Replaces @since NEXT_VERSION with the actual release version in all PHP files.
+# Called by semantic-release prepareCmd. Safe when no placeholders exist.
+set -euo pipefail
+
+VERSION="${1:?Usage: stamp-since-tags.sh <version>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# grep exits 1 on no matches — || true prevents set -e from killing the script.
+MATCHED_FILES=$(
+  grep -rl --include="*.php" \
+    --exclude-dir=vendor \
+    --exclude-dir=assets \
+    --exclude-dir=dist \
+    "@since NEXT_VERSION" \
+    "${REPO_ROOT}" || true
+)
+
+if [[ -z "$MATCHED_FILES" ]]; then
+  echo "stamp-since-tags: no @since NEXT_VERSION placeholders found — nothing to stamp."
+  exit 0
+fi
+
+FILE_COUNT=$(echo "$MATCHED_FILES" | wc -l | tr -d ' ')
+echo "$MATCHED_FILES" | xargs sed -i "s/@since NEXT_VERSION/@since ${VERSION}/g"
+
+echo "stamp-since-tags: stamped @since NEXT_VERSION → @since ${VERSION} in ${FILE_COUNT} file(s):"
+echo "$MATCHED_FILES" | sed "s|${REPO_ROOT}/||"

--- a/bin/stamp-since-tags.sh
+++ b/bin/stamp-since-tags.sh
@@ -31,12 +31,12 @@ if [[ -z "$MATCHED_FILES" ]]; then
   exit 0
 fi
 
-FILE_COUNT=$(echo "$MATCHED_FILES" | wc -l | tr -d ' ')
 grep -rl0 --include="*.php" \
   --exclude-dir=vendor --exclude-dir=assets --exclude-dir=dist \
   "@since NEXT_VERSION" "${REPO_ROOT}" \
-  | xargs -0 sed -i "s/@since NEXT_VERSION/@since ${VERSION}/g"
+  | xargs -0 sed -i '' "s/@since NEXT_VERSION/@since ${VERSION}/g"
 
+FILE_COUNT=$(echo "$MATCHED_FILES" | wc -l | tr -d ' ')
 echo "stamp-since-tags: updated files:"
 echo "$MATCHED_FILES" | sed "s|${REPO_ROOT}/||"
-echo "stamp-since-tags: stamped @since NEXT_VERSION → @since ${VERSION} in ${FILE_COUNT} file(s)."
+echo "stamp-since-tags: stamped @since NEXT_VERSION → @since ${VERSION} in the ${FILE_COUNT} file(s) above."

--- a/bin/stamp-since-tags.sh
+++ b/bin/stamp-since-tags.sh
@@ -32,10 +32,10 @@ if [[ -z "$MATCHED_FILES" ]]; then
 fi
 
 FILE_COUNT=$(echo "$MATCHED_FILES" | wc -l | tr -d ' ')
-
-# -d '\n' splits on newlines only — safe for filenames containing spaces.
-# GNU sed: -i without a suffix argument; CI runner is ubuntu-latest (GNU sed only).
-echo "$MATCHED_FILES" | xargs -d '\n' sed -i "s/@since NEXT_VERSION/@since ${VERSION}/g"
+grep -rl0 --include="*.php" \
+  --exclude-dir=vendor --exclude-dir=assets --exclude-dir=dist \
+  "@since NEXT_VERSION" "${REPO_ROOT}" \
+  | xargs -0 sed -i "s/@since NEXT_VERSION/@since ${VERSION}/g"
 
 echo "stamp-since-tags: updated files:"
 echo "$MATCHED_FILES" | sed "s|${REPO_ROOT}/||"

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -195,7 +195,7 @@ class Plugin {
 	 * plume_options_migrated flag. Each option is only copied when the new key does
 	 * not yet exist — existing plume_* values are never overwritten.
 	 *
-	 * @since 2.0.0
+	 * @since NEXT_VERSION
 	 * @return void
 	 */
 	private static function maybe_migrate_from_wp_ai_mind(): void {


### PR DESCRIPTION
## Summary

- Introduces `@since NEXT_VERSION` as the standard placeholder for all new/unreleased PHPDoc `@since` tags — agents and developers no longer need to guess the next version
- Adds `bin/stamp-since-tags.sh`: replaces every `@since NEXT_VERSION` in PHP files with the real release version, called by `semantic-release` inside `prepareCmd` (before `build-wporg.sh`, so the zip is built from already-stamped source)
- Extends `@semantic-release/git` assets with `includes/**/*.php` so stamped files are included in the `[skip ci]` release commit
- Documents the convention in `.claude/CLAUDE.md` under a new **Code Documentation — @since Tags** section
- Fixes the pre-existing incorrect `@since 2.0.0` guess in `includes/Core/Plugin.php` → `@since NEXT_VERSION`

This PR title uses `chore(docs):` which produces **no version bump** — correct, as this is purely tooling/infrastructure.

## Test plan

- [ ] `bin/stamp-since-tags.sh 1.9.0` on a branch with `@since NEXT_VERSION` in PHP files — confirm replacement and clean exit
- [ ] `bin/stamp-since-tags.sh 1.9.0` on a clean branch with no placeholders — confirm "nothing to stamp" message and exit 0
- [ ] Merge a `feat:` or `fix:` PR after this lands — confirm the release commit contains updated `@since` tags in `includes/**/*.php`

https://claude.ai/code/session_017vS1CJkS2GXFY6opyW7eyd

---
_Generated by [Claude Code](https://claude.ai/code/session_017vS1CJkS2GXFY6opyW7eyd)_

Closes #753

Closes #754