### PR TITLE
fix(triage): use GitHub comments as authoritative deferred-state source

### DIFF
--- a/.claude/commands/issue-triage.md
+++ b/.claude/commands/issue-triage.md
@@ -60,6 +60,13 @@ Compare `updatedAt` against the `deferred_at` timestamp in the file.
   - **New information or partial clarification** (adds context but does not fully resolve the question) → re-evaluate whether the issue can now be planned. If yes, re-classify. If the decision question is still open, update the deferred state file with the new context and post a follow-up comment asking the remaining clarifying question
   - **Unrelated comment** (off-topic, acknowledgement only) → mark `SKIP (deferred, no update)` and continue skipping
 
+**If the deferred state file does not exist or is empty**, reconstruct the deferred list from GitHub using the `comments` data already loaded in Phase 1a — do not make additional API calls. For each open issue in the candidate set:
+
+- If it has at least one comment whose body starts with `**Nightly triage` AND no owner/member comment was posted after the last such triage comment → treat as `SKIP (deferred, no update)` and exclude from the working set.
+- If it has a triage comment followed by an owner/member reply → treat as `Deferred re-evaluated (new activity)` and re-classify normally.
+
+This makes GitHub issue comments the authoritative source of deferred state. The local `.artifacts/reports/triage-deferred.md` file is a performance cache — the run is correct with or without it.
+
 ### Step 1d — Check recent commits
 
 ```bash
@@ -107,7 +114,17 @@ Classify each issue in the working set across two axes.
 
 **Strategic flag:** Issues that cannot be resolved without an architectural or product decision get a `DEFER` flag and a one-line note describing the decision needed. Do not stop the run. Continue with everything else; DEFER items are written to the deferred state file at the end of the run.
 
-When an issue is marked DEFER **for the first time** (i.e. it is not already in the deferred state file), post a comment on the issue:
+When an issue is marked DEFER, check whether a triage comment has already been posted **using the `comments` data already fetched in Phase 1a** — do not make another API call.
+
+A triage comment is any comment whose body starts with `**Nightly triage`.
+
+Post a new DEFER comment only when **at least one** of these is true:
+- No triage comment exists on the issue yet.
+- The last triage comment was followed by an owner/member reply (i.e. the human responded, but the question is still not fully resolved — a follow-up clarification is warranted).
+
+**Do not post** if the most recent comment on the issue is itself a triage comment with no owner/member reply since — the issue is already awaiting a decision and another comment is noise.
+
+When posting is warranted:
 
 ```bash
 gh issue comment <n> --body "**Nightly triage — decision needed**
@@ -119,7 +136,7 @@ This issue was reviewed in the automated nightly triage run but cannot be resolv
 Reply to this comment with your decision and the next nightly run will pick it up automatically."
 ```
 
-Do not post this comment if the issue is already in the deferred state file — it was commented on in a previous run. A follow-up comment is only posted if re-evaluation in Phase 1c finds new information that narrows but does not resolve the question.
+A follow-up comment (not a duplicate) is only posted when Phase 1c re-evaluation finds new information that narrows but does not fully resolve the question.
 
 Output the prioritisation matrix:
 
@@ -427,7 +444,9 @@ After outputting the report, update the deferred state file:
 mkdir -p .artifacts/reports
 cat > .artifacts/reports/triage-deferred.md << 'EOF'
 # Triage deferred issues
-# Maintained automatically by /issue-triage. Do not edit manually.
+# Performance cache only — GitHub issue comments are the authoritative source.
+# If this file is deleted, Phase 1c reconstructs state from GitHub automatically.
+# Do not edit manually.
 # Format: issue number | deferred_at (ISO date) | decision needed
 
 7 | 2026-06-07 | Choose between transient and object cache — impacts multisite behaviour
@@ -435,4 +454,4 @@ cat > .artifacts/reports/triage-deferred.md << 'EOF'
 EOF
 ```
 
-Write only issues that remain unresolved and deferred. Remove any issue from this file that was resolved, covered by a PR, or re-evaluated and actioned in this run. The file is the single source of truth for skip logic in Phase 1c of the next run.
+Write only issues that remain unresolved and deferred. Remove any issue from this file that was resolved, covered by a PR, or re-evaluated and actioned in this run. This file accelerates Phase 1c skip logic — if it is absent, Phase 1c reconstructs the same state from GitHub comments.

--- a/.claude/commands/issue-triage.md
+++ b/.claude/commands/issue-triage.md
@@ -126,8 +126,6 @@ Post a new DEFER comment only when **at least one** of these is true:
 
 When posting is warranted:
 
-> **Sentinel:** The opening line `**Nightly triage` is the string both Phase 1c and Phase 2 use to identify previously-posted triage comments. If you change the header below, update both detection checks to match.
-
 ```bash
 gh issue comment <n> --body "**Nightly triage — decision needed**
 

--- a/.claude/commands/issue-triage.md
+++ b/.claude/commands/issue-triage.md
@@ -138,6 +138,8 @@ This issue was reviewed in the automated nightly triage run but cannot be resolv
 Reply to this comment with your decision and the next nightly run will pick it up automatically."
 ```
 
+> _Detection sentinel: comments starting with `**Nightly triage` are treated as triage comments. Update both Phase 1c and Phase 2 if this prefix ever changes._
+
 A follow-up comment (not a duplicate) is only posted when Phase 1c re-evaluation finds new information that narrows but does not fully resolve the question.
 
 Output the prioritisation matrix:

--- a/.claude/commands/issue-triage.md
+++ b/.claude/commands/issue-triage.md
@@ -126,6 +126,8 @@ Post a new DEFER comment only when **at least one** of these is true:
 
 When posting is warranted:
 
+> **Sentinel:** The opening line `**Nightly triage` is the string both Phase 1c and Phase 2 use to identify previously-posted triage comments. If you change the header below, update both detection checks to match.
+
 ```bash
 gh issue comment <n> --body "**Nightly triage — decision needed**
 


### PR DESCRIPTION
## Summary

- The `/issue-triage` skill was posting a duplicate "Nightly triage — decision needed" comment on every weekly run for deferred issues (e.g. issue #746 accumulated 5 identical comments). Root cause: the deferred state file lives in `.artifacts/` (gitignored, ephemeral) and is lost on container restart.
- Phase 1c now reconstructs the deferred list from GitHub issue comments when the local cache file is absent — no extra API calls, the `comments` field is already fetched in Phase 1a.
- Phase 2's posting guard is strengthened to check in-memory comments before posting, blocking a duplicate whenever the most recent comment is already a triage comment with no owner/member reply since.
- `.artifacts/reports/triage-deferred.md` is now documented as a performance cache, not the authoritative source.

## Test plan

- [ ] Delete `.artifacts/reports/triage-deferred.md` (or leave absent) and run `/issue-triage` with issue #746 in its current state (has triage comments, no owner reply).
- [ ] Confirm filter summary shows #746 as `SKIP (deferred, no update)` — not in the working set.
- [ ] Confirm no new comment is posted on #746.
- [ ] Post a reply on #746, re-run — confirm it re-enters the working set and is re-evaluated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDoF5t7dmbweQUpjKgfebz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDoF5t7dmbweQUpjKgfebz)_

Closes #808