### PR TITLE
feat(core): prompt caching + tool stripping for token efficiency

### DIFF
--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -45,7 +45,9 @@ use Plume\Tiers\UsageTracker;
  */
 class ChatRestController {
 
-	private const MAX_TOOL_ITERATIONS = 5;
+	// Single tool exchange (call + result) followed by one text-response turn.
+	// Raising this would silently break: iterations ≥ 3 have tools stripped and can never produce a tool call.
+	private const MAX_TOOL_ITERATIONS = 2;
 
 	/**
 	 * Inject the tool registry and executor used during AI tool-call loops.
@@ -250,7 +252,9 @@ class ChatRestController {
 	/**
 	 * Append a user message and run an AI completion turn, including tool-call loops.
 	 *
-	 * Handles multi-step tool-call agentic loops up to 5 iterations.
+	 * Supports one tool exchange (call + result) then one text-response turn (2 iterations max).
+	 * Tools are stripped on the continuation call to reduce token overhead; the model must
+	 * respond in plain text on its second turn.
 	 * Provider 401/403 errors are mapped to 502 so the client cannot distinguish
 	 * a plugin auth failure from a provider auth failure.
 	 *

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -339,11 +339,12 @@ class ChatRestController {
 				? $this->tool_registry->get_for_provider( $provider_slug )
 				: [];
 
-			$max_iterations = self::MAX_TOOL_ITERATIONS;
-			$iteration      = 0;
-			$final_response = null;
-			$pending_plan   = null;
-			$tools_called   = [];
+			$max_iterations    = self::MAX_TOOL_ITERATIONS;
+			$iteration         = 0;
+			$final_response    = null;
+			$pending_plan      = null;
+			$tools_called      = [];
+			$had_tool_exchange = false;
 
 			while ( $iteration < $max_iterations ) {
 				++$iteration;
@@ -356,8 +357,8 @@ class ChatRestController {
 						'feature' => 'chat',
 						'post_id' => null,
 					],
-					tools:          $tools,
-					force_tool_use: ! empty( $tools ),
+					tools:          $had_tool_exchange ? [] : $tools,
+					force_tool_use: ! $had_tool_exchange && ! empty( $tools ),
 				);
 
 				$response = $provider->complete( $req );
@@ -409,7 +410,8 @@ class ChatRestController {
 					break;
 				}
 
-				$messages = $this->append_tool_exchange( $messages, $provider_slug, $response, $tool_results );
+				$messages          = $this->append_tool_exchange( $messages, $provider_slug, $response, $tool_results );
+				$had_tool_exchange = true;
 			}
 
 			if ( null === $final_response ) {

--- a/includes/Providers/AbstractProvider.php
+++ b/includes/Providers/AbstractProvider.php
@@ -67,6 +67,22 @@ abstract class AbstractProvider implements ProviderInterface {
 	}
 
 	/**
+	 * Format the system prompt for transmission to the provider API.
+	 *
+	 * The default returns the plain string, which is correct for OpenAI, Gemini,
+	 * and Ollama (their caching is either automatic or not applicable). Providers
+	 * that support explicit cache-control blocks (e.g. Claude) override this method
+	 * to return a structured array when the prompt exceeds the minimum cacheable length.
+	 *
+	 * @since NEXT_VERSION
+	 * @param string $system Raw system prompt text.
+	 * @return string|array Plain string for most providers; structured block array for Claude.
+	 */
+	protected function system_payload( string $system ): string|array {
+		return $system;
+	}
+
+	/**
 	 * Perform the actual completion API call (no retry wrapper).
 	 *
 	 * @since 1.0.0

--- a/includes/Providers/AbstractProvider.php
+++ b/includes/Providers/AbstractProvider.php
@@ -78,7 +78,7 @@ abstract class AbstractProvider implements ProviderInterface {
 	 * @param string $system Raw system prompt text.
 	 * @return string|array Plain string for most providers; structured block array for Claude.
 	 */
-	protected function system_payload( string $system ): string|array {
+	protected function build_system_field( string $system ): string|array {
 		return $system;
 	}
 

--- a/includes/Providers/ClaudeProvider.php
+++ b/includes/Providers/ClaudeProvider.php
@@ -29,6 +29,8 @@ class ClaudeProvider extends AbstractProvider {
 	private const API_BASE      = 'https://api.anthropic.com/v1';
 	private const API_VERSION   = '2023-06-01';
 	private const DEFAULT_MODEL = 'claude-sonnet-4-6';
+	// Minimum character count for a system prompt to receive a cache_control block (~2,048 tokens).
+	private const CACHE_CONTROL_MIN_CHARS = 8192;
 
 	// Mirrors TIER_MODELS in plume-proxy/src/index.ts — update both when adding models.
 	private const MODELS = [
@@ -42,21 +44,21 @@ class ClaudeProvider extends AbstractProvider {
 	// cache_read_in: cache-read rate (0.10× normal input).
 	private const PRICING = [
 		'claude-opus-4-6'           => [
-			'in'           => 5.0,
-			'out'          => 25.0,
-			'cache_in'     => 6.25,
+			'in'            => 5.0,
+			'out'           => 25.0,
+			'cache_in'      => 6.25,
 			'cache_read_in' => 0.50,
 		],
 		'claude-sonnet-4-6'         => [
-			'in'           => 3.0,
-			'out'          => 15.0,
-			'cache_in'     => 3.75,
+			'in'            => 3.0,
+			'out'           => 15.0,
+			'cache_in'      => 3.75,
 			'cache_read_in' => 0.30,
 		],
 		'claude-haiku-4-5-20251001' => [
-			'in'           => 1.0,
-			'out'          => 5.0,
-			'cache_in'     => 1.25,
+			'in'            => 1.0,
+			'out'           => 5.0,
+			'cache_in'      => 1.25,
 			'cache_read_in' => 0.10,
 		],
 	];
@@ -262,15 +264,15 @@ class ClaudeProvider extends AbstractProvider {
 
 	/**
 	 * Format the system prompt for Claude's API, adding a cache_control block when
-	 * the prompt exceeds the minimum cacheable length (2,048 tokens, approximated by
-	 * character count). Short prompts are passed through unchanged.
+	 * the prompt exceeds CACHE_CONTROL_MIN_CHARS characters (~2,048 tokens at 4 chars/token).
+	 * Short prompts are passed through unchanged.
 	 *
 	 * @since NEXT_VERSION
 	 * @param string $system Raw system prompt text.
 	 * @return string|array Plain string for short prompts; cache-control block array for long ones.
 	 */
 	protected function system_payload( string $system ): string|array {
-		if ( mb_strlen( $system ) <= 2048 ) {
+		if ( mb_strlen( $system ) <= self::CACHE_CONTROL_MIN_CHARS ) {
 			return $system;
 		}
 		return [
@@ -304,11 +306,11 @@ class ClaudeProvider extends AbstractProvider {
 		int $cache_read_tokens = 0,
 		int $cache_write_tokens = 0
 	): float {
-		$pricing    = self::PRICING[ $model ] ?? self::PRICING[ self::DEFAULT_MODEL ];
+		$pricing     = self::PRICING[ $model ] ?? self::PRICING[ self::DEFAULT_MODEL ];
 		$normal_cost = $in_tokens / 1_000_000 * $pricing['in'];
 		$out_cost    = $out_tokens / 1_000_000 * $pricing['out'];
-		$read_cost  = $cache_read_tokens / 1_000_000 * $pricing['cache_read_in'];
-		$write_cost = $cache_write_tokens / 1_000_000 * $pricing['cache_in'];
+		$read_cost   = $cache_read_tokens / 1_000_000 * $pricing['cache_read_in'];
+		$write_cost  = $cache_write_tokens / 1_000_000 * $pricing['cache_in'];
 		return $normal_cost + $out_cost + $read_cost + $write_cost;
 	}
 
@@ -387,12 +389,12 @@ class ClaudeProvider extends AbstractProvider {
 	 * @return CompletionResponse
 	 */
 	protected function parse_response( array $data, CompletionRequest $request ): CompletionResponse {
-		$model         = $data['model'] ?? ( ! empty( $request->model ) ? $request->model : self::DEFAULT_MODEL );
-		$in_tokens     = (int) ( $data['usage']['input_tokens'] ?? 0 );
-		$out_tokens    = (int) ( $data['usage']['output_tokens'] ?? 0 );
-		$cache_read    = (int) ( $data['usage']['cache_read_input_tokens'] ?? 0 );
-		$cache_write   = (int) ( $data['usage']['cache_creation_input_tokens'] ?? 0 );
-		$cost          = $this->calculate_cost( $model, $in_tokens, $out_tokens, $cache_read, $cache_write );
+		$model       = $data['model'] ?? ( ! empty( $request->model ) ? $request->model : self::DEFAULT_MODEL );
+		$in_tokens   = (int) ( $data['usage']['input_tokens'] ?? 0 );
+		$out_tokens  = (int) ( $data['usage']['output_tokens'] ?? 0 );
+		$cache_read  = (int) ( $data['usage']['cache_read_input_tokens'] ?? 0 );
+		$cache_write = (int) ( $data['usage']['cache_creation_input_tokens'] ?? 0 );
+		$cost        = $this->calculate_cost( $model, $in_tokens, $out_tokens, $cache_read, $cache_write );
 
 		// Check for a tool_use block in the response content.
 		$content_blocks = $data['content'] ?? [];

--- a/includes/Providers/ClaudeProvider.php
+++ b/includes/Providers/ClaudeProvider.php
@@ -178,7 +178,7 @@ class ClaudeProvider extends AbstractProvider {
 		$raw_options = [
 			'model'      => ! empty( $request->model ) ? $request->model : null,
 			'max_tokens' => $request->max_tokens,
-			'system'     => '' !== $request->system ? $this->system_payload( $request->system ) : null,
+			'system'     => '' !== $request->system ? $this->format_system_prompt( $request->system ) : null,
 		];
 		$options     = array_filter( $raw_options, fn( $v ) => null !== $v );
 		if ( ! empty( $request->tools ) ) {
@@ -271,7 +271,7 @@ class ClaudeProvider extends AbstractProvider {
 	 * @param string $system Raw system prompt text.
 	 * @return string|array Plain string for short prompts; cache-control block array for long ones.
 	 */
-	protected function system_payload( string $system ): string|array {
+	protected function format_system_prompt( string $system ): string|array {
 		if ( mb_strlen( $system ) <= self::CACHE_CONTROL_MIN_CHARS ) {
 			return $system;
 		}
@@ -328,7 +328,7 @@ class ClaudeProvider extends AbstractProvider {
 			'messages'   => $request->messages,
 		];
 		if ( '' !== $request->system ) {
-			$body['system'] = $this->system_payload( $request->system );
+			$body['system'] = $this->format_system_prompt( $request->system );
 		}
 		if ( ! empty( $request->tools ) ) {
 			$body['tools'] = $request->tools; // Already in Claude wire format from ToolRegistry.

--- a/includes/Providers/ClaudeProvider.php
+++ b/includes/Providers/ClaudeProvider.php
@@ -307,8 +307,8 @@ class ClaudeProvider extends AbstractProvider {
 		$pricing    = self::PRICING[ $model ] ?? self::PRICING[ self::DEFAULT_MODEL ];
 		$normal_cost = $in_tokens / 1_000_000 * $pricing['in'];
 		$out_cost    = $out_tokens / 1_000_000 * $pricing['out'];
-		$read_cost   = $cache_read_tokens / 1_000_000 * ( $pricing['cache_read_in'] ?? $pricing['in'] );
-		$write_cost  = $cache_write_tokens / 1_000_000 * ( $pricing['cache_in'] ?? $pricing['in'] );
+		$read_cost  = $cache_read_tokens / 1_000_000 * $pricing['cache_read_in'];
+		$write_cost = $cache_write_tokens / 1_000_000 * $pricing['cache_in'];
 		return $normal_cost + $out_cost + $read_cost + $write_cost;
 	}
 

--- a/includes/Providers/ClaudeProvider.php
+++ b/includes/Providers/ClaudeProvider.php
@@ -29,8 +29,8 @@ class ClaudeProvider extends AbstractProvider {
 	private const API_BASE      = 'https://api.anthropic.com/v1';
 	private const API_VERSION   = '2023-06-01';
 	private const DEFAULT_MODEL = 'claude-sonnet-4-6';
-	// Minimum character count for a system prompt to receive a cache_control block (~2,048 tokens).
-	private const CACHE_CONTROL_MIN_CHARS = 8192;
+	// English text averages ~4 chars/token; Anthropic's minimum cacheable prompt is 2,048 tokens.
+	private const CACHE_MIN_CHARS = 8_192;
 
 	// Mirrors TIER_MODELS in plume-proxy/src/index.ts — update both when adding models.
 	private const MODELS = [
@@ -178,7 +178,7 @@ class ClaudeProvider extends AbstractProvider {
 		$raw_options = [
 			'model'      => ! empty( $request->model ) ? $request->model : null,
 			'max_tokens' => $request->max_tokens,
-			'system'     => '' !== $request->system ? $this->format_system_prompt( $request->system ) : null,
+			'system'     => '' !== $request->system ? $this->build_system_field( $request->system ) : null,
 		];
 		$options     = array_filter( $raw_options, fn( $v ) => null !== $v );
 		if ( ! empty( $request->tools ) ) {
@@ -264,15 +264,16 @@ class ClaudeProvider extends AbstractProvider {
 
 	/**
 	 * Format the system prompt for Claude's API, adding a cache_control block when
-	 * the prompt exceeds CACHE_CONTROL_MIN_CHARS characters (~2,048 tokens at 4 chars/token).
-	 * Short prompts are passed through unchanged.
+	 * the prompt exceeds CACHE_MIN_CHARS. Anthropic requires at least 2,048 tokens to
+	 * activate prompt caching; at ~4 chars/token that is roughly 8,192 characters.
+	 * Short prompts are passed through unchanged to avoid the 1.25× cache-write surcharge.
 	 *
 	 * @since NEXT_VERSION
 	 * @param string $system Raw system prompt text.
 	 * @return string|array Plain string for short prompts; cache-control block array for long ones.
 	 */
-	protected function format_system_prompt( string $system ): string|array {
-		if ( mb_strlen( $system ) <= self::CACHE_CONTROL_MIN_CHARS ) {
+	protected function build_system_field( string $system ): string|array {
+		if ( mb_strlen( $system ) <= self::CACHE_MIN_CHARS ) {
 			return $system;
 		}
 		return [
@@ -328,7 +329,7 @@ class ClaudeProvider extends AbstractProvider {
 			'messages'   => $request->messages,
 		];
 		if ( '' !== $request->system ) {
-			$body['system'] = $this->format_system_prompt( $request->system );
+			$body['system'] = $this->build_system_field( $request->system );
 		}
 		if ( ! empty( $request->tools ) ) {
 			$body['tools'] = $request->tools; // Already in Claude wire format from ToolRegistry.

--- a/includes/Providers/ClaudeProvider.php
+++ b/includes/Providers/ClaudeProvider.php
@@ -37,19 +37,27 @@ class ClaudeProvider extends AbstractProvider {
 		'claude-haiku-4-5-20251001' => 'Claude Haiku 4.5',
 	];
 
-	// Cost per 1M tokens (input/output) in USD.
+	// Cost per 1M tokens (input/output/cache) in USD.
+	// cache_in: cache-write surcharge (1.25× normal input).
+	// cache_read_in: cache-read rate (0.10× normal input).
 	private const PRICING = [
 		'claude-opus-4-6'           => [
-			'in'  => 15.0,
-			'out' => 75.0,
+			'in'           => 5.0,
+			'out'          => 25.0,
+			'cache_in'     => 6.25,
+			'cache_read_in' => 0.50,
 		],
 		'claude-sonnet-4-6'         => [
-			'in'  => 3.0,
-			'out' => 15.0,
+			'in'           => 3.0,
+			'out'          => 15.0,
+			'cache_in'     => 3.75,
+			'cache_read_in' => 0.30,
 		],
 		'claude-haiku-4-5-20251001' => [
-			'in'  => 0.25,
-			'out' => 1.25,
+			'in'           => 1.0,
+			'out'          => 5.0,
+			'cache_in'     => 1.25,
+			'cache_read_in' => 0.10,
 		],
 	];
 
@@ -168,7 +176,7 @@ class ClaudeProvider extends AbstractProvider {
 		$raw_options = [
 			'model'      => ! empty( $request->model ) ? $request->model : null,
 			'max_tokens' => $request->max_tokens,
-			'system'     => '' !== $request->system ? $request->system : null,
+			'system'     => '' !== $request->system ? $this->system_payload( $request->system ) : null,
 		];
 		$options     = array_filter( $raw_options, fn( $v ) => null !== $v );
 		if ( ! empty( $request->tools ) ) {
@@ -253,19 +261,55 @@ class ClaudeProvider extends AbstractProvider {
 	// ── Private helpers ───────────────────────────────────────────────────────
 
 	/**
+	 * Format the system prompt for Claude's API, adding a cache_control block when
+	 * the prompt exceeds the minimum cacheable length (2,048 tokens, approximated by
+	 * character count). Short prompts are passed through unchanged.
+	 *
+	 * @since NEXT_VERSION
+	 * @param string $system Raw system prompt text.
+	 * @return string|array Plain string for short prompts; cache-control block array for long ones.
+	 */
+	protected function system_payload( string $system ): string|array {
+		if ( mb_strlen( $system ) <= 2048 ) {
+			return $system;
+		}
+		return [
+			[
+				'type'          => 'text',
+				'text'          => $system,
+				'cache_control' => [ 'type' => 'ephemeral' ],
+			],
+		];
+	}
+
+	/**
 	 * Calculate the USD cost for a completion based on token usage.
 	 *
 	 * Centralises pricing so future rate changes require a single edit.
+	 * Cache read tokens are billed at cache_read_in (0.10× normal input).
+	 * Cache write tokens are billed at cache_in (1.25× normal input).
 	 *
 	 * @since 1.0.0
-	 * @param string $model      Model slug used for the completion.
-	 * @param int    $in_tokens  Input token count.
-	 * @param int    $out_tokens Output token count.
+	 * @param string $model              Model slug used for the completion.
+	 * @param int    $in_tokens          Normal input token count.
+	 * @param int    $out_tokens         Output token count.
+	 * @param int    $cache_read_tokens  Tokens read from cache (billed at cache_read_in rate).
+	 * @param int    $cache_write_tokens Tokens written to cache (billed at cache_in rate).
 	 * @return float Cost in USD.
 	 */
-	private function calculate_cost( string $model, int $in_tokens, int $out_tokens ): float {
-		$pricing = self::PRICING[ $model ] ?? self::PRICING[ self::DEFAULT_MODEL ];
-		return ( $in_tokens / 1_000_000 * $pricing['in'] ) + ( $out_tokens / 1_000_000 * $pricing['out'] );
+	private function calculate_cost(
+		string $model,
+		int $in_tokens,
+		int $out_tokens,
+		int $cache_read_tokens = 0,
+		int $cache_write_tokens = 0
+	): float {
+		$pricing    = self::PRICING[ $model ] ?? self::PRICING[ self::DEFAULT_MODEL ];
+		$normal_cost = $in_tokens / 1_000_000 * $pricing['in'];
+		$out_cost    = $out_tokens / 1_000_000 * $pricing['out'];
+		$read_cost   = $cache_read_tokens / 1_000_000 * ( $pricing['cache_read_in'] ?? $pricing['in'] );
+		$write_cost  = $cache_write_tokens / 1_000_000 * ( $pricing['cache_in'] ?? $pricing['in'] );
+		return $normal_cost + $out_cost + $read_cost + $write_cost;
 	}
 
 	/**
@@ -282,7 +326,7 @@ class ClaudeProvider extends AbstractProvider {
 			'messages'   => $request->messages,
 		];
 		if ( '' !== $request->system ) {
-			$body['system'] = $request->system;
+			$body['system'] = $this->system_payload( $request->system );
 		}
 		if ( ! empty( $request->tools ) ) {
 			$body['tools'] = $request->tools; // Already in Claude wire format from ToolRegistry.
@@ -343,10 +387,12 @@ class ClaudeProvider extends AbstractProvider {
 	 * @return CompletionResponse
 	 */
 	protected function parse_response( array $data, CompletionRequest $request ): CompletionResponse {
-		$model      = $data['model'] ?? ( ! empty( $request->model ) ? $request->model : self::DEFAULT_MODEL );
-		$in_tokens  = (int) ( $data['usage']['input_tokens'] ?? 0 );
-		$out_tokens = (int) ( $data['usage']['output_tokens'] ?? 0 );
-		$cost       = $this->calculate_cost( $model, $in_tokens, $out_tokens );
+		$model         = $data['model'] ?? ( ! empty( $request->model ) ? $request->model : self::DEFAULT_MODEL );
+		$in_tokens     = (int) ( $data['usage']['input_tokens'] ?? 0 );
+		$out_tokens    = (int) ( $data['usage']['output_tokens'] ?? 0 );
+		$cache_read    = (int) ( $data['usage']['cache_read_input_tokens'] ?? 0 );
+		$cache_write   = (int) ( $data['usage']['cache_creation_input_tokens'] ?? 0 );
+		$cost          = $this->calculate_cost( $model, $in_tokens, $out_tokens, $cache_read, $cache_write );
 
 		// Check for a tool_use block in the response content.
 		$content_blocks = $data['content'] ?? [];
@@ -360,17 +406,19 @@ class ClaudeProvider extends AbstractProvider {
 
 		if ( null !== $tool_use_block ) {
 			return new CompletionResponse(
-				content: '',
-				model: $model,
-				prompt_tokens: $in_tokens,
-				completion_tokens: $out_tokens,
-				cost_usd: $cost,
-				raw: $data,
-				tool_call: [
+				content:            '',
+				model:              $model,
+				prompt_tokens:      $in_tokens,
+				completion_tokens:  $out_tokens,
+				cost_usd:           $cost,
+				raw:                $data,
+				tool_call:          [
 					'id'        => $tool_use_block['id'],
 					'name'      => $tool_use_block['name'],
 					'arguments' => $tool_use_block['input'] ?? [],
 				],
+				cache_read_tokens:  $cache_read,
+				cache_write_tokens: $cache_write,
 			);
 		}
 
@@ -383,6 +431,15 @@ class ClaudeProvider extends AbstractProvider {
 			}
 		}
 
-		return new CompletionResponse( $text_content, $model, $in_tokens, $out_tokens, $cost, $data );
+		return new CompletionResponse(
+			content:            $text_content,
+			model:              $model,
+			prompt_tokens:      $in_tokens,
+			completion_tokens:  $out_tokens,
+			cost_usd:           $cost,
+			raw:                $data,
+			cache_read_tokens:  $cache_read,
+			cache_write_tokens: $cache_write,
+		);
 	}
 }

--- a/includes/Providers/CompletionResponse.php
+++ b/includes/Providers/CompletionResponse.php
@@ -43,13 +43,13 @@ final class CompletionResponse {
 	public function __construct(
 		public readonly string $content,
 		public readonly string $model,
-		public readonly int    $prompt_tokens,
-		public readonly int    $completion_tokens,
-		public readonly float  $cost_usd           = 0.0,
-		public readonly mixed  $raw                = [],
-		public readonly ?array $tool_call          = null,
-		public readonly int    $cache_read_tokens  = 0,
-		public readonly int    $cache_write_tokens = 0,
+		public readonly int $prompt_tokens,
+		public readonly int $completion_tokens,
+		public readonly float $cost_usd = 0.0,
+		public readonly mixed $raw = [],
+		public readonly ?array $tool_call = null,
+		public readonly int $cache_read_tokens = 0,
+		public readonly int $cache_write_tokens = 0,
 	) {
 		$this->total_tokens = $prompt_tokens + $completion_tokens;
 	}

--- a/includes/Providers/CompletionResponse.php
+++ b/includes/Providers/CompletionResponse.php
@@ -29,6 +29,7 @@ final class CompletionResponse {
 	/**
 	 * Constructor.
 	 *
+	 * @since 1.0.0
 	 * @param string     $content             The completion content.
 	 * @param string     $model               The model used.
 	 * @param int        $prompt_tokens       Tokens used in the prompt.
@@ -36,15 +37,19 @@ final class CompletionResponse {
 	 * @param float      $cost_usd            USD cost of the request.
 	 * @param mixed      $raw                 Raw API response (array or structured value).
 	 * @param array|null $tool_call           Tool call data if the response is a tool invocation.
+	 * @param int        $cache_read_tokens   Tokens served from the prompt cache (Anthropic cache_read_input_tokens).
+	 * @param int        $cache_write_tokens  Tokens written to the prompt cache (Anthropic cache_creation_input_tokens).
 	 */
 	public function __construct(
 		public readonly string $content,
 		public readonly string $model,
-		public readonly int $prompt_tokens,
-		public readonly int $completion_tokens,
-		public readonly float $cost_usd = 0.0,
-		public readonly mixed $raw = [],
-		public readonly ?array $tool_call = null,
+		public readonly int    $prompt_tokens,
+		public readonly int    $completion_tokens,
+		public readonly float  $cost_usd           = 0.0,
+		public readonly mixed  $raw                = [],
+		public readonly ?array $tool_call          = null,
+		public readonly int    $cache_read_tokens  = 0,
+		public readonly int    $cache_write_tokens = 0,
 	) {
 		$this->total_tokens = $prompt_tokens + $completion_tokens;
 	}
@@ -70,13 +75,15 @@ final class CompletionResponse {
 	 */
 	public function with_text( string $text ): self {
 		return new self(
-			content:           $text,
-			model:             $this->model,
-			prompt_tokens:     $this->prompt_tokens,
-			completion_tokens: $this->completion_tokens,
-			cost_usd:          $this->cost_usd,
-			raw:               $this->raw,
-			tool_call:         null,
+			content:            $text,
+			model:              $this->model,
+			prompt_tokens:      $this->prompt_tokens,
+			completion_tokens:  $this->completion_tokens,
+			cost_usd:           $this->cost_usd,
+			raw:                $this->raw,
+			tool_call:          null,
+			cache_read_tokens:  $this->cache_read_tokens,
+			cache_write_tokens: $this->cache_write_tokens,
 		);
 	}
 }

--- a/includes/Providers/GeminiProvider.php
+++ b/includes/Providers/GeminiProvider.php
@@ -188,7 +188,7 @@ class GeminiProvider extends AbstractProvider {
 		$raw_options = [
 			'model'      => $model,
 			'max_tokens' => $request->max_tokens,
-			'system'     => '' !== $request->system ? $request->system : null,
+			'system'     => '' !== $request->system ? $this->system_payload( $request->system ) : null,
 		];
 		$options     = array_filter( $raw_options, fn( $v ) => null !== $v );
 		if ( ! empty( $request->tools ) ) {

--- a/includes/Providers/GeminiProvider.php
+++ b/includes/Providers/GeminiProvider.php
@@ -188,7 +188,7 @@ class GeminiProvider extends AbstractProvider {
 		$raw_options = [
 			'model'      => $model,
 			'max_tokens' => $request->max_tokens,
-			'system'     => '' !== $request->system ? $this->system_payload( $request->system ) : null,
+			'system'     => '' !== $request->system ? $this->build_system_field( $request->system ) : null,
 		];
 		$options     = array_filter( $raw_options, fn( $v ) => null !== $v );
 		if ( ! empty( $request->tools ) ) {

--- a/includes/Providers/OpenAIProvider.php
+++ b/includes/Providers/OpenAIProvider.php
@@ -196,7 +196,7 @@ class OpenAIProvider extends AbstractProvider {
 		$raw_options = [
 			'model'      => $model,
 			'max_tokens' => $request->max_tokens,
-			'system'     => '' !== $request->system ? $request->system : null,
+			'system'     => '' !== $request->system ? $this->system_payload( $request->system ) : null,
 		];
 		$options     = array_filter( $raw_options, fn( $v ) => null !== $v );
 		if ( ! empty( $request->tools ) ) {

--- a/includes/Providers/OpenAIProvider.php
+++ b/includes/Providers/OpenAIProvider.php
@@ -196,7 +196,7 @@ class OpenAIProvider extends AbstractProvider {
 		$raw_options = [
 			'model'      => $model,
 			'max_tokens' => $request->max_tokens,
-			'system'     => '' !== $request->system ? $this->system_payload( $request->system ) : null,
+			'system'     => '' !== $request->system ? $this->build_system_field( $request->system ) : null,
 		];
 		$options     = array_filter( $raw_options, fn( $v ) => null !== $v );
 		if ( ! empty( $request->tools ) ) {

--- a/plume-proxy/src/index.ts
+++ b/plume-proxy/src/index.ts
@@ -214,8 +214,12 @@ async function callOpenAI(
 	clampedMaxTokens: number,
 	env: Env
 ): Promise< NormalizedResponse > {
-	const messages = body.system
-		? [ { role: 'system', content: body.system }, ...body.messages ]
+	const sysText =
+		typeof body.system === 'string'
+			? body.system
+			: ( body.system?.[ 0 ]?.text ?? '' );
+	const messages = sysText
+		? [ { role: 'system', content: sysText }, ...body.messages ]
 		: body.messages;
 	const openaiBody: Record< string, unknown > = {
 		model: resolvedModel,
@@ -304,7 +308,13 @@ async function callGemini(
 		generationConfig: { maxOutputTokens: clampedMaxTokens },
 	};
 	if ( body.system ) {
-		geminiBody.systemInstruction = { parts: [ { text: body.system } ] };
+		const sysText =
+			typeof body.system === 'string'
+				? body.system
+				: ( body.system?.[ 0 ]?.text ?? '' );
+		if ( sysText ) {
+			geminiBody.systemInstruction = { parts: [ { text: sysText } ] };
+		}
 	}
 	if ( body.tools && body.tools.length > 0 ) {
 		geminiBody.tools = toGeminiTools( body.tools );

--- a/plume-proxy/src/index.ts
+++ b/plume-proxy/src/index.ts
@@ -127,6 +127,20 @@ function toGeminiTools( tools: ToolParam[] ) {
 	];
 }
 
+/**
+ * Extract a plain text string from a system field that may be a string or a SystemBlock array.
+ * Claude passes the block array through as-is; OpenAI and Gemini need a plain string.
+ *
+ * @param {ProxyRequest['system']} system - System field from the proxy request.
+ * @return {string} Plain text content.
+ */
+function resolveSystemText( system: ProxyRequest[ 'system' ] ): string {
+	if ( ! system ) {
+		return '';
+	}
+	return typeof system === 'string' ? system : ( system[ 0 ]?.text ?? '' );
+}
+
 async function callClaude(
 	body: ProxyRequest,
 	resolvedModel: string,

--- a/plume-proxy/src/index.ts
+++ b/plume-proxy/src/index.ts
@@ -208,16 +208,18 @@ async function callClaude(
 	};
 }
 
+function resolveSystemText( system: string | SystemBlock[] | undefined ): string {
+	if ( ! system ) return '';
+	return typeof system === 'string' ? system : ( system[ 0 ]?.text ?? '' );
+}
+
 async function callOpenAI(
 	body: ProxyRequest,
 	resolvedModel: string,
 	clampedMaxTokens: number,
 	env: Env
 ): Promise< NormalizedResponse > {
-	const sysText =
-		typeof body.system === 'string'
-			? body.system
-			: ( body.system?.[ 0 ]?.text ?? '' );
+	const sysText = resolveSystemText( body.system );
 	const messages = sysText
 		? [ { role: 'system', content: sysText }, ...body.messages ]
 		: body.messages;
@@ -307,14 +309,9 @@ async function callGemini(
 		contents,
 		generationConfig: { maxOutputTokens: clampedMaxTokens },
 	};
-	if ( body.system ) {
-		const sysText =
-			typeof body.system === 'string'
-				? body.system
-				: ( body.system?.[ 0 ]?.text ?? '' );
-		if ( sysText ) {
-			geminiBody.systemInstruction = { parts: [ { text: sysText } ] };
-		}
+	const sysText = resolveSystemText( body.system );
+	if ( sysText ) {
+		geminiBody.systemInstruction = { parts: [ { text: sysText } ] };
 	}
 	if ( body.tools && body.tools.length > 0 ) {
 		geminiBody.tools = toGeminiTools( body.tools );

--- a/plume-proxy/src/types.ts
+++ b/plume-proxy/src/types.ts
@@ -59,11 +59,18 @@ export interface NormalizedResponse {
 	};
 }
 
+export interface SystemBlock {
+	type: 'text';
+	text: string;
+	cache_control?: { type: 'ephemeral' };
+}
+
 export interface ProxyRequest {
 	messages: MessageParam[];
 	model?: string;
 	max_tokens?: number;
-	system?: string;
+	/** Plain string for OpenAI/Gemini; SystemBlock[] for Claude with prompt caching. */
+	system?: string | SystemBlock[];
 	tools?: ToolParam[];
 	provider?: 'claude' | 'openai' | 'gemini';
 }

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -569,7 +569,7 @@ class ChatRestControllerTest extends TestCase {
         // Tool call response (iteration 1).
         $tool_response = new CompletionResponse(
             content:           '',
-            model:             'claude-3-5-sonnet',
+            model:             'claude-sonnet-4-6',
             prompt_tokens:     10,
             completion_tokens: 5,
             cost_usd:          0.0,
@@ -580,7 +580,7 @@ class ChatRestControllerTest extends TestCase {
         // Final text response (iteration 2).
         $final_response = new CompletionResponse(
             content:           'Final answer',
-            model:             'claude-3-5-sonnet',
+            model:             'claude-sonnet-4-6',
             prompt_tokens:     20,
             completion_tokens: 15,
             cost_usd:          0.001,
@@ -613,7 +613,7 @@ class ChatRestControllerTest extends TestCase {
 
         $request = new \WP_REST_Request( 'POST' );
         $request->set_url_params( [ 'id' => '42' ] );
-        $request->set_body_params( [ 'content' => 'Hello', 'provider' => 'claude', 'model' => 'claude-3-5-sonnet' ] );
+        $request->set_body_params( [ 'content' => 'Hello', 'provider' => 'claude', 'model' => 'claude-sonnet-4-6' ] );
 
         $response = $controller->send_message( $request );
 
@@ -711,7 +711,7 @@ class ChatRestControllerTest extends TestCase {
 
         $tool_response = new CompletionResponse(
             content:           '',
-            model:             'claude-3-5-sonnet',
+            model:             'claude-sonnet-4-6',
             prompt_tokens:     10,
             completion_tokens: 5,
             cost_usd:          0.0,
@@ -1099,7 +1099,7 @@ class ChatRestControllerTest extends TestCase {
 
         $tool_response = new CompletionResponse(
             content:           '',
-            model:             'claude-3-5-sonnet',
+            model:             'claude-sonnet-4-6',
             prompt_tokens:     10,
             completion_tokens: 5,
             cost_usd:          0.0,
@@ -1108,7 +1108,7 @@ class ChatRestControllerTest extends TestCase {
         );
         $final_response = new CompletionResponse(
             content:           'Done',
-            model:             'claude-3-5-sonnet',
+            model:             'claude-sonnet-4-6',
             prompt_tokens:     20,
             completion_tokens: 15,
             cost_usd:          0.001,
@@ -1348,7 +1348,7 @@ class ChatRestControllerTest extends TestCase {
     public function test_extract_tool_calls_returns_all_claude_tool_use_blocks(): void {
         $response = new CompletionResponse(
             content: '',
-            model: 'claude-3-5-sonnet',
+            model: 'claude-sonnet-4-6',
             prompt_tokens: 10,
             completion_tokens: 5,
             raw: [
@@ -1374,7 +1374,7 @@ class ChatRestControllerTest extends TestCase {
     public function test_extract_tool_calls_falls_back_to_tool_call_when_raw_is_empty(): void {
         $response = new CompletionResponse(
             content: '',
-            model: 'claude-3-5-sonnet',
+            model: 'claude-sonnet-4-6',
             prompt_tokens: 10,
             completion_tokens: 5,
             raw: [ 'content' => [] ],
@@ -1487,7 +1487,7 @@ class ChatRestControllerTest extends TestCase {
 
         $chat_response = new CompletionResponse(
             content:           '',
-            model:             'claude-3-5-sonnet',
+            model:             'claude-sonnet-4-6',
             prompt_tokens:     10,
             completion_tokens: 5,
             cost_usd:          0.0,
@@ -1539,7 +1539,7 @@ class ChatRestControllerTest extends TestCase {
 
         $plan_response = new CompletionResponse(
             content:           '',
-            model:             'claude-3-5-sonnet',
+            model:             'claude-sonnet-4-6',
             prompt_tokens:     10,
             completion_tokens: 5,
             cost_usd:          0.0,
@@ -1553,7 +1553,7 @@ class ChatRestControllerTest extends TestCase {
 
         $final_response = new CompletionResponse(
             content:           'I have proposed a post for your approval.',
-            model:             'claude-3-5-sonnet',
+            model:             'claude-sonnet-4-6',
             prompt_tokens:     20,
             completion_tokens: 15,
             cost_usd:          0.0,

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -1082,6 +1082,76 @@ class ChatRestControllerTest extends TestCase {
         };
     }
 
+    // ── Tool stripping on continuation calls ──────────────────────────────────
+
+    public function test_send_message_strips_tools_on_continuation_call(): void {
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );
+        Functions\when( 'get_option' )->justReturn( 'claude' );
+        Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+
+        $store_mock = $this->createMock( \Plume\DB\ConversationStore::class );
+        $store_mock->method( 'get_conversation' )->willReturn( [ 'user_id' => 1 ] );
+        $store_mock->method( 'get_messages' )->willReturn( [
+            [ 'role' => 'user', 'content' => 'Hello' ],
+        ] );
+        $store_mock->method( 'add_message' )->willReturn( 1 );
+
+        $tool_response = new CompletionResponse(
+            content:           '',
+            model:             'claude-3-5-sonnet',
+            prompt_tokens:     10,
+            completion_tokens: 5,
+            cost_usd:          0.0,
+            raw:               [ 'content' => [] ],
+            tool_call:         [ 'id' => 'tc_1', 'name' => 'get_recent_posts', 'arguments' => [ 'count' => 3 ] ],
+        );
+        $final_response = new CompletionResponse(
+            content:           'Done',
+            model:             'claude-3-5-sonnet',
+            prompt_tokens:     20,
+            completion_tokens: 15,
+            cost_usd:          0.001,
+            raw:               [],
+            tool_call:         null,
+        );
+
+        $non_empty_tools = [ [ 'name' => 'get_recent_posts', 'description' => 'Fetch posts.' ] ];
+        $this->tool_registry->method( 'get_for_provider' )->willReturn( $non_empty_tools );
+        $this->tool_executor->method( 'execute' )->willReturn( [ 'posts' => [] ] );
+
+        $captured_requests = [];
+        $provider_mock = $this->createMock( \Plume\Providers\ProviderInterface::class );
+        $provider_mock->method( 'is_available' )->willReturn( true );
+        $provider_mock->method( 'supports_tools' )->willReturn( true );
+        $provider_mock->method( 'complete' )->willReturnCallback(
+            function ( $req ) use ( &$captured_requests, $tool_response, $final_response ) {
+                $captured_requests[] = $req;
+                return 1 === count( $captured_requests ) ? $tool_response : $final_response;
+            }
+        );
+
+        $factory_mock = $this->createMock( \Plume\Providers\ProviderFactory::class );
+        $factory_mock->method( 'make' )->willReturn( $provider_mock );
+
+        $voice_mock = $this->createMock( \Plume\Voice\VoiceInjector::class );
+        $voice_mock->method( 'build_system_prompt' )->willReturn( '' );
+
+        $controller = $this->make_controller( $store_mock, $factory_mock, $voice_mock );
+
+        $request = new \WP_REST_Request( 'POST' );
+        $request->set_url_params( [ 'id' => '42' ] );
+        $request->set_body_params( [ 'content' => 'Hello', 'provider' => 'claude', 'model' => '' ] );
+
+        $controller->send_message( $request );
+
+        $this->assertCount( 2, $captured_requests, 'Provider must be called exactly twice' );
+        $this->assertNotEmpty( $captured_requests[0]->tools, 'First call must include tools' );
+        $this->assertTrue( $captured_requests[0]->force_tool_use, 'First call must have force_tool_use=true' );
+        $this->assertEmpty( $captured_requests[1]->tools, 'Continuation call must have empty tools' );
+        $this->assertFalse( $captured_requests[1]->force_tool_use, 'Continuation call must have force_tool_use=false' );
+    }
+
     // ── append_tool_exchange: Gemini multi-tool ───────────────────────────────
 
     /**

--- a/tests/Unit/Providers/AbstractProviderTest.php
+++ b/tests/Unit/Providers/AbstractProviderTest.php
@@ -57,9 +57,9 @@ class AbstractProviderTest extends TestCase {
 		Functions\when( 'sanitize_text_field' )->alias( fn($v) => $v );
 	}
 
-	public function test_system_payload_returns_plain_string_by_default(): void {
+	public function test_build_system_field_returns_plain_string_by_default(): void {
 		$provider = $this->make_provider( 0 );
-		$result   = ( new \ReflectionMethod( $provider, 'system_payload' ) )
+		$result   = ( new \ReflectionMethod( $provider, 'build_system_field' ) )
 			->invoke( $provider, 'You are a helpful assistant.' );
 		$this->assertSame( 'You are a helpful assistant.', $result );
 	}

--- a/tests/Unit/Providers/AbstractProviderTest.php
+++ b/tests/Unit/Providers/AbstractProviderTest.php
@@ -57,6 +57,13 @@ class AbstractProviderTest extends TestCase {
 		Functions\when( 'sanitize_text_field' )->alias( fn($v) => $v );
 	}
 
+	public function test_system_payload_returns_plain_string_by_default(): void {
+		$provider = $this->make_provider( 0 );
+		$result   = ( new \ReflectionMethod( $provider, 'system_payload' ) )
+			->invoke( $provider, 'You are a helpful assistant.' );
+		$this->assertSame( 'You are a helpful assistant.', $result );
+	}
+
 	private function make_provider( int $failures_before_success ): AbstractProvider {
 		return new class( $failures_before_success ) extends AbstractProvider {
 			private int $calls = 0;

--- a/tests/Unit/Providers/ClaudeProviderTest.php
+++ b/tests/Unit/Providers/ClaudeProviderTest.php
@@ -358,7 +358,7 @@ class ClaudeProviderTest extends TestCase {
 	public function test_system_payload_returns_cache_block_for_long_system(): void {
 		$provider     = new ClaudeProvider( 'sk-ant-test' );
 		$method       = new \ReflectionMethod( $provider, 'system_payload' );
-		$long_system  = str_repeat( 'a', 2049 );
+		$long_system  = str_repeat( 'a', 8193 );
 		$result       = $method->invoke( $provider, $long_system );
 		$this->assertIsArray( $result );
 		$this->assertCount( 1, $result );
@@ -370,7 +370,7 @@ class ClaudeProviderTest extends TestCase {
 	public function test_system_payload_boundary_at_2048_chars_stays_plain_string(): void {
 		$provider    = new ClaudeProvider( 'sk-ant-test' );
 		$method      = new \ReflectionMethod( $provider, 'system_payload' );
-		$edge_system = str_repeat( 'b', 2048 );
+		$edge_system = str_repeat( 'b', 8192 );
 		$result      = $method->invoke( $provider, $edge_system );
 		$this->assertIsString( $result );
 	}

--- a/tests/Unit/Providers/ClaudeProviderTest.php
+++ b/tests/Unit/Providers/ClaudeProviderTest.php
@@ -402,6 +402,9 @@ class ClaudeProviderTest extends TestCase {
 		$this->assertSame( 800, $response->cache_read_tokens );
 		$this->assertSame( 200, $response->cache_write_tokens );
 		$this->assertSame( 'Cached reply', $response->content );
+		// For claude-sonnet-4-6: 100 in × $3/M + 20 out × $15/M + 800 cache-read × $0.30/M + 200 cache-write × $3.75/M.
+		$expected_cost = ( 100 / 1_000_000 * 3.0 ) + ( 20 / 1_000_000 * 15.0 ) + ( 800 / 1_000_000 * 0.30 ) + ( 200 / 1_000_000 * 3.75 );
+		$this->assertEqualsWithDelta( $expected_cost, $response->cost_usd, 1.0e-10 );
 	}
 
 	public function test_tools_injected_in_request_body(): void {

--- a/tests/Unit/Providers/ClaudeProviderTest.php
+++ b/tests/Unit/Providers/ClaudeProviderTest.php
@@ -349,7 +349,7 @@ class ClaudeProviderTest extends TestCase {
 
 	public function test_system_payload_returns_plain_string_for_short_system(): void {
 		$provider = new ClaudeProvider( 'sk-ant-test' );
-		$method   = new \ReflectionMethod( $provider, 'system_payload' );
+		$method   = new \ReflectionMethod( $provider, 'format_system_prompt' );
 		$result   = $method->invoke( $provider, 'Short prompt.' );
 		$this->assertIsString( $result );
 		$this->assertSame( 'Short prompt.', $result );
@@ -357,7 +357,7 @@ class ClaudeProviderTest extends TestCase {
 
 	public function test_system_payload_returns_cache_block_for_long_system(): void {
 		$provider     = new ClaudeProvider( 'sk-ant-test' );
-		$method       = new \ReflectionMethod( $provider, 'system_payload' );
+		$method       = new \ReflectionMethod( $provider, 'format_system_prompt' );
 		$long_system  = str_repeat( 'a', 8193 );
 		$result       = $method->invoke( $provider, $long_system );
 		$this->assertIsArray( $result );
@@ -369,7 +369,7 @@ class ClaudeProviderTest extends TestCase {
 
 	public function test_system_payload_boundary_at_2048_chars_stays_plain_string(): void {
 		$provider    = new ClaudeProvider( 'sk-ant-test' );
-		$method      = new \ReflectionMethod( $provider, 'system_payload' );
+		$method      = new \ReflectionMethod( $provider, 'format_system_prompt' );
 		$edge_system = str_repeat( 'b', 8192 );
 		$result      = $method->invoke( $provider, $edge_system );
 		$this->assertIsString( $result );

--- a/tests/Unit/Providers/ClaudeProviderTest.php
+++ b/tests/Unit/Providers/ClaudeProviderTest.php
@@ -347,19 +347,19 @@ class ClaudeProviderTest extends TestCase {
 		$this->assertSame( "I'll fetch that post for you.", $response->content );
 	}
 
-	public function test_system_payload_returns_plain_string_for_short_system(): void {
+	public function test_build_system_field_returns_plain_string_for_short_system(): void {
 		$provider = new ClaudeProvider( 'sk-ant-test' );
-		$method   = new \ReflectionMethod( $provider, 'format_system_prompt' );
+		$method   = new \ReflectionMethod( $provider, 'build_system_field' );
 		$result   = $method->invoke( $provider, 'Short prompt.' );
 		$this->assertIsString( $result );
 		$this->assertSame( 'Short prompt.', $result );
 	}
 
-	public function test_system_payload_returns_cache_block_for_long_system(): void {
-		$provider     = new ClaudeProvider( 'sk-ant-test' );
-		$method       = new \ReflectionMethod( $provider, 'format_system_prompt' );
-		$long_system  = str_repeat( 'a', 8193 );
-		$result       = $method->invoke( $provider, $long_system );
+	public function test_build_system_field_returns_cache_block_for_long_system(): void {
+		$provider    = new ClaudeProvider( 'sk-ant-test' );
+		$method      = new \ReflectionMethod( $provider, 'build_system_field' );
+		$long_system = str_repeat( 'a', 8193 );
+		$result      = $method->invoke( $provider, $long_system );
 		$this->assertIsArray( $result );
 		$this->assertCount( 1, $result );
 		$this->assertSame( 'text', $result[0]['type'] );
@@ -367,9 +367,9 @@ class ClaudeProviderTest extends TestCase {
 		$this->assertSame( [ 'type' => 'ephemeral' ], $result[0]['cache_control'] );
 	}
 
-	public function test_system_payload_boundary_at_2048_chars_stays_plain_string(): void {
+	public function test_build_system_field_boundary_at_8192_chars_stays_plain_string(): void {
 		$provider    = new ClaudeProvider( 'sk-ant-test' );
-		$method      = new \ReflectionMethod( $provider, 'format_system_prompt' );
+		$method      = new \ReflectionMethod( $provider, 'build_system_field' );
 		$edge_system = str_repeat( 'b', 8192 );
 		$result      = $method->invoke( $provider, $edge_system );
 		$this->assertIsString( $result );

--- a/tests/Unit/Providers/ClaudeProviderTest.php
+++ b/tests/Unit/Providers/ClaudeProviderTest.php
@@ -347,6 +347,63 @@ class ClaudeProviderTest extends TestCase {
 		$this->assertSame( "I'll fetch that post for you.", $response->content );
 	}
 
+	public function test_system_payload_returns_plain_string_for_short_system(): void {
+		$provider = new ClaudeProvider( 'sk-ant-test' );
+		$method   = new \ReflectionMethod( $provider, 'system_payload' );
+		$result   = $method->invoke( $provider, 'Short prompt.' );
+		$this->assertIsString( $result );
+		$this->assertSame( 'Short prompt.', $result );
+	}
+
+	public function test_system_payload_returns_cache_block_for_long_system(): void {
+		$provider     = new ClaudeProvider( 'sk-ant-test' );
+		$method       = new \ReflectionMethod( $provider, 'system_payload' );
+		$long_system  = str_repeat( 'a', 2049 );
+		$result       = $method->invoke( $provider, $long_system );
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'text', $result[0]['type'] );
+		$this->assertSame( $long_system, $result[0]['text'] );
+		$this->assertSame( [ 'type' => 'ephemeral' ], $result[0]['cache_control'] );
+	}
+
+	public function test_system_payload_boundary_at_2048_chars_stays_plain_string(): void {
+		$provider    = new ClaudeProvider( 'sk-ant-test' );
+		$method      = new \ReflectionMethod( $provider, 'system_payload' );
+		$edge_system = str_repeat( 'b', 2048 );
+		$result      = $method->invoke( $provider, $edge_system );
+		$this->assertIsString( $result );
+	}
+
+	public function test_complete_parses_cache_tokens_in_response(): void {
+		Functions\when( 'wp_remote_post' )->justReturn( [
+			'response' => [ 'code' => 200 ],
+			'body'     => json_encode( [
+				'content' => [ [ 'type' => 'text', 'text' => 'Cached reply' ] ],
+				'model'   => 'claude-sonnet-4-6',
+				'usage'   => [
+					'input_tokens'                  => 100,
+					'output_tokens'                 => 20,
+					'cache_read_input_tokens'       => 800,
+					'cache_creation_input_tokens'   => 200,
+				],
+			] ),
+		] );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->alias( fn( $r ) => $r['body'] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+		$this->mock_wpdb();
+
+		$provider = new ClaudeProvider( 'sk-ant-test' );
+		$request  = new CompletionRequest( [ [ 'role' => 'user', 'content' => 'hi' ] ] );
+		$response = $provider->complete( $request );
+
+		$this->assertSame( 800, $response->cache_read_tokens );
+		$this->assertSame( 200, $response->cache_write_tokens );
+		$this->assertSame( 'Cached reply', $response->content );
+	}
+
 	public function test_tools_injected_in_request_body(): void {
 		$captured_body = null;
 		Functions\when( 'wp_remote_post' )->alias( function( $url, $args ) use ( &$captured_body ) {


### PR DESCRIPTION
## Summary

- **Tool stripping on continuation calls** — after a tool exchange the model only needs to return text. Passing the full tool list again re-tokenises all schemas on every iteration with no benefit. A `$had_tool_exchange` boolean in the agentic loop now sends `tools: []` and `force_tool_use: false` on every turn after the first tool result is appended. `MAX_TOOL_ITERATIONS` is capped at 2 (one tool exchange + one text turn) to match this single-exchange design. Closes #568, #747.

- **Prompt caching via `cache_control` blocks** — `AbstractProvider::build_system_field()` is the single decision point for system prompt formatting. `ClaudeProvider` overrides it to wrap prompts longer than 8,192 chars in a `cache_control: { type: 'ephemeral' }` block, enabling Anthropic prompt caching (~2,048 token minimum). OpenAI and Gemini inherit the plain-string default. All provider proxy paths call `build_system_field()`, so the cache block is forwarded to the Cloudflare Worker for managed tiers. The Worker's `callOpenAI()` and `callGemini()` coerce the block to plain text via a shared `resolveSystemText()` helper.

- **Cache token tracking** — `CompletionResponse` gains `cache_read_tokens` and `cache_write_tokens` fields. `ClaudeProvider::calculate_cost()` applies the correct per-model cache-read and cache-write rates. `ClaudeProvider::PRICING` is updated with accurate Opus, Sonnet, and Haiku rates including cache tiers.

## Reviewer feedback addressed (#793–#796)

- `CACHE_MIN_CHARS = 8_192` — threshold corrected to actual Anthropic minimum; boundary condition is `<=` so exactly 8,192 chars stays plain string
- `MAX_TOOL_ITERATIONS` lowered to 2 to match the single-exchange constraint enforced by `$had_tool_exchange`
- Cost test uses computed `$expected_cost` expression rather than a hardcoded magic number
- `resolveSystemText()` helper extracted in Worker TypeScript to remove duplicated ternary in `callOpenAI`/`callGemini`
- Test fixtures updated to use `claude-sonnet-4-6` model slug

## Test plan

- [x] `./vendor/bin/phpunit tests/Unit/` — 413 tests, 919 assertions, all pass
- [x] `AbstractProviderTest` — `build_system_field()` returns plain string by default
- [x] `ClaudeProviderTest` — `build_system_field()` returns cache block for long prompts, plain string at/below 8,192 chars; `cache_read_tokens` / `cache_write_tokens` parsed from API response; cost calculation verified
- [x] `ChatRestControllerTest` — tools stripped on continuation call, `force_tool_use` false after first exchange
- [ ] Manual: verify Claude responses on long system prompts show `cache_read_input_tokens` in subsequent turns
- [ ] Manual: verify continuation turns no longer include tool schemas in the API payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)