### PR TITLE
fix(release): skip pre-push hook in CI

### DIFF
--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,5 +1,8 @@
 #!/bin/sh
 # Full PHPCS + PHPStan gate before pushing.
+# Skip in CI — dev deps (phpcs/phpstan) are absent in the release workflow's --no-dev install.
+[ "${CI}" = "true" ] && exit 0
+
 echo "Running pre-push checks..."
 
 ./vendor/bin/phpcs --standard=phpcs.xml.dist --warning-severity=0 || {


### PR DESCRIPTION
## Summary

- The release workflow runs `composer install --no-dev`, so `vendor/bin/phpcs` and `vendor/bin/phpstan` are absent
- When `@semantic-release/git` pushes the version-bump commit back to `main`, the `pre-push` hook fires, can't find `phpcs`, and aborts the push with exit code 1
- Fix: add `[ "${CI}" = "true" ] && exit 0` at the top of `scripts/pre-push` — code reaching the release step has already passed PHPCS + PHPStan in `pr-checks.yml`, so repeating them at push time adds no value in CI

## Verification

Verified locally before pushing:
- `CI=true sh scripts/pre-push` → exits 0 immediately ✅
- `CI=false sh scripts/pre-push` → runs normally (hook still protects local dev pushes) ✅

Note: `scripts/pre-commit` already handles missing phpcs gracefully via an existence check (`if [ ! -x "$PHPCS_BIN" ]`) — no change needed there.

## Test plan

- [ ] Merge and confirm the next semantic-release run completes the `@semantic-release/git` push step without exit code 1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8GsTLwMWHxyiG4CqDqbH7)_