### PR TITLE
ci(workflows): skip on push, trigger on ready_for_review, add missing caches

### DIFF
--- a/.github/workflows/auto-fix-ci.yml
+++ b/.github/workflows/auto-fix-ci.yml
@@ -40,6 +40,9 @@ jobs:
           # No ref — checks out the default branch (main). Claude fetches
           # and switches to the failing branch in the prompt steps below.
 
+      # Cache keys are hashed from the default-branch (main) lockfiles because
+      # the workspace is still on main at this point. Claude switches to the
+      # failing branch below; composer install / npm ci then corrects any drift.
       - name: Cache Composer deps
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:

--- a/.github/workflows/auto-fix-ci.yml
+++ b/.github/workflows/auto-fix-ci.yml
@@ -40,6 +40,20 @@ jobs:
           # No ref — checks out the default branch (main). Claude fetches
           # and switches to the failing branch in the prompt steps below.
 
+      - name: Cache Composer deps
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Cache npm deps
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-npm-
+
       - uses: anthropics/claude-code-action@d44caa1f5268e7643c11e317db4c2ad1e5ea3211 # v1
         with:
           # Max plan: use OAuth token (run `claude setup-token` locally, store as CLAUDE_CODE_OAUTH_TOKEN)

--- a/.github/workflows/auto-fix-review-issue.yml
+++ b/.github/workflows/auto-fix-review-issue.yml
@@ -97,6 +97,28 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
 
+      - name: Cache Composer deps
+        if: |
+          steps.guard.outputs.skip != 'true' &&
+          steps.parse.outputs.pr_number != '' &&
+          steps.pr_state.outcome == 'success'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Cache npm deps
+        if: |
+          steps.guard.outputs.skip != 'true' &&
+          steps.parse.outputs.pr_number != '' &&
+          steps.pr_state.outcome == 'success'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-npm-
+
       # Pre-flight: checkout the target branch and install all dependencies so
       # Claude's turn budget is spent on the actual fix, not infrastructure.
       # For OPEN PRs we switch to the PR's head branch so Claude can commit

--- a/.github/workflows/auto-fix-review-issue.yml
+++ b/.github/workflows/auto-fix-review-issue.yml
@@ -97,6 +97,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
 
+      # Cache keys are hashed from the default-branch (main) lockfiles because
+      # the workspace is still on main at this point. The Prepare workspace step
+      # below switches to the target branch; npm ci / composer install then
+      # corrects any lockfile drift automatically.
       - name: Cache Composer deps
         if: |
           steps.guard.outputs.skip != 'true' &&

--- a/.github/workflows/batch-auto-fix.yml
+++ b/.github/workflows/batch-auto-fix.yml
@@ -35,6 +35,20 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           HEAD_BRANCH: ${{ github.event.client_payload.head_branch }}
 
+      - name: Cache Composer deps
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Cache npm deps
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-npm-
+
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, reopened, edited, ready_for_review]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   commitlint:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -173,7 +173,6 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
-          cache: 'pip'
 
       - name: Install Semgrep
         run: pip install --upgrade semgrep

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -108,6 +108,13 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Cache Composer deps
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
 
@@ -166,6 +173,7 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
+          cache: 'pip'
 
       - name: Install Semgrep
         run: pip install --upgrade semgrep

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,13 @@ jobs:
           php-version: '8.1'
           tools: composer:v2
 
+      - name: Cache Composer deps (no-dev)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-nodev-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-nodev-
+
       - name: Install JS dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

- **Smart triggers**: removes `synchronize` from `ci.yml` and `pr-checks.yml` so pushing commits to a PR no longer auto-runs CI. Adds `ready_for_review` so CI fires when you explicitly mark a PR ready. `ci.yml` also gains a concurrency group (`cancel-in-progress: true`) to cancel stale runs.
- **Missing caches**: adds pip cache to the `semgrep` job and composer cache to the `php-compat` matrix job in `pr-checks.yml` (both were downloading deps from scratch on every run).
- **Auto-fix workflow caches**: all three auto-fix workflows (`auto-fix-ci`, `auto-fix-review-issue`, `batch-auto-fix`) previously had zero caching — each run re-downloaded all npm and composer deps. Adds composer + npm caches to all three.
- **Release composer cache**: `release.yml` installs `composer install --no-dev` with no cache. Adds a cache with a distinct `-nodev-` key suffix to avoid poisoning the dev-deps cache used by CI jobs.

## Workflow after this change

1. Open a PR → CI runs once on `opened`
2. Push fix commits freely → no CI triggered
3. Mark "Ready for review" → CI runs (via `ready_for_review` event)
4. If you push more commits after marking ready, re-trigger manually ("Re-run all jobs") or convert to draft and back

## Cache key design

All new caches use the same key pattern already established in `pr-checks.yml`:
- `${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}` — invalidated when `composer.lock` changes
- `${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}` — invalidated when `package-lock.json` changes

GitHub Actions caches are repository-scoped, so a cache warmed by a CI run is reusable by any auto-fix run that follows.

## Test plan

- [ ] Open a new PR — confirm `CI` and `PR Quality Checks` workflows run
- [ ] Push a commit to the PR — confirm no new workflow runs are triggered
- [ ] Mark PR as "Ready for review" — confirm both workflows fire with event type `ready_for_review`
- [ ] On a second auto-fix run, check logs for "Cache restored successfully" on composer/npm steps
- [ ] Check `semgrep` job logs for pip cache hit after a second run

https://claude.ai/code/session_01DykcYt2iH7Rirmr3SUuB9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01DykcYt2iH7Rirmr3SUuB9X)_

Closes #773