### PR TITLE
fix(release): use GH_PAT to push version-bump commit past branch ruleset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,6 @@ jobs:
             echo "::warning::Moved orphaned version tags to HEAD:$moved. Branch history likely diverged from tag history."
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_PAT: ${{ secrets.GH_PAT }}
 
       - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         # commit to main. This step detects any such orphaned tags and moves
         # them to HEAD so semantic-release treats them as already released.
         run: |
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.git"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           moved=""
@@ -75,11 +75,14 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}
 
       - name: Release
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GH_PAT required — GITHUB_TOKEN cannot push the version-bump commit to main
+          # because the branch ruleset blocks direct pushes; GH_PAT has bypass access.
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
   deploy-worker:
     name: Deploy prod Worker

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Full PHPCS + PHPStan gate before pushing.
-# Skip in CI — dev deps (phpcs/phpstan) are absent in the release workflow's --no-dev install.
+# Skip in CI — dev deps (phpcs/phpstan) are absent in --no-dev installs; CI checks run separately in pr-checks.yml.
 [ "${CI}" = "true" ] && exit 0
 
 echo "Running pre-push checks..."


### PR DESCRIPTION
## Summary

`GITHUB_TOKEN` cannot push directly to `main` because the repository ruleset requires changes to go through a pull request. `@semantic-release/git` tries to push the version-bump commit directly to `main` and is rejected with `GH013: Repository rule violations`.

`GH_PAT` is the same PAT already used by `batch-auto-fix.yml` to push workflow-file changes that bypass the branch ruleset. Switching the release workflow to use it:

1. `git remote set-url` in the reconcile step now uses `${GH_PAT}` — so tag pushes also use the PAT
2. `GH_PAT` exposed as an env var to the reconcile step's shell script
3. Release step passes `GH_PAT` as `GITHUB_TOKEN` — `@semantic-release/git` uses the existing `origin` remote URL for its push, which now carries the PAT

## Caveat

If `GH_PAT` doesn't already have bypass access in the branch ruleset, the repo owner will need to add the PAT's owner account (or `github-actions[bot]`) to the **Bypass list** under Settings → Rules → Rulesets → `main`. The code change alone is sufficient if the PAT already has admin/bypass privileges.

## Test plan

- [ ] Merge and trigger a manual `workflow_dispatch` on `release.yml` — the `@semantic-release/git` push step should complete without `GH013`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8GsTLwMWHxyiG4CqDqbH7)_

Closes #763