### PR TITLE
fix(plugin): update Plugin URI to wpaimind.com and align branding to Plume AI - Write and Design

### DIFF
--- a/bin/stamp-since-tags.sh
+++ b/bin/stamp-since-tags.sh
@@ -39,3 +39,11 @@ FILE_COUNT=$(echo "$MATCHED_FILES" | wc -l | tr -d ' ')
 echo "stamp-since-tags: updated files:"
 echo "$MATCHED_FILES" | sed "s|${REPO_ROOT}/||"
 echo "stamp-since-tags: stamped @since NEXT_VERSION → @since ${VERSION} in the ${FILE_COUNT} file(s) above."
+
+# Stamp the POT file header separately — it uses bare NEXT_VERSION (no @since prefix)
+# and is not a PHP file, so it is excluded from the grep above.
+POT_FILE="${REPO_ROOT}/languages/plume.pot"
+if [[ -f "$POT_FILE" ]]; then
+  perl -pi -e "s|NEXT_VERSION|${VERSION}|g" "$POT_FILE"
+  echo "stamp-since-tags: stamped NEXT_VERSION → ${VERSION} in languages/plume.pot"
+fi

--- a/includes/Admin/ActivationNotice.php
+++ b/includes/Admin/ActivationNotice.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Displays a one-time admin notice after plugin activation disclosing
- * that the plugin connects to Plume - Write and Design and to
+ * that the plugin connects to Plume AI - Write and Design and to
  * third-party AI providers.
  *
  * Uses the plume_just_activated option as a single-use flag.
@@ -58,12 +58,12 @@ class ActivationNotice {
 		?>
 		<div class="notice notice-info is-dismissible">
 			<p>
-			<strong><?php \esc_html_e( 'Plume - Write and Design — External Services & Privacy Notice', 'plume' ); ?></strong>
+			<strong><?php \esc_html_e( 'Plume AI - Write and Design — External Services & Privacy Notice', 'plume' ); ?></strong>
 			</p>
 			<p>
 				<?php
 				\esc_html_e(
-					'This plugin connects to Plume - Write and Design and to third-party AI providers (Anthropic Claude, OpenAI, Google Gemini). Only your site address is shared during setup — no content leaves your site until you start a conversation. Your messages are then forwarded to the AI provider on your behalf.',
+					'This plugin connects to Plume AI - Write and Design and to third-party AI providers (Anthropic Claude, OpenAI, Google Gemini). Only your site address is shared during setup — no content leaves your site until you start a conversation. Your messages are then forwarded to the AI provider on your behalf.',
 					'plume'
 				);
 				?>

--- a/includes/Admin/TierSyncBackfillNotice.php
+++ b/includes/Admin/TierSyncBackfillNotice.php
@@ -120,12 +120,12 @@ class TierSyncBackfillNotice {
 		?>
 		<div class="notice notice-warning is-dismissible">
 			<p>
-			<strong><?php \esc_html_e( 'Plume - Write and Design — Plan sync setup required', 'plume' ); ?></strong>
+			<strong><?php \esc_html_e( 'Plume AI - Write and Design — Plan sync setup required', 'plume' ); ?></strong>
 			</p>
 			<p>
 				<?php
 				\esc_html_e(
-					'Your site is connected to Plume - Write and Design, but the connection has not been fully set up yet. Without this step, plan upgrades and cancellations will not take effect automatically. Click the button below to complete the one-time setup.',
+					'Your site is connected to Plume AI - Write and Design, but the connection has not been fully set up yet. Without this step, plan upgrades and cancellations will not take effect automatically. Click the button below to complete the one-time setup.',
 					'plume'
 				);
 				?>
@@ -171,12 +171,12 @@ class TierSyncBackfillNotice {
 		?>
 		<div class="notice notice-warning is-dismissible">
 			<p>
-			<strong><?php \esc_html_e( 'Plume - Write and Design — Plan verification required', 'plume' ); ?></strong>
+			<strong><?php \esc_html_e( 'Plume AI - Write and Design — Plan verification required', 'plume' ); ?></strong>
 			</p>
 			<p>
 				<?php
 				\esc_html_e(
-					'Your site shows a paid plan in the database, but the plan integrity signature is missing or does not match. This can happen after a direct database edit or a migration. Until re-verified, the plugin will treat your site as free. Click below to re-sync your plan with Plume - Write and Design.',
+					'Your site shows a paid plan in the database, but the plan integrity signature is missing or does not match. This can happen after a direct database edit or a migration. Until re-verified, the plugin will treat your site as free. Click below to re-sync your plan with Plume AI - Write and Design.',
 					'plume'
 				);
 				?>
@@ -219,7 +219,7 @@ class TierSyncBackfillNotice {
 			?>
 			<div class="notice notice-success is-dismissible">
 				<p>
-				<?php \esc_html_e( 'Plume - Write and Design — Plan sync is now active. Your site will automatically receive plan updates.', 'plume' ); ?>
+				<?php \esc_html_e( 'Plume AI - Write and Design — Plan sync is now active. Your site will automatically receive plan updates.', 'plume' ); ?>
 				</p>
 			</div>
 			<?php
@@ -235,7 +235,7 @@ class TierSyncBackfillNotice {
 		?>
 		<div class="notice notice-error is-dismissible">
 			<p>
-			<?php \esc_html_e( 'Plume - Write and Design — Setup failed.', 'plume' ); ?>
+			<?php \esc_html_e( 'Plume AI - Write and Design — Setup failed.', 'plume' ); ?>
 				<?php if ( '' !== $detail ) : ?>
 					<br />
 					<code><?php echo \esc_html( $detail ); ?></code>

--- a/includes/Proxy/ProxyClient.php
+++ b/includes/Proxy/ProxyClient.php
@@ -46,7 +46,7 @@ class ProxyClient {
 			if ( ! has_action( 'shutdown', [ SiteRegistration::class, 'maybe_register' ] ) ) {
 				add_action( 'shutdown', [ SiteRegistration::class, 'maybe_register' ] );
 			}
-			return new WP_Error( 'not_registered', __( 'Site not connected to Plume - Write and Design. Please reload the page.', 'plume' ) );
+			return new WP_Error( 'not_registered', __( 'Site not connected to Plume AI - Write and Design. Please reload the page.', 'plume' ) );
 		}
 
 		$user_id = get_current_user_id();
@@ -110,12 +110,12 @@ class ProxyClient {
 			if ( ! has_action( 'shutdown', [ SiteRegistration::class, 'maybe_register' ] ) ) {
 				add_action( 'shutdown', [ SiteRegistration::class, 'maybe_register' ] );
 			}
-			return new WP_Error( 'auth_failed', __( 'Connection to Plume - Write and Design failed. Please reload the page and try again.', 'plume' ) );
+			return new WP_Error( 'auth_failed', __( 'Connection to Plume AI - Write and Design failed. Please reload the page and try again.', 'plume' ) );
 		}
 
 		if ( $code < 200 || $code >= 300 ) {
 			// translators: %d is the HTTP status code returned by the service.
-			return new WP_Error( 'service_error', $body['error'] ?? sprintf( __( 'Plume - Write and Design returned HTTP %d', 'plume' ), $code ) );
+			return new WP_Error( 'service_error', $body['error'] ?? sprintf( __( 'Plume AI - Write and Design returned HTTP %d', 'plume' ), $code ) );
 		}
 
 		// Mirror usage locally for dashboard display only — KV is authoritative for quota enforcement.

--- a/includes/Proxy/SiteRegistration.php
+++ b/includes/Proxy/SiteRegistration.php
@@ -202,7 +202,7 @@ class SiteRegistration {
 	public static function rotate_secret(): string|WP_Error {
 		$token = self::get_site_token();
 		if ( '' === $token ) {
-			return new WP_Error( 'not_registered', __( 'This site is not registered with Plume - Write and Design.', 'plume' ) );
+			return new WP_Error( 'not_registered', __( 'This site is not registered with Plume AI - Write and Design.', 'plume' ) );
 		}
 
 		$response = wp_remote_post(

--- a/languages/plume.pot
+++ b/languages/plume.pot
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plume NEXT_VERSION\n"
-"Report-Msgid-Bugs-To: https://wpaimind.com\n"
+"Report-Msgid-Bugs-To: https://wpaimind.com/support\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"

--- a/languages/plume.pot
+++ b/languages/plume.pot
@@ -2,8 +2,8 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP AI Mind 0.2.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-ai-mind\n"
+"Project-Id-Version: Plume NEXT_VERSION\n"
+"Report-Msgid-Bugs-To: https://wpaimind.com\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -12,72 +12,83 @@ msgstr ""
 "POT-Creation-Date: 2026-03-25T12:43:36+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
-"X-Domain: wp-ai-mind\n"
+"X-Domain: plume\n"
 
 #. Plugin Name of the plugin
-#: wp-ai-mind.php
-#: includes/Admin/AdminMenu.php:9
-msgid "WP AI Mind"
+#: plume.php
+msgid "Plume AI - Write and Design"
 msgstr ""
 
 #. Plugin URI of the plugin
-#: wp-ai-mind.php
-msgid "https://njohansson.eu/wp-ai-mind/"
+#: plume.php
+msgid "https://wpaimind.com"
 msgstr ""
 
 #. Description of the plugin
-#: wp-ai-mind.php
-msgid "AI-powered content co-pilot for WordPress."
+#: plume.php
+msgid "AI-powered writing, image generation, and content design tools for WordPress."
 msgstr ""
 
 #. Author of the plugin
-#: wp-ai-mind.php
+#: plume.php
 msgid "Niklas Johansson"
 msgstr ""
 
 #. Author URI of the plugin
-#: wp-ai-mind.php
-msgid "https://njohansson.eu"
+#: plume.php
+msgid "https://github.com/niklas-joh"
 msgstr ""
 
-#: includes/Admin/ActivationNotice.php:47
-msgid "WP AI Mind — External Services Notice"
+#: includes/Admin/ActivationNotice.php:61
+msgid "Plume AI - Write and Design — External Services & Privacy Notice"
 msgstr ""
 
-#: includes/Admin/ActivationNotice.php:51
-msgid "WP AI Mind sends the content you submit to third-party AI providers (OpenAI, Anthropic Claude, Google Gemini, Ollama). Your data is governed by each provider's privacy policy. Configure your active provider under WP AI Mind → Settings."
+#: includes/Admin/ActivationNotice.php:65
+msgid "This plugin connects to Plume AI - Write and Design and to third-party AI providers (Anthropic Claude, OpenAI, Google Gemini). Only your site address is shared during setup — no content leaves your site until you start a conversation. Your messages are then forwarded to the AI provider on your behalf."
 msgstr ""
 
-#: includes/Admin/AdminMenu.php:10
-msgid "AI Mind"
+#: includes/Admin/ActivationNotice.php:75
+msgid "Learn more"
 msgstr ""
 
-#: includes/Admin/AdminMenu.php:18
+#: includes/Admin/AdminMenu.php:31
+msgid "Plume AI — Write and Design"
+msgstr ""
+
+#: includes/Admin/AdminMenu.php:32
+msgid "Plume AI"
+msgstr ""
+
+#: includes/Admin/AdminMenu.php:42
+msgid "Dashboard"
+msgstr ""
+
+#: includes/Admin/AdminMenu.php:43
 msgid "Chat"
 msgstr ""
 
-#: includes/Admin/AdminMenu.php:19
+#: includes/Admin/AdminMenu.php:44
 msgid "Generator"
 msgstr ""
 
-#: includes/Admin/AdminMenu.php:20
+#: includes/Admin/AdminMenu.php:45
 msgid "SEO"
 msgstr ""
 
-#: includes/Admin/AdminMenu.php:21
+#: includes/Admin/AdminMenu.php:46
 msgid "Images"
 msgstr ""
 
-#: includes/Admin/AdminMenu.php:22
-msgid "Usage"
-msgstr ""
-
-#: includes/Admin/AdminMenu.php:22
-msgid "Usage &amp; Cost"
-msgstr ""
-
-#: includes/Admin/AdminMenu.php:23
+#: includes/Admin/AdminMenu.php:47
 msgid "Settings"
+msgstr ""
+
+#: includes/Admin/AdminMenu.php:53
+msgid "Upgrade"
+msgstr ""
+
+#: includes/Admin/AdminMenu.php:54
+msgid "Upgrade ✦"
 msgstr ""
 
 #: includes/Modules/Chat/ChatRestController.php:282

--- a/languages/plume.pot
+++ b/languages/plume.pot
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plume NEXT_VERSION\n"
-"Report-Msgid-Bugs-To: https://wpaimind.com/support\n"
+"Report-Msgid-Bugs-To: https://github.com/niklas-joh/wp-ai-mind/issues\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"

--- a/plume.php
+++ b/plume.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:       Plume
- * Plugin URI:        https://njohansson.eu/plume/
+ * Plugin URI:        https://wpaimind.com
  * Description:       AI-powered writing, image generation, and content design tools for WordPress.
  * Version:           1.10.0
  * Requires at least: 6.4

--- a/readme.txt
+++ b/readme.txt
@@ -25,9 +25,9 @@ into your WordPress dashboard, giving you AI assistance without leaving the edit
 
 **Free vs Pro:**
 
-* **Free** — Chat assistant (50,000 tokens/month via Plume - Write and Design, Claude only)
-* **Trial** — All features for 30 days (300,000 tokens/month via Plume - Write and Design)
-* **Pro Managed** — All features, 2,000,000 tokens/month via Plume - Write and Design
+* **Free** — Chat assistant (50,000 tokens/month via Plume AI - Write and Design, Claude only)
+* **Trial** — All features for 30 days (300,000 tokens/month via Plume AI - Write and Design)
+* **Pro Managed** — All features, 2,000,000 tokens/month via Plume AI - Write and Design
 * **Pro BYOK** — All features, unlimited tokens, your own API key sent direct to provider
 
 **Supported AI providers:** Anthropic Claude, OpenAI (GPT-4+), Google Gemini, Ollama (local/self-hosted)
@@ -40,16 +40,16 @@ chosen provider. Review each provider's privacy policy and terms of service befo
 * OpenAI: https://openai.com/policies/privacy-policy
 * Google Gemini: https://policies.google.com/privacy
 * Ollama is self-hosted; no external transmission occurs when using Ollama.
-* **Plume - Write and Design** (`https://plume-proxy.plume.workers.dev`): Free and managed-pro
+* **Plume AI - Write and Design** (`https://plume-proxy.plume.workers.dev`): Free and managed-pro
   tiers route chat requests through this service. The service receives your
   site URL (for registration) and the chat messages you send. No messages are stored
-  beyond the in-flight API call. See: https://wpaimind.com/privacy-policy (legacy domain — to be updated)
+  beyond the in-flight API call. See: https://wpaimind.com/privacy-policy
 
 == Installation ==
 
 1. Upload the `plume` folder to the `/wp-content/plugins/` directory.
 2. Activate the plugin through the **Plugins** menu in WordPress.
-3. (Optional — Pro BYOK only) Navigate to **Plume - Write and Design → Settings** and enter your own API key. Free and managed-plan users do not need an API key.
+3. (Optional — Pro BYOK only) Navigate to **Plume AI - Write and Design → Settings** and enter your own API key. Free and managed-plan users do not need an API key.
 4. Start using the Chat, Generator, or Usage modules from the admin menu.
 
 == Frequently Asked Questions ==
@@ -62,7 +62,7 @@ one or more providers and switch between them in the settings.
 = Does this plugin store my API keys securely? =
 
 **Free / Trial / Pro Managed tiers:** No API key is required — chat requests are routed
-through Plume - Write and Design (see External services above). Your messages are
+through Plume AI - Write and Design (see External services above). Your messages are
 forwarded to Claude (Anthropic) on your behalf.
 
 **Pro BYOK tier:** Your own API key is stored encrypted (AES-256-CBC) in the WordPress
@@ -71,11 +71,11 @@ to any other server.
 
 = Is this plugin GDPR-compliant? =
 
-The plugin transmits content you submit to Plume - Write and Design and/or the AI
+The plugin transmits content you submit to Plume AI - Write and Design and/or the AI
 provider you have configured (Anthropic Claude, OpenAI, Google Gemini). Both the service and
 the AI provider receive your chat messages. You are responsible for ensuring that
 transmission is compliant with your applicable data protection regulations. Consider adding
-the Plume - Write and Design privacy policy and your chosen provider's data processing agreement to your
+the Plume AI - Write and Design privacy policy and your chosen provider's data processing agreement to your
 privacy documentation.
 
 = What WordPress roles can use the AI features? =
@@ -160,5 +160,5 @@ Initial release. No upgrade steps required.
 
 == Screenshots ==
 
-1. The Plume - Write and Design chat assistant in the WordPress admin.
+1. The Plume AI - Write and Design chat assistant in the WordPress admin.
 2. The blog post generator with tone and length controls.

--- a/tests/Unit/Admin/TierStatusPageTest.php
+++ b/tests/Unit/Admin/TierStatusPageTest.php
@@ -33,7 +33,7 @@ class TierStatusPageTest extends TestCase {
 		Functions\when( 'esc_html__' )->returnArg();
 		Functions\when( 'esc_html_e' )->echoArg();
 		Functions\when( 'number_format_i18n' )->alias( fn( $n ) => (string) number_format( (int) $n ) );
-		Functions\when( 'get_admin_page_title' )->justReturn( 'Plume - Write and Design - Plan &amp; Usage' );
+		Functions\when( 'get_admin_page_title' )->justReturn( 'Plume AI - Write and Design - Plan &amp; Usage' );
 		Functions\when( 'admin_url' )->alias( fn( $path ) => 'http://example.com/wp-admin/' . ltrim( $path, '/' ) );
 	}
 


### PR DESCRIPTION
## Summary

- **`plume.php`**: Plugin URI corrected from `https://njohansson.eu/plume/` to `https://wpaimind.com`
- **`readme.txt`**: All occurrences of `Plume - Write and Design` updated to `Plume AI - Write and Design`; stale `(legacy domain — to be updated)` note removed from the privacy section
- **PHP source files** (`ActivationNotice.php`, `TierSyncBackfillNotice.php`, `ProxyClient.php`, `SiteRegistration.php`): Same branding correction in all user-facing strings and admin notices
- **`languages/plume.pot`**: Header metadata corrected (`Project-Id-Version`, `X-Domain`, `Report-Msgid-Bugs-To`); plugin-level entries updated to match current `plume.php` identity; stale `wp-ai-mind.php` source references replaced with `plume.php`
- **`tests/Unit/Admin/TierStatusPageTest.php`**: Test stub updated to match corrected brand name

This is a `fix:` commit to trigger a `semantic-release` patch bump (1.10.0 → 1.10.1) so these metadata corrections ship as a release before WordPress.org submission.

## Test plan

- [ ] CI passes (commitlint, PHPCS, PHPUnit)
- [ ] After merge to `main`, confirm `semantic-release` creates a `v1.10.1` tag and GitHub Release
- [ ] Confirm `bin/stamp-since-tags.sh` correctly replaces `NEXT_VERSION` in the POT header during the release commit
- [ ] Verify no remaining `Plume - Write and Design` (without "AI") references remain in tracked files
- [ ] Before WP.org submission: run `wp i18n make-pot` in the local Docker environment to fully regenerate the translation string catalogue (the POT header is now correct; the string catalogue may have gaps from new code added since the last regeneration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3Ggh5V1UyS5BNAw1Fx1Lc)_

Closes #819

Closes #820