### PR TITLE
fix(wporg): add composer.json to zip allowlist and escape DB table names

### DIFF
--- a/bin/build-wporg.sh
+++ b/bin/build-wporg.sh
@@ -46,6 +46,8 @@ rsync -a \
     --include='languages/***' \
     --include='vendor/***' \
     --include='assets/***' \
+    --include='composer.json' \
+    --include='composer.lock' \
     --include='plume.php' \
     --include='readme.txt' \
     --include='uninstall.php' \

--- a/includes/DB/ConversationStore.php
+++ b/includes/DB/ConversationStore.php
@@ -82,9 +82,8 @@ class ConversationStore {
 	 */
 	public function get_messages( int $conversation_id ): array {
 		global $wpdb;
-		$table   = esc_sql( Schema::table( 'messages' ) );
 		$results = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare( "SELECT * FROM {$table} WHERE conversation_id = %d ORDER BY id ASC", $conversation_id ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->prepare( 'SELECT * FROM %i WHERE conversation_id = %d ORDER BY id ASC', Schema::table( 'messages' ), $conversation_id ),
 			ARRAY_A
 		);
 		return ! empty( $results ) ? $results : [];
@@ -100,10 +99,10 @@ class ConversationStore {
 	 */
 	public function list_for_user( int $user_id, int $limit = 50 ): array {
 		global $wpdb;
-		$table   = esc_sql( Schema::table( 'conversations' ) );
 		$results = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
-				"SELECT * FROM {$table} WHERE user_id = %d ORDER BY updated_at DESC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				'SELECT * FROM %i WHERE user_id = %d ORDER BY updated_at DESC LIMIT %d',
+				Schema::table( 'conversations' ),
 				$user_id,
 				$limit
 			),
@@ -121,9 +120,8 @@ class ConversationStore {
 	 */
 	public function get_conversation( int $conversation_id ): ?array {
 		global $wpdb;
-		$table = esc_sql( Schema::table( 'conversations' ) );
-		$row   = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $conversation_id ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$row = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', Schema::table( 'conversations' ), $conversation_id ),
 			ARRAY_A
 		);
 		return ! empty( $row ) ? $row : null;

--- a/includes/DB/ConversationStore.php
+++ b/includes/DB/ConversationStore.php
@@ -82,10 +82,9 @@ class ConversationStore {
 	 */
 	public function get_messages( int $conversation_id ): array {
 		global $wpdb;
-		// $table is from Schema::table() — a closed internal whitelist, not user input.
-		$table   = Schema::table( 'messages' );
+		$table   = esc_sql( Schema::table( 'messages' ) );
 		$results = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare( "SELECT * FROM {$table} WHERE conversation_id = %d ORDER BY id ASC", $conversation_id ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
+			$wpdb->prepare( "SELECT * FROM {$table} WHERE conversation_id = %d ORDER BY id ASC", $conversation_id ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			ARRAY_A
 		);
 		return ! empty( $results ) ? $results : [];
@@ -101,11 +100,10 @@ class ConversationStore {
 	 */
 	public function list_for_user( int $user_id, int $limit = 50 ): array {
 		global $wpdb;
-		// $table is from Schema::table() — a closed internal whitelist, not user input.
-		$table   = Schema::table( 'conversations' );
+		$table   = esc_sql( Schema::table( 'conversations' ) );
 		$results = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
-				"SELECT * FROM {$table} WHERE user_id = %d ORDER BY updated_at DESC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
+				"SELECT * FROM {$table} WHERE user_id = %d ORDER BY updated_at DESC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$user_id,
 				$limit
 			),
@@ -123,10 +121,9 @@ class ConversationStore {
 	 */
 	public function get_conversation( int $conversation_id ): ?array {
 		global $wpdb;
-		// $table is from Schema::table() — a closed internal whitelist, not user input.
-		$table = Schema::table( 'conversations' );
+		$table = esc_sql( Schema::table( 'conversations' ) );
 		$row   = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $conversation_id ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
+			$wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $conversation_id ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			ARRAY_A
 		);
 		return ! empty( $row ) ? $row : null;


### PR DESCRIPTION
## Summary

Addresses two warnings from the WordPress.org automated plugin checker after the initial submission.

- **`bin/build-wporg.sh`** — The rsync allowlist included `vendor/` but not `composer.json` or `composer.lock`. The checker flagged: *"The `/vendor` directory using composer exists, but `composer.json` file is missing."* Both files are now included in the allowlist.

- **`includes/DB/ConversationStore.php`** — Three `Schema::table()` calls were interpolated directly into `$wpdb->prepare()` queries. The checker flagged `PluginCheck.Security.DirectDB.UnescapedDBParameter` on each. Wrapping with `esc_sql()` makes the escaping explicit and removes the need for those specific phpcs:ignore suppressions.

## Not changed

- **Slow DB query warnings** (`Plugin.php`, `TierManager.php`) — both files already carry `// phpcs:ignore` suppressions with explanatory comments. The online checker does not parse phpcs:ignore; the manual reviewer will see the in-source justification.
- **Plugin name mismatch** (`readme.txt` vs `plume.php`) — deferred; the `Plugin Name:` field determines the WordPress.org URL slug, so this requires a deliberate decision before changing.

## Test plan

- [ ] Run `./bin/build-wporg.sh` locally; confirm the produced zip contains `composer.json` and `composer.lock`
- [ ] Re-run the WordPress Plugin Checker against the new zip; confirm the two fixed warnings are gone
- [ ] Run `./vendor/bin/phpcs --standard=phpcs.xml.dist includes/DB/ConversationStore.php`; confirm no new violations

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6mDSr5ArEYP8616tp436E)_

Closes #823