### PR TITLE
chore: update references after GitHub repo rename to plume-ai

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -647,7 +647,7 @@ jobs:
         # The script replaces the call with a safe empty-array no-op.
         run: |
           npx wp-env run tests-wordpress -- php \
-            /var/www/html/wp-content/plugins/wp-ai-mind/tests/phpunit10-compat.php
+            /var/www/html/wp-content/plugins/plume-ai/tests/phpunit10-compat.php
 
       - name: Run real integration tests
         # Secrets are expanded on the host by the GitHub Actions runner before
@@ -660,7 +660,7 @@ jobs:
           PLUME_PROXY_URL: ${{ secrets.PLUME_PROXY_URL }}
         run: |
           npx wp-env run tests-wordpress -- bash -c "
-            cd /var/www/html/wp-content/plugins/wp-ai-mind
+            cd /var/www/html/wp-content/plugins/plume-ai
             CLAUDE_API_KEY='${CLAUDE_API_KEY}' \
             PLUME_CI_SITE_TOKEN='${PLUME_CI_SITE_TOKEN}' \
             PLUME_PROXY_URL='${PLUME_PROXY_URL}' \
@@ -732,12 +732,12 @@ jobs:
         # The script replaces the call with a safe empty-array no-op.
         run: |
           npx wp-env run tests-wordpress -- php \
-            /var/www/html/wp-content/plugins/wp-ai-mind/tests/phpunit10-compat.php
+            /var/www/html/wp-content/plugins/plume-ai/tests/phpunit10-compat.php
 
       - name: Run integration tests
         run: |
           npx wp-env run tests-wordpress -- bash -c "
-            cd /var/www/html/wp-content/plugins/wp-ai-mind
+            cd /var/www/html/wp-content/plugins/plume-ai
             vendor/bin/phpunit \
               -c phpunit-integration.xml.dist \
               --colors=always

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,13 +414,13 @@ See `.agents/profiles/wordpress/_shared/block-reference.md` for the full decisio
 
 ## Plume Plugin
 
-Active plugin. Maintained in a dedicated repository: **[niklas-joh/wp-ai-mind](https://github.com/niklas-joh/wp-ai-mind)** (to be renamed `niklas-joh/plume` once the GitHub repo is renamed)
+Active plugin. Maintained in a dedicated repository: **[niklas-joh/plume-ai](https://github.com/niklas-joh/plume-ai)**
 
 The plugin is referenced in this blog repo as a git submodule at `wp-content/plugins/plume/`.
 
 | Item | Value |
 |------|-------|
-| Plugin repo | `https://github.com/niklas-joh/wp-ai-mind` |
+| Plugin repo | `https://github.com/niklas-joh/plume-ai` |
 | Submodule path | `wp-content/plugins/plume/` |
 | Active branches | `main` (stable), `develop` (next release) |
 | Namespace | `Plume\` (not `nj_` prefix) |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -363,13 +363,13 @@ See `.agents/profiles/wordpress/_shared/block-reference.md` for the full decisio
 
 ## Plume Plugin
 
-Active plugin. Maintained in a dedicated repository: **[niklas-joh/wp-ai-mind](https://github.com/niklas-joh/wp-ai-mind)** (to be renamed `niklas-joh/plume` once the GitHub repo is renamed)
+Active plugin. Maintained in a dedicated repository: **[niklas-joh/plume-ai](https://github.com/niklas-joh/plume-ai)**
 
 The plugin is referenced in this blog repo as a git submodule at `wp-content/plugins/plume/`.
 
 | Item | Value |
 |------|-------|
-| Plugin repo | `https://github.com/niklas-joh/wp-ai-mind` |
+| Plugin repo | `https://github.com/niklas-joh/plume-ai` |
 | Submodule path | `wp-content/plugins/plume/` |
 | Active branches | `main` (stable), `develop` (next release) |
 | Namespace | `Plume\` (not `nj_` prefix) |

--- a/docs/WP_7_0_AUGMENTATION_PLAN.md
+++ b/docs/WP_7_0_AUGMENTATION_PLAN.md
@@ -53,7 +53,7 @@ Tier structure stays. **Pro BYOK becomes a monthly subscription** (e.g. €9.90/
 | 2.2 | Single clear UX path for BYOK key entry | 3 | High | S | Low | Yes | 2.1 |
 | 3.3 | Emit `GenerativeAiResult` from abstract provider | 4 | Medium | XS | Low | Yes | GA |
 | 5.2 | Voice/tone as WP-7.0 system instruction *(if API exists)* | 4 | Medium | S–M | Medium | Yes | GA |
-| — | Issue [#497](https://github.com/niklas-joh/wp-ai-mind/issues/497) — Tier-sync webhook | Out of plan | High | M+M | Medium | No | 1.3 (optional) |
+| — | Issue [#497](https://github.com/niklas-joh/plume-ai/issues/497) — Tier-sync webhook | Out of plan | High | M+M | Medium | No | 1.3 (optional) |
 
 **Dropped after dialogue (audit trail):**
 
@@ -93,7 +93,7 @@ Single function consolidating the four scattered gates (tier feature check, mont
 `NJ_Tier_Manager::get_user_tier()` reads `user_meta` on every call. Cache to `wp_cache_get/set` with a 1-hour TTL, invalidate on `set_user_tier()` and on a new `wp_ai_mind_tier_changed` action.
 
 - **Files:** `includes/Tiers/NJ_Tier_Manager.php:37-41` (get), `:53-59` (set)
-- **Required by:** 4.1 (permission_callback hot path), useful for Issue [#497](https://github.com/niklas-joh/wp-ai-mind/issues/497)
+- **Required by:** 4.1 (permission_callback hot path), useful for Issue [#497](https://github.com/niklas-joh/plume-ai/issues/497)
 
 ### Phase 1 acceptance
 
@@ -230,7 +230,7 @@ When `AbstractProvider::maybe_log()` (`includes/Providers/AbstractProvider.php:1
 
 ---
 
-## Out of plan — Issue [#497](https://github.com/niklas-joh/wp-ai-mind/issues/497)
+## Out of plan — Issue [#497](https://github.com/niklas-joh/plume-ai/issues/497)
 
 **Tier-sync webhook gap.** Today the Cloudflare Worker stores LemonSqueezy tier upgrades in KV but never pushes them back to WP user meta. Pro-tier features that gate on `NJ_Tier_Manager::user_can()` (SEO, Images, Generator, model selection in admin UI) stay locked even after a paid upgrade.
 
@@ -288,7 +288,7 @@ The decision to switch Pro BYOK from one-time fee → monthly subscription has i
 | `includes/Abilities/ToolToAbility.php` *(new)* | 4.1 | 3 |
 | `includes/Voice/VoiceInjector.php` | 5.2 | 4 |
 
-(Out-of-plan tier-sync items in [#497](https://github.com/niklas-joh/wp-ai-mind/issues/497) touch `includes/Payments/`, `includes/Settings/NJ_Site_Registration.php`, `stilus-proxy/src/webhook.ts`, `stilus-proxy/src/registration.ts`.)
+(Out-of-plan tier-sync items in [#497](https://github.com/niklas-joh/plume-ai/issues/497) touch `includes/Payments/`, `includes/Settings/NJ_Site_Registration.php`, `stilus-proxy/src/webhook.ts`, `stilus-proxy/src/registration.ts`.)
 
 ---
 
@@ -317,7 +317,7 @@ On a WP 7.0 staging site with stilus installed and an Anthropic key configured v
 ## References
 
 - [`docs/WP_AI_MIND_ARCHITECTURE.md`](./WP_AI_MIND_ARCHITECTURE.md) — current architecture spec
-- [Issue #497](https://github.com/niklas-joh/wp-ai-mind/issues/497) — Tier-sync webhook gap (out of plan)
+- [Issue #497](https://github.com/niklas-joh/plume-ai/issues/497) — Tier-sync webhook gap (out of plan)
 - WP 7.0 dev-notes:
   - AI Client SDK (2026-03-18)
   - Connectors API (2026-03-24)

--- a/languages/plume.pot
+++ b/languages/plume.pot
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WP AI Mind 0.2.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-ai-mind\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/plume\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -12,31 +12,31 @@ msgstr ""
 "POT-Creation-Date: 2026-03-25T12:43:36+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
-"X-Domain: wp-ai-mind\n"
+"X-Domain: plume\n"
 
 #. Plugin Name of the plugin
-#: wp-ai-mind.php
+#: plume.php
 #: includes/Admin/AdminMenu.php:9
 msgid "WP AI Mind"
 msgstr ""
 
 #. Plugin URI of the plugin
-#: wp-ai-mind.php
+#: plume.php
 msgid "https://njohansson.eu/wp-ai-mind/"
 msgstr ""
 
 #. Description of the plugin
-#: wp-ai-mind.php
+#: plume.php
 msgid "AI-powered content co-pilot for WordPress."
 msgstr ""
 
 #. Author of the plugin
-#: wp-ai-mind.php
+#: plume.php
 msgid "Niklas Johansson"
 msgstr ""
 
 #. Author URI of the plugin
-#: wp-ai-mind.php
+#: plume.php
 msgid "https://njohansson.eu"
 msgstr ""
 


### PR DESCRIPTION
## Summary

- Replaces all in-repo `wp-ai-mind` references with `plume-ai` following the GitHub repo rename
- Updates Docker plugin mount paths in `.github/workflows/pr-checks.yml` (4 occurrences)
- Cleans up docs links in `CLAUDE.md`, `GEMINI.md`, and `docs/WP_7_0_AUGMENTATION_PLAN.md`
- Updates stale `.pot` file header (`X-Domain`, `Report-Msgid-Bugs-To`, source file refs)

## What was intentionally left unchanged

- `CHANGELOG.md` historical links — GitHub redirects cover these; semantic-release owns future entries
- `tests/Unit/Proxy/NamespaceContractTest.php` — legacy REST namespace guards (`wp-ai-mind/v1`) are intentional
- `languages/plume.pot` plugin URI `msgid` — stale extracted string, will be overwritten by the next `wp i18n make-pot` run

## Test plan

- [ ] Verify CI passes (Docker paths now resolve to `plume-ai` in the test container)
- [ ] Confirm no remaining `wp-ai-mind` references: `grep -r "wp-ai-mind" --include="*.yml" --include="*.md" --include="*.php" --include="*.pot" . | grep -v CHANGELOG.md | grep -v tests/Unit/Proxy/NamespaceContractTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYx9auxRdTjH4jbeXVyEAB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYx9auxRdTjH4jbeXVyEAB)_