### PR TITLE
fix(release): make stamp-since-tags.sh portable on Linux/macOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,18 +107,17 @@ When you open a PR against `main`, two workflows run:
 - Semgrep — security scan (PHP, OWASP Top 10); SARIF uploaded to Security tab
 - WP Plugin Check — WordPress.org's plugin auditor (general/security/performance/accessibility)
 - Lighthouse — front-end performance budget against a wp-env site
-- E2E Playwright tests (runs on the maintainer's Mac via Tailscale SSH)
+- E2E Playwright tests (runs on `ubuntu-latest` via wp-env)
 
 ## Required GitHub Secrets
 
-For the Tailscale SSH E2E job to work, these must be set in the repo settings:
+For the real-integration job in `pr-checks.yml` to run live API calls, these must be set in the repo settings:
 
 | Secret | Description |
 |---|---|
-| `TAILSCALE_AUTHKEY` | Tailscale ephemeral auth key |
-| `MAC_SSH_HOST` | Tailscale hostname of the Mac runner |
-| `MAC_SSH_USER` | SSH username on the Mac |
-| `MAC_SSH_PRIVATE_KEY` | Private SSH key (public key in `~/.ssh/authorized_keys` on Mac) |
+| `CLAUDE_API_KEY` | Anthropic API key for live API calls in the `real-integration` job |
+| `PLUME_CI_SITE_TOKEN` | Site token for proxy authentication in the `real-integration` job |
+| `PLUME_PROXY_URL` | Proxy endpoint URL used by the `real-integration` job |
 
 ## Release Process
 

--- a/bin/stamp-since-tags.sh
+++ b/bin/stamp-since-tags.sh
@@ -31,10 +31,9 @@ if [[ -z "$MATCHED_FILES" ]]; then
   exit 0
 fi
 
-grep -rl0 --include="*.php" \
-  --exclude-dir=vendor --exclude-dir=assets --exclude-dir=dist \
-  "@since NEXT_VERSION" "${REPO_ROOT}" \
-  | xargs -0 sed -i '' "s/@since NEXT_VERSION/@since ${VERSION}/g"
+while IFS= read -r file; do
+  perl -pi -e "s/\@since NEXT_VERSION/\@since ${VERSION}/g" "$file"
+done <<< "$MATCHED_FILES"
 
 FILE_COUNT=$(echo "$MATCHED_FILES" | wc -l | tr -d ' ')
 echo "stamp-since-tags: updated files:"

--- a/bin/stamp-since-tags.sh
+++ b/bin/stamp-since-tags.sh
@@ -31,9 +31,8 @@ if [[ -z "$MATCHED_FILES" ]]; then
   exit 0
 fi
 
-while IFS= read -r file; do
-  perl -pi -e "s/\@since NEXT_VERSION/\@since ${VERSION}/g" "$file"
-done <<< "$MATCHED_FILES"
+mapfile -t _since_files <<< "$MATCHED_FILES"
+perl -pi -e "s|\@since NEXT_VERSION|\@since ${VERSION}|g" "${_since_files[@]}"  # \@ prevents Perl array interpolation
 
 FILE_COUNT=$(echo "$MATCHED_FILES" | wc -l | tr -d ' ')
 echo "stamp-since-tags: updated files:"

--- a/bin/stamp-since-tags.sh
+++ b/bin/stamp-since-tags.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 VERSION="${1:?Usage: stamp-since-tags.sh <version>}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# STAMP_REPO_ROOT can be overridden in tests to point at a temp directory.
+REPO_ROOT="${STAMP_REPO_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
 
 # Distinguish no-match (exit 1, expected) from a real grep error (exit 2, abort).
 set +e

--- a/tests/shell/stamp-since-tags.bats
+++ b/tests/shell/stamp-since-tags.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# Tests for bin/stamp-since-tags.sh
+#
+# Run with: bats tests/shell/stamp-since-tags.bats
+# Install:  npm install --save-dev bats  OR  brew install bats-core
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/bin/stamp-since-tags.sh"
+
+setup() {
+  TEST_ROOT="$(mktemp -d /tmp/stamp-since-tags-XXXXXX)"
+  export STAMP_REPO_ROOT="$TEST_ROOT"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+  unset STAMP_REPO_ROOT
+}
+
+@test "replaces @since NEXT_VERSION with the given version" {
+  printf '<?php\n/** @since NEXT_VERSION */\nfunction foo() {}\n' > "$TEST_ROOT/subject.php"
+
+  run "$SCRIPT" "1.9.0"
+
+  [ "$status" -eq 0 ]
+  grep -q "@since 1.9.0" "$TEST_ROOT/subject.php"
+  ! grep -q "@since NEXT_VERSION" "$TEST_ROOT/subject.php"
+}
+
+@test "leaves files without the placeholder unchanged" {
+  printf '<?php\n/** @since 1.0.0 */\nfunction bar() {}\n' > "$TEST_ROOT/stable.php"
+  ORIGINAL="$(cat "$TEST_ROOT/stable.php")"
+  # Provide a placeholder file so the script does not exit early.
+  printf '<?php\n/** @since NEXT_VERSION */\n' > "$TEST_ROOT/needs-stamp.php"
+
+  run "$SCRIPT" "2.0.0"
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$TEST_ROOT/stable.php")" = "$ORIGINAL" ]
+}
+
+@test "exits cleanly when no @since NEXT_VERSION placeholders are found" {
+  printf '<?php\n/** @since 1.0.0 */\n' > "$TEST_ROOT/already-released.php"
+
+  run "$SCRIPT" "1.9.0"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nothing to stamp"* ]]
+}


### PR DESCRIPTION
## Summary

- **Root cause of release failure**: `grep -rl0 | xargs -0 sed -i ''` in `bin/stamp-since-tags.sh` has two platform-specific bugs that both trigger on Linux (GitHub Actions `ubuntu-latest`):
  1. GNU grep's `-0` flag does not output null-terminated filenames (macOS BSD grep does) — so `xargs -0` receives one giant argument with embedded newlines, and the expression is treated as a filename
  2. BSD `sed` requires `sed -i ''` for in-place editing without a backup; GNU `sed` treats the empty-string argument as a filename rather than a backup suffix
- **Fix**: Replace the second `grep + xargs` pipeline with a `while read` loop over `$MATCHED_FILES` (already collected by the first grep scan) and use `perl -pi -e` for cross-platform in-place substitution
- **CONTRIBUTING.md**: E2E tests now run via `wp-env` on `ubuntu-latest` — remove the four stale Mac SSH/Tailscale secret rows and document the three secrets that `pr-checks.yml` actually uses

## Test plan

- [x] `./bin/stamp-since-tags.sh 1.9.0` runs cleanly on Linux and correctly stamps `@since NEXT_VERSION` → `@since 1.9.0` in `includes/Core/Plugin.php`
- [ ] Semantic-release `prepare` step completes without exit code 123 on the next release run

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8GsTLwMWHxyiG4CqDqbH7)_

Closes #759

Closes #760