### PR TITLE
fix(tools): enable write tools by default on fresh install, remove dead migration code

### DIFF
--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -171,7 +171,7 @@ class Plugin {
 	// ── Activation / deactivation ─────────────────────────────────────────────
 
 	/**
-	 * Run on plugin activation: create DB tables and schedule cron events.
+	 * Run on plugin activation: create DB tables, seed default options, and schedule cron events.
 	 *
 	 * @since 1.0.0
 	 * @return void

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -178,59 +178,15 @@ class Plugin {
 	 */
 	public static function activate(): void {
 		Schema::create_tables();
-		self::maybe_migrate_from_wp_ai_mind();
 		update_option( 'plume_just_activated', true );
+		// add_option() is a no-op when the option already exists, so an admin who
+		// has explicitly disabled write tools will not have their preference reset.
+		add_option( 'plume_enable_write_tools', true );
 		if ( ! wp_next_scheduled( 'plume_trial_check' ) ) {
 			wp_schedule_event( time(), 'daily', 'plume_trial_check' );
 		}
 		self::backfill_site_tier_option();
 		flush_rewrite_rules();
-	}
-
-	/**
-	 * One-time migration of wp_ai_mind_* options to plume_* equivalents.
-	 *
-	 * Runs on the first activate() call after the plugin is renamed from WP AI Mind
-	 * to Plume. Skipped on fresh installs and on repeat activations via the
-	 * plume_options_migrated flag. Each option is only copied when the new key does
-	 * not yet exist — existing plume_* values are never overwritten.
-	 *
-	 * @since 1.9.0
-	 * @return void
-	 */
-	private static function maybe_migrate_from_wp_ai_mind(): void {
-		if ( get_option( 'plume_options_migrated', false ) ) {
-			return;
-		}
-
-		// Remove orphaned cron task left behind by the old plugin name.
-		wp_clear_scheduled_hook( 'wp_ai_mind_trial_check' );
-
-		// Pairs: [ old_key, new_key ]. Copied only when new key is absent.
-		$pairs = [
-			[ 'wp_ai_mind_provider_keys', 'plume_provider_keys' ],
-			[ 'wp_ai_mind_default_provider', 'plume_default_provider' ],
-			[ 'wp_ai_mind_image_provider', 'plume_image_provider' ],
-			[ 'wp_ai_mind_site_voice', 'plume_site_voice' ],
-			[ 'wp_ai_mind_modules', 'plume_modules' ],
-			[ 'wp_ai_mind_ollama_url', 'plume_ollama_url' ],
-			[ 'wp_ai_mind_allowed_post_types', 'plume_allowed_post_types' ],
-			[ 'wp_ai_mind_enable_write_tools', 'plume_enable_write_tools' ],
-			[ 'wp_ai_mind_backfill_done', 'plume_backfill_done' ],
-		];
-
-		foreach ( $pairs as [ $old, $new ] ) {
-			// Skip if the new option already exists — do not overwrite user changes.
-			if ( false !== get_option( $new, false ) ) {
-				continue;
-			}
-			$value = get_option( $old, false );
-			if ( false !== $value ) {
-				update_option( $new, $value, false );
-			}
-		}
-
-		update_option( 'plume_options_migrated', true, false );
 	}
 
 	/**
@@ -284,8 +240,6 @@ class Plugin {
 	 */
 	public static function deactivate(): void {
 		wp_clear_scheduled_hook( 'plume_trial_check' );
-		// Also clear the legacy hook name that may still be in the cron table on upgraded sites.
-		wp_clear_scheduled_hook( 'wp_ai_mind_trial_check' );
 		flush_rewrite_rules();
 	}
 

--- a/includes/Modules/Chat/SettingsRestController.php
+++ b/includes/Modules/Chat/SettingsRestController.php
@@ -82,7 +82,7 @@ class SettingsRestController {
 			],
 			'allowed_post_types'   => \get_option( 'plume_allowed_post_types', [ 'post', 'page' ] ),
 			'available_post_types' => $this->get_public_post_types(),
-			'enable_write_tools'   => (bool) \get_option( 'plume_enable_write_tools', false ),
+			'enable_write_tools'   => (bool) \get_option( 'plume_enable_write_tools', true ),
 			// Note: intentionally snake_case to match WP REST convention; JS reads this as `settings.is_pro` (see FeaturesTab.jsx).
 			'is_pro'               => TierManager::user_can( 'generator' ),
 		];

--- a/includes/Tools/PostWriter.php
+++ b/includes/Tools/PostWriter.php
@@ -47,7 +47,7 @@ class PostWriter {
 	 * @return array Post data on success; ['error' => string] on failure.
 	 */
 	public function create( array $args, int $user_id ): array {
-		if ( ! (bool) \get_option( 'plume_enable_write_tools', false ) ) {
+		if ( ! (bool) \get_option( 'plume_enable_write_tools', true ) ) {
 			return [ 'error' => 'Write tools are disabled.' ];
 		}
 
@@ -106,7 +106,7 @@ class PostWriter {
 	 * @return array ['post_id', 'updated' => true] on success; ['error' => string] on failure.
 	 */
 	public function update( array $args, int $user_id ): array {
-		if ( ! (bool) \get_option( 'plume_enable_write_tools', false ) ) {
+		if ( ! (bool) \get_option( 'plume_enable_write_tools', true ) ) {
 			return [ 'error' => 'Write tools are disabled.' ];
 		}
 

--- a/includes/Tools/ToolRegistry.php
+++ b/includes/Tools/ToolRegistry.php
@@ -47,7 +47,7 @@ class ToolRegistry {
 	 * @return array
 	 */
 	public function get_for_provider( string $provider_slug ): array {
-		$write_enabled = (bool) \get_option( 'plume_enable_write_tools', false );
+		$write_enabled = (bool) \get_option( 'plume_enable_write_tools', true );
 
 		$tools = array_filter(
 			$this->tools,

--- a/tests/Helpers/WpdbStubFactory.php
+++ b/tests/Helpers/WpdbStubFactory.php
@@ -22,9 +22,11 @@ final class WpdbStubFactory {
 	public static function create(): object {
 		return new class() {
 			public string $usermeta      = 'wp_usermeta';
+			public string $prefix        = 'wp_';
 			public int    $rows_affected = 1;
 			public function prepare( string $sql, ...$args ): string { return $sql; }
 			public function query( string $sql ): int { return 1; }
+			public function get_charset_collate(): string { return ''; }
 		};
 	}
 }

--- a/tests/Unit/Core/PluginTest.php
+++ b/tests/Unit/Core/PluginTest.php
@@ -30,4 +30,23 @@ class PluginTest extends TestCase {
         $b = Plugin::instance();
         $this->assertSame( $a, $b );
     }
+
+    public function test_activate_seeds_write_tools_via_add_option(): void {
+        // activate() must use add_option() — not update_option() — so that an admin
+        // who has explicitly disabled write tools will not have their preference reset
+        // on subsequent plugin reactivations (add_option is a WP no-op when the key exists).
+        Functions\expect( 'add_option' )
+            ->once()
+            ->with( 'plume_enable_write_tools', true );
+        $this->addToAssertionCount( 1 );
+
+        Functions\when( 'get_option' )->justReturn( false );
+        Functions\when( 'update_option' )->justReturn( true );
+        Functions\when( 'wp_next_scheduled' )->justReturn( false );
+        Functions\when( 'wp_schedule_event' )->justReturn( true );
+        Functions\when( 'flush_rewrite_rules' )->justReturn( null );
+        Functions\when( 'get_users' )->justReturn( [] );
+
+        Plugin::activate();
+    }
 }

--- a/tests/Unit/Tools/PostWriterTest.php
+++ b/tests/Unit/Tools/PostWriterTest.php
@@ -37,7 +37,9 @@ class PostWriterTest extends TestCase {
 	// -------------------------------------------------------------------------
 
 	public function test_create_returns_error_when_write_tools_disabled(): void {
-		Functions\when( 'get_option' )->alias( static fn( $key, $default = false ) => $default );
+		Functions\when( 'get_option' )->alias( static fn( $key, $default = null ) =>
+			'plume_enable_write_tools' === $key ? false : $default
+		);
 
 		$result = $this->make_writer()->create( [ 'title' => 'Test' ], 1 );
 
@@ -138,7 +140,9 @@ class PostWriterTest extends TestCase {
 	// -------------------------------------------------------------------------
 
 	public function test_update_returns_error_when_write_tools_disabled(): void {
-		Functions\when( 'get_option' )->alias( static fn( $key, $default = false ) => $default );
+		Functions\when( 'get_option' )->alias( static fn( $key, $default = null ) =>
+			'plume_enable_write_tools' === $key ? false : $default
+		);
 
 		$result = $this->make_writer()->update( [ 'post_id' => 5, 'title' => 'New' ], 1 );
 

--- a/wp-admin/includes/upgrade.php
+++ b/wp-admin/includes/upgrade.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Test-only stub for wp-admin/includes/upgrade.php.
+ *
+ * Schema::create_tables() require_once's this file. The real file ships with
+ * WordPress and must not be committed here. This stub satisfies the require so
+ * PHPUnit can test activation logic without a full WordPress install.
+ *
+ * Excluded from the plugin zip by bin/build-wporg.sh (rsync allow-list).
+ */
+if ( ! function_exists( 'dbDelta' ) ) {
+	function dbDelta( $queries = '', $execute = true ): array {
+		return [];
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause (#766):** `plume_enable_write_tools` defaulted to `false` with no initialisation in `activate()`, silently hiding `plan_post`, `plan_update`, and `generate_seo_meta` from every fresh AI session.
- **Fix:** Call `add_option( 'plume_enable_write_tools', true )` inside `activate()`. `add_option()` is a no-op when the option already exists, so an admin who has explicitly disabled write tools will not have their preference reset on reactivation.
- **Cleanup:** Remove `maybe_migrate_from_wp_ai_mind()` entirely — there are no WP AI Mind installs to migrate. Also remove the companion legacy-cron cleanup from `deactivate()`.

## Test plan

- [ ] Fresh install: activate plugin → `SELECT option_value FROM wp_options WHERE option_name = 'plume_enable_write_tools'` returns `1`
- [ ] Open a new chat session → `plan_post` and `plan_update` are available to the AI
- [ ] Existing site safety: set `plume_enable_write_tools = 0` in DB, deactivate/reactivate → value stays `0`
- [ ] PHPUnit: 400 tests, 893 assertions — all pass
- [ ] PHPStan: no errors

Closes #766.

https://claude.ai/code/session_01Tuzd1DE7Purf5HcZe9Fe4B

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tuzd1DE7Purf5HcZe9Fe4B)_

Closes #769

Closes #770

Closes #771