### PR TITLE
fix(ci): add workflow_dispatch to CI, PR Quality Checks, and Claude Code Review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
     types: [opened, reopened, edited, ready_for_review]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,6 +8,7 @@ on:
       - "composer.lock"
       - "yarn.lock"
       - "*.lock"
+  workflow_dispatch:
 
 jobs:
   claude-review:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,6 +11,7 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - 'CHANGELOG.md'
       - 'RELEASING.md'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `ci.yml`, `pr-checks.yml`, and `claude-code-review.yml`
- No `synchronize` trigger added — CI still only fires on PR open, not every commit push

## Why

**Root cause of PR #828 showing only 3 checks on its current HEAD:**

All three workflows trigger on `pull_request` with types `[opened, ...]` but not `synchronize`. They ran once on the first commit when the PR was opened. Three lint-fix follow-up commits were then pushed (`synchronize` events) — those never re-triggered CI. GitHub's checks panel shows checks for the current HEAD only, so only CodeQL (GitHub-managed, runs on all PR events) was visible.

Additionally, the **Claude Code Review** job ran on PR #828 but failed silently:
```
Claude Code returned an error result: You've hit your session limit · resets 2:10pm (UTC)
```
The PR was opened at 14:08 UTC, the limit reset at 14:10 — two minutes too late. `continue-on-error: true` masked this as a workflow "success" with no comment posted.

**The fix:** `workflow_dispatch` lets maintainers manually re-trigger any of these workflows from the Actions tab against the current HEAD, without burning minutes on every commit.

## Test plan

- [ ] Go to Actions → CI → "Run workflow" → select this branch → confirm the 4 jobs run (commitlint, phpcs, phpunit, js-lint)
- [ ] Go to Actions → Claude Code Review → "Run workflow" → confirm a review comment is posted on the target PR
- [ ] Confirm no new runs trigger automatically when a commit is pushed to an open PR (no `synchronize` behaviour added)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKFzA6u2sNRjRfKJt9ZFTU)_