### PR TITLE
fix(ci): update STILUS_* secret references to PLUME_* after rename

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -649,8 +649,8 @@ jobs:
         # we cd to the plugin directory explicitly before running phpunit.
         env:
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
-          PLUME_CI_SITE_TOKEN: ${{ secrets.STILUS_CI_SITE_TOKEN }}
-          PLUME_PROXY_URL: ${{ secrets.STILUS_PROXY_URL }}
+          PLUME_CI_SITE_TOKEN: ${{ secrets.PLUME_CI_SITE_TOKEN }}
+          PLUME_PROXY_URL: ${{ secrets.PLUME_PROXY_URL }}
         run: |
           npx wp-env run tests-wordpress -- bash -c "
             cd /var/www/html/wp-content/plugins/wp-ai-mind

--- a/includes/Tiers/TierConfig.php
+++ b/includes/Tiers/TierConfig.php
@@ -36,7 +36,7 @@ class TierConfig {
 	/**
 	 * Production proxy URL used when PLUME_PROXY_URL is not defined.
 	 *
-	 * @since 1.9.0
+	 * @since 1.8.1
 	 */
 	const DEFAULT_PROXY_URL = 'https://plume-proxy.plumewp.workers.dev';
 

--- a/includes/Tiers/TierConfig.php
+++ b/includes/Tiers/TierConfig.php
@@ -34,6 +34,13 @@ class TierConfig {
 	const TIERS = [ 'free', 'trial', 'pro_managed', 'pro_byok' ];
 
 	/**
+	 * Production proxy URL used when PLUME_PROXY_URL is not defined.
+	 *
+	 * @since 1.9.0
+	 */
+	const DEFAULT_PROXY_URL = 'https://plume-proxy.plumewp.workers.dev';
+
+	/**
 	 * Authoritative feature matrix for local enforcement. Changing this file
 	 * requires direct file-system access (SSH/SFTP); the Cloudflare Worker proxy
 	 * is the server-side source of truth for rate limits and paid entitlements.
@@ -101,7 +108,7 @@ class TierConfig {
 		if ( '' !== $option ) {
 			return rtrim( $option, '/' );
 		}
-		return 'https://plume-proxy.plumewp.workers.dev';
+		return self::DEFAULT_PROXY_URL;
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,12 +11,14 @@ if ( ! defined( 'PLUME_BASENAME' ) ) {
 if ( ! defined( 'PLUME_HTTP_TIMEOUT' ) ) {
 	define( 'PLUME_HTTP_TIMEOUT', 60 );
 }
-// Prevent get_proxy_url() from calling get_option() in unit tests.
-if ( ! defined( 'PLUME_PROXY_URL' ) ) {
-	define( 'PLUME_PROXY_URL', 'https://plume-proxy.plumewp.workers.dev' );
-}
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+// Prevent get_proxy_url() from calling get_option() in unit tests.
+// Must be after autoload so TierConfig::DEFAULT_PROXY_URL can be resolved.
+if ( ! defined( 'PLUME_PROXY_URL' ) ) {
+	define( 'PLUME_PROXY_URL', \Plume\Tiers\TierConfig::DEFAULT_PROXY_URL );
+}
 
 // WordPress query-result format constants (not provided by Brain Monkey).
 if ( ! defined( 'OBJECT' ) )          { define( 'OBJECT',          'OBJECT' ); }


### PR DESCRIPTION
## Summary

- Updates `STILUS_CI_SITE_TOKEN` and `STILUS_PROXY_URL` secret references in `.github/workflows/pr-checks.yml` to `PLUME_CI_SITE_TOKEN` and `PLUME_PROXY_URL` — the old secrets pointed at `stilus-proxy.stilus.workers.dev` which no longer resolves, causing 3 real-integration tests to return 502
- Adds `TierConfig::DEFAULT_PROXY_URL` class constant so the hardcoded fallback URL lives in one place
- Updates `tests/bootstrap.php` to reference `TierConfig::DEFAULT_PROXY_URL` instead of duplicating the string literal (moved after `require_once vendor/autoload.php` so the class is available when the constant is resolved)

## Test plan

- [ ] Create GitHub secrets `PLUME_CI_SITE_TOKEN` and `PLUME_PROXY_URL` with the values from the old `STILUS_CI_SITE_TOKEN` / `STILUS_PROXY_URL` secrets, then delete the old ones
- [ ] Re-run the real-integration CI job — `test_proxy_chat_returns_real_response`, `test_proxy_generator_creates_real_draft_post`, and `test_proxy_seo_returns_real_meta` should all pass
- [ ] Confirm unit tests still pass (`vendor/bin/phpunit -c phpunit.xml`)

https://claude.ai/code/session_01GMAhQ4LDKSUN4zhdzgpnoL

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMAhQ4LDKSUN4zhdzgpnoL)_

Closes #757