### PR TITLE
chore(ci): pin review and auto-fix workflows to claude-opus-4-8

### DIFF
--- a/.github/workflows/auto-fix-ci.yml
+++ b/.github/workflows/auto-fix-ci.yml
@@ -90,4 +90,4 @@ jobs:
             - PHPUnit: fix the code under test, not the tests themselves, unless the test assertion is clearly wrong.
             - Do NOT bump version numbers, modify composer.lock, or change package-lock.json.
 
-          claude_args: "--allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"
+          claude_args: "--model claude-opus-4-8 --allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"

--- a/.github/workflows/auto-fix-review-issue.yml
+++ b/.github/workflows/auto-fix-review-issue.yml
@@ -268,7 +268,7 @@ jobs:
             - Do NOT bump version numbers, modify `composer.lock`, or change `package-lock.json`.
             - Do NOT open more than one PR per issue.
 
-          claude_args: "--allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"
+          claude_args: "--model claude-opus-4-8 --allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"
 
       # Surface the actual failure reason when Claude hits max turns or errors out.
       # The action's default error chain ("Execution failed: Action failed with error:

--- a/.github/workflows/batch-auto-fix.yml
+++ b/.github/workflows/batch-auto-fix.yml
@@ -197,7 +197,7 @@ jobs:
             - Do NOT open new PRs — push all fixes directly to the head branch.
             - Do NOT open more than one PR per issue.
 
-          claude_args: "--allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"
+          claude_args: "--model claude-opus-4-8 --allowedTools Bash(git:*),Bash(gh:*),Bash(composer:*),Bash(npm:*),Bash(npx:*),Bash(./vendor/bin/phpcs:*),Bash(./vendor/bin/phpunit:*),Read,Edit,MultiEdit,Write,Glob,Grep,LS"
 
       - name: Report execution failure
         if: failure() && steps.claude.outcome == 'failure'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -208,7 +208,7 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: "--allowedTools Bash(gh:*),Read,Glob,Grep"
+          claude_args: "--model claude-opus-4-8 --allowedTools Bash(gh:*),Read,Glob,Grep"
 
       - name: Collect auto-fix issue numbers
         id: collect


### PR DESCRIPTION
## Summary

- Adds `--model claude-opus-4-8` to `claude_args` in all four Claude-powered CI workflows
- Affected workflows: `claude-code-review.yml`, `auto-fix-review-issue.yml`, `batch-auto-fix.yml`, `auto-fix-ci.yml`
- Previously no model was pinned, so sessions fell back to the OAuth token's default

## Test plan

- [ ] Merge and open a test PR to confirm the review workflow initialises with `claude-opus-4-8` in the Actions log
- [ ] Verify auto-fix triggers correctly after the review run

---
_Generated by [Claude Code](https://claude.ai/code/session_01U34yN5qxgdHd3ohzJMkqDQ)_