### PR TITLE
test(build): assert stamp-since-tags skips vendor/ directory

### DIFF
--- a/tests/shell/stamp-since-tags.bats
+++ b/tests/shell/stamp-since-tags.bats
@@ -56,6 +56,7 @@ teardown() {
   run "$SCRIPT" "1.9.0"
 
   [ "$status" -eq 0 ]
-  grep -q "NEXT_VERSION" "$TEST_ROOT/vendor/some-lib/bar.php"
+  grep -q "@since NEXT_VERSION" "$TEST_ROOT/vendor/some-lib/bar.php"
+  ! grep -q "@since 1.9.0" "$TEST_ROOT/vendor/some-lib/bar.php"
   grep -q "@since 1.9.0" "$TEST_ROOT/needs-stamp.php"
 }

--- a/tests/shell/stamp-since-tags.bats
+++ b/tests/shell/stamp-since-tags.bats
@@ -46,3 +46,16 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"nothing to stamp"* ]]
 }
+
+@test "does not stamp files inside vendor/" {
+  mkdir -p "$TEST_ROOT/vendor/some-lib"
+  printf '<?php\n/** @since NEXT_VERSION */\nfunction bar() {}\n' > "$TEST_ROOT/vendor/some-lib/bar.php"
+  # Non-vendor placeholder so the script does not exit early with "nothing to stamp".
+  printf '<?php\n/** @since NEXT_VERSION */\n' > "$TEST_ROOT/needs-stamp.php"
+
+  run "$SCRIPT" "1.9.0"
+
+  [ "$status" -eq 0 ]
+  grep -q "NEXT_VERSION" "$TEST_ROOT/vendor/some-lib/bar.php"
+  grep -q "@since 1.9.0" "$TEST_ROOT/needs-stamp.php"
+}


### PR DESCRIPTION
## Summary

- Adds a fourth bats test to the existing `tests/shell/stamp-since-tags.bats` suite
- Asserts that `bin/stamp-since-tags.sh` does **not** stamp `@since NEXT_VERSION` in files under `vendor/`
- Validates the `--exclude-dir=vendor` flag already present in the script's `grep` invocation
- Closes #755 (all four acceptance criteria now met: tests 1–3 already in suite, this PR adds test 4)

## Test plan

- [ ] `bats tests/shell/stamp-since-tags.bats` — all 4 tests pass
- [ ] No production code changed; CI lint/unit suites unaffected

https://claude.ai/code/session_01FUnCrdaQvZMMjmzL2SsiLg

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUnCrdaQvZMMjmzL2SsiLg)_

Closes #791
Closes #755