### PR TITLE
refactor(proxy): replace trial tier with credits-based usage tracking

### DIFF
--- a/plume-proxy/src/constants.ts
+++ b/plume-proxy/src/constants.ts
@@ -1,3 +1,0 @@
-// src/constants.ts
-
-export const TRIAL_PERIOD_MS = 30 * 24 * 60 * 60 * 1000;

--- a/plume-proxy/src/credits.ts
+++ b/plume-proxy/src/credits.ts
@@ -1,0 +1,26 @@
+// src/credits.ts
+
+export const GENERATOR_CREDITS = 10;
+export const SEO_CREDITS = 1;
+export const IMAGE_CREDITS = 15;
+
+/**
+ * Computes the credit cost of a single chat completion, scaled by total token
+ * volume and the model's relative weight (the existing per-model weight table
+ * resolved by index.ts's getModelConfig(), not redefined here).
+ *
+ * Formula: ceil((inputTokens + outputTokens) * weight / 2000).
+ *
+ * @since NEXT_VERSION
+ * @param {number} inputTokens  Actual input token count returned by the provider for this call.
+ * @param {number} outputTokens Actual output token count returned by the provider for this call.
+ * @param {number} weight       Resolved per-model weight (DEFAULT_MODEL_TOKEN_WEIGHT, possibly KV-overridden).
+ * @return {number} Credits to charge, rounded up to the nearest whole credit.
+ */
+export function chatCredits(
+	inputTokens: number,
+	outputTokens: number,
+	weight: number
+): number {
+	return Math.ceil( ( inputTokens + outputTokens ) * weight / 2000 );
+}

--- a/plume-proxy/src/credits.ts
+++ b/plume-proxy/src/credits.ts
@@ -5,11 +5,18 @@ export const SEO_CREDITS = 1;
 export const IMAGE_CREDITS = 15;
 
 /**
+ * Weighted tokens that map to a single chat credit. Deliberately mirrors the
+ * free-tier MAX_TOKENS (2_000) in index.ts so the relationship between the
+ * per-call token cap and one credit is explicit and tunable in one place.
+ */
+export const TOKENS_PER_CREDIT = 2000;
+
+/**
  * Computes the credit cost of a single chat completion, scaled by total token
  * volume and the model's relative weight (the existing per-model weight table
  * resolved by index.ts's getModelConfig(), not redefined here).
  *
- * Formula: ceil((inputTokens + outputTokens) * weight / 2000).
+ * Formula: ceil((inputTokens + outputTokens) * weight / TOKENS_PER_CREDIT).
  *
  * @since NEXT_VERSION
  * @param {number} inputTokens  Actual input token count returned by the provider for this call.
@@ -22,5 +29,7 @@ export function chatCredits(
 	outputTokens: number,
 	weight: number
 ): number {
-	return Math.ceil( ( inputTokens + outputTokens ) * weight / 2000 );
+	return Math.ceil(
+		( ( inputTokens + outputTokens ) * weight ) / TOKENS_PER_CREDIT
+	);
 }

--- a/plume-proxy/src/index.ts
+++ b/plume-proxy/src/index.ts
@@ -755,12 +755,7 @@ async function handleChatProxy(
 			);
 		}
 
-		// Coerce any unrecognised/legacy tier (e.g. records still stored as
-		// 'trial' before that tier was removed) to free, so they degrade
-		// gracefully instead of yielding undefined credit limits. pro_byok is
-		// already 403'd above, leaving pro_managed as the only non-free value.
-		const effectiveTier: ProxyTier =
-			tier === 'pro_managed' ? 'pro_managed' : 'free';
+		const effectiveTier = tier as ProxyTier;
 
 		const rateLimitCheck = await checkRateLimit(
 			siteToken,

--- a/plume-proxy/src/index.ts
+++ b/plume-proxy/src/index.ts
@@ -824,10 +824,20 @@ async function handleChatProxy(
 	} catch ( error ) {
 		// eslint-disable-next-line no-console
 		console.error( 'Proxy error:', error );
-		const status = typeof ( error as { status?: number } )?.status === 'number'
-			? ( error as { status: number } ).status
-			: 500;
-		const message = status !== 500 && error instanceof Error ? error.message : 'Internal proxy error';
+		// Only honour our own tagged validation error (the typed 400 from
+		// getModelForTier). Upstream provider errors also carry a `status`
+		// (e.g. a 429/401 from our Anthropic/OpenAI account) but must never be
+		// forwarded verbatim, as their status semantics collide with the
+		// proxy's own — they collapse to a generic 500 instead.
+		const tagged = error as { status?: number; isValidationError?: boolean };
+		const isValidationError =
+			tagged?.isValidationError === true &&
+			typeof tagged.status === 'number';
+		const status = isValidationError ? ( tagged.status as number ) : 500;
+		const message =
+			isValidationError && error instanceof Error
+				? error.message
+				: 'Internal proxy error';
 		return jsonResponse( { error: message }, status );
 	}
 }
@@ -882,9 +892,12 @@ function getModelForTier(
 		tierModels[ provider ]?.[ tier ] ??
 		DEFAULT_TIER_MODELS[ provider ][ tier ];
 	if ( allowed.length === 0 ) {
+		// Tagged with isValidationError so the handleChatProxy catch block can
+		// distinguish this intended 400 from arbitrary upstream provider errors
+		// (which also carry a `status`) and avoid forwarding their status verbatim.
 		throw Object.assign(
 			new Error( `No ${ provider } models available for tier ${ tier }` ),
-			{ status: 400 }
+			{ status: 400, isValidationError: true }
 		);
 	}
 	if ( requestedModel && allowed.includes( requestedModel ) ) {

--- a/plume-proxy/src/index.ts
+++ b/plume-proxy/src/index.ts
@@ -737,7 +737,12 @@ async function handleChatProxy(
 			);
 		}
 
-		const effectiveTier = tier as ProxyTier;
+		// Coerce any unrecognised/legacy tier (e.g. records still stored as
+		// 'trial' before that tier was removed) to free, so they degrade
+		// gracefully instead of yielding undefined credit limits. pro_byok is
+		// already 403'd above, leaving pro_managed as the only non-free value.
+		const effectiveTier: ProxyTier =
+			tier === 'pro_managed' ? 'pro_managed' : 'free';
 
 		const rateLimitCheck = await checkRateLimit(
 			siteToken,

--- a/plume-proxy/src/index.ts
+++ b/plume-proxy/src/index.ts
@@ -14,17 +14,18 @@ import { authenticateRequest, generateToken } from './auth';
 import { handleActivationChallenge, handleRegistration } from './registration';
 import { handleWebhook } from './webhook';
 import { verifyHmac } from './signature';
-import { TRIAL_PERIOD_MS } from './constants';
+import { chatCredits, GENERATOR_CREDITS, SEO_CREDITS, IMAGE_CREDITS } from './credits';
 
 const MAX_BODY_BYTES = 1_048_576; // 1 MB
 
 type Provider = 'claude' | 'openai' | 'gemini';
 
 // Fallback model lists used when no config:models entry exists in USAGE_KV.
+// `free` carries only Claude Haiku — gpt-4.1-nano is deliberately not added
+// (its weight is undefined, tracked in issue #856).
 const DEFAULT_TIER_MODELS: Record< Provider, Record< ProxyTier, string[] > > = {
 	claude: {
 		free: [ 'claude-haiku-4-5-20251001' ],
-		trial: [ 'claude-haiku-4-5-20251001' ],
 		pro_managed: [
 			'claude-haiku-4-5-20251001',
 			'claude-sonnet-4-6',
@@ -32,27 +33,24 @@ const DEFAULT_TIER_MODELS: Record< Provider, Record< ProxyTier, string[] > > = {
 		],
 	},
 	openai: {
-		free: [ 'gpt-4o-mini' ],
-		trial: [ 'gpt-4o-mini' ],
-		pro_managed: [ 'gpt-4o-mini', 'gpt-4o' ],
+		free: [],
+		pro_managed: [ 'gpt-4.1' ],
 	},
 	gemini: {
-		free: [ 'gemini-2.5-flash' ],
-		trial: [ 'gemini-2.5-flash' ],
-		pro_managed: [ 'gemini-2.5-flash', 'gemini-2.5-pro' ],
+		free: [],
+		pro_managed: [ 'gemini-3.5-flash', 'gemini-3.1-pro' ],
 	},
 };
 
 // Fallback token weights — relative cost multipliers applied to raw token counts
-// before storing in the usage KV, so quota enforcement is provider/model-agnostic.
+// before computing credits, so quota enforcement is provider/model-agnostic.
 const DEFAULT_MODEL_TOKEN_WEIGHT: Record< string, number > = {
 	'claude-haiku-4-5-20251001': 1,
 	'claude-sonnet-4-6': 3,
 	'claude-opus-4-6': 5,
-	'gpt-4o-mini': 1,
-	'gpt-4o': 10,
-	'gemini-2.5-flash': 1,
-	'gemini-2.5-pro': 5,
+	'gpt-4.1': 2,
+	'gemini-3.5-flash': 2,
+	'gemini-3.1-pro': 2,
 };
 
 /**
@@ -490,7 +488,7 @@ async function handleRotateSecret(
 const DEV_TIMESTAMP_WINDOW_S = 60;
 
 /** Valid tier values accepted by /dev/set-tier. */
-const VALID_TIERS: SiteTier[] = [ 'free', 'trial', 'pro_managed', 'pro_byok' ];
+const VALID_TIERS: SiteTier[] = [ 'free', 'pro_managed', 'pro_byok' ];
 
 type DevAuthResult =
 	| { authenticated: true; site_token: string; record: SiteRecord }
@@ -620,7 +618,7 @@ async function handleDevSetTier(
 }
 
 /**
- * Zero out this month's usage counter for the authenticated site.
+ * Zero out this month's credit counter for the authenticated site.
  *
  * @param {Request} request Incoming Worker request.
  * @param {Env}     env     Worker environment bindings.
@@ -645,8 +643,9 @@ async function handleDevResetUsage(
 }
 
 /**
- * Set this month's usage counter to an explicit value for the authenticated site.
- * Pass the tier's monthly limit to simulate a fully-exhausted quota.
+ * Set this month's credit counter to an explicit value for the authenticated site.
+ * Pass the tier's monthly limit (free=100, pro_managed=500) to simulate a
+ * fully-exhausted quota.
  *
  * @param {Request} request Incoming Worker request.
  * @param {Env}     env     Worker environment bindings.
@@ -709,6 +708,15 @@ async function handleChatProxy(
 		}
 
 		const body = JSON.parse( bodyText ) as ProxyRequest;
+		const VALID_FEATURES = [ 'chat', 'generator', 'seo', 'images' ] as const;
+		if ( ! body.feature || ! VALID_FEATURES.includes( body.feature ) ) {
+			return jsonResponse(
+				{ error: 'Missing or invalid feature — must be one of: chat, generator, seo, images' },
+				400
+			);
+		}
+		const { feature } = body;
+
 		const { model, max_tokens: maxTokens } = body;
 		const { site_token: siteToken, tier } = auth;
 
@@ -729,20 +737,7 @@ async function handleChatProxy(
 			);
 		}
 
-		// Lazily downgrade expired trials to free without blocking the request.
-		let effectiveTier = tier as ProxyTier;
-		if ( effectiveTier === 'trial' && auth.record ) {
-			const startedAt =
-				auth.record.trial_started_at ?? auth.record.created_at;
-			if ( Date.now() - startedAt > TRIAL_PERIOD_MS ) {
-				const demoted: SiteRecord = { ...auth.record, tier: 'free' };
-				await env.USAGE_KV.put(
-					`site:${ siteToken }`,
-					JSON.stringify( demoted )
-				);
-				effectiveTier = 'free';
-			}
-		}
+		const effectiveTier = tier as ProxyTier;
 
 		const rateLimitCheck = await checkRateLimit(
 			siteToken,
@@ -796,10 +791,22 @@ async function handleChatProxy(
 			);
 		}
 
-		const weight = tokenWeights[ selectedModel ] ?? 1;
-		const rawTokens =
-			normalized.usage.input_tokens + normalized.usage.output_tokens;
-		await updateUsage( siteToken, rawTokens * weight, env );
+		let creditsCharged: number;
+		if ( feature === 'chat' ) {
+			const weight = tokenWeights[ selectedModel ] ?? 1;
+			creditsCharged = chatCredits(
+				normalized.usage.input_tokens,
+				normalized.usage.output_tokens,
+				weight
+			);
+		} else if ( feature === 'generator' ) {
+			creditsCharged = GENERATOR_CREDITS;
+		} else if ( feature === 'seo' ) {
+			creditsCharged = SEO_CREDITS;
+		} else {
+			creditsCharged = IMAGE_CREDITS;
+		}
+		await updateUsage( siteToken, creditsCharged, env );
 
 		const responseData: Record< string, unknown > = {
 			content: normalized.content,
@@ -812,20 +819,24 @@ async function handleChatProxy(
 	} catch ( error ) {
 		// eslint-disable-next-line no-console
 		console.error( 'Proxy error:', error );
-		return jsonResponse( { error: 'Internal proxy error' }, 500 );
+		const status = typeof ( error as { status?: number } )?.status === 'number'
+			? ( error as { status: number } ).status
+			: 500;
+		const message = status !== 500 && error instanceof Error ? error.message : 'Internal proxy error';
+		return jsonResponse( { error: message }, status );
 	}
 }
 
-// Mirrors NJ_Tier_Config::MONTHLY_LIMITS (PHP). Keep in sync.
-const MONTHLY_LIMITS: Record< ProxyTier, number > = {
-	free: 50_000,
-	trial: 300_000,
-	pro_managed: 2_000_000,
+// Worker is now authoritative for monthly allowances, expressed in credits
+// (not raw tokens). PR 2 will have the plugin fetch this from the Worker at
+// runtime rather than re-declaring it in PHP — see plan §3.3.
+const MONTHLY_CREDIT_LIMITS: Record< ProxyTier, number > = {
+	free: 100,
+	pro_managed: 500,
 };
 
 const MAX_TOKENS: Record< ProxyTier, number > = {
-	free: 1_000,
-	trial: 4_000,
+	free: 2_000,
 	pro_managed: 8_000,
 };
 
@@ -834,7 +845,7 @@ async function checkRateLimit(
 	tier: ProxyTier,
 	env: Env
 ): Promise< { allowed: boolean; used: number; limit: number } > {
-	const limit = MONTHLY_LIMITS[ tier ];
+	const limit = MONTHLY_CREDIT_LIMITS[ tier ];
 	const key = `usage:${ siteToken }:${ getCurrentMonth() }`;
 	const used = parseInt( ( await env.USAGE_KV.get( key ) ) ?? '0', 10 );
 	return { allowed: used < limit, used, limit };
@@ -842,17 +853,16 @@ async function checkRateLimit(
 
 async function updateUsage(
 	siteToken: string,
-	tokens: number,
+	credits: number,
 	env: Env
 ): Promise< void > {
 	const key = `usage:${ siteToken }:${ getCurrentMonth() }`;
 	// KV does not support atomic increments, so concurrent requests perform a
-	// non-atomic read-modify-write. Under burst load this can under-count tokens,
-	// meaning at most one extra request per concurrent burst slips past the monthly
-	// limit. Replace with a Durable Object counter (tracked in issue #312) to make
-	// enforcement fully atomic.
+	// non-atomic read-modify-write. Under burst load this can under-count credits.
+	// Replace with a Durable Object counter (tracked in issue #312) to make
+	// enforcement fully atomic. NOT fixed by this migration — see risk list.
 	const current = parseInt( ( await env.USAGE_KV.get( key ) ) ?? '0', 10 );
-	await env.USAGE_KV.put( key, String( current + tokens ), {
+	await env.USAGE_KV.put( key, String( current + credits ), {
 		expirationTtl: getSecondsUntilNextMonth(),
 	} );
 }
@@ -866,6 +876,12 @@ function getModelForTier(
 	const allowed =
 		tierModels[ provider ]?.[ tier ] ??
 		DEFAULT_TIER_MODELS[ provider ][ tier ];
+	if ( allowed.length === 0 ) {
+		throw Object.assign(
+			new Error( `No ${ provider } models available for tier ${ tier }` ),
+			{ status: 400 }
+		);
+	}
 	if ( requestedModel && allowed.includes( requestedModel ) ) {
 		return requestedModel;
 	}

--- a/plume-proxy/src/index.ts
+++ b/plume-proxy/src/index.ts
@@ -18,6 +18,17 @@ import { chatCredits, GENERATOR_CREDITS, SEO_CREDITS, IMAGE_CREDITS } from './cr
 
 const MAX_BODY_BYTES = 1_048_576; // 1 MB
 
+// Flat per-call credit cost for non-chat features. Chat is special-cased
+// (token-weighted) in handleChatProxy; everything else is a fixed lookup.
+const FLAT_FEATURE_CREDITS: Record<
+	Exclude< ProxyRequest[ 'feature' ], 'chat' >,
+	number
+> = {
+	generator: GENERATOR_CREDITS,
+	seo: SEO_CREDITS,
+	images: IMAGE_CREDITS,
+};
+
 type Provider = 'claude' | 'openai' | 'gemini';
 
 // Fallback model lists used when no config:models entry exists in USAGE_KV.
@@ -490,6 +501,14 @@ const DEV_TIMESTAMP_WINDOW_S = 60;
 /** Valid tier values accepted by /dev/set-tier. */
 const VALID_TIERS: SiteTier[] = [ 'free', 'pro_managed', 'pro_byok' ];
 
+/** Valid feature values accepted by /v1/chat — kept in lockstep with ProxyRequest['feature']. */
+const VALID_FEATURES: ProxyRequest[ 'feature' ][] = [
+	'chat',
+	'generator',
+	'seo',
+	'images',
+];
+
 type DevAuthResult =
 	| { authenticated: true; site_token: string; record: SiteRecord }
 	| { authenticated: false; error: string; status: number };
@@ -708,7 +727,6 @@ async function handleChatProxy(
 		}
 
 		const body = JSON.parse( bodyText ) as ProxyRequest;
-		const VALID_FEATURES = [ 'chat', 'generator', 'seo', 'images' ] as const;
 		if ( ! body.feature || ! VALID_FEATURES.includes( body.feature ) ) {
 			return jsonResponse(
 				{ error: 'Missing or invalid feature — must be one of: chat, generator, seo, images' },
@@ -804,12 +822,8 @@ async function handleChatProxy(
 				normalized.usage.output_tokens,
 				weight
 			);
-		} else if ( feature === 'generator' ) {
-			creditsCharged = GENERATOR_CREDITS;
-		} else if ( feature === 'seo' ) {
-			creditsCharged = SEO_CREDITS;
 		} else {
-			creditsCharged = IMAGE_CREDITS;
+			creditsCharged = FLAT_FEATURE_CREDITS[ feature ];
 		}
 		await updateUsage( siteToken, creditsCharged, env );
 

--- a/plume-proxy/src/registration.ts
+++ b/plume-proxy/src/registration.ts
@@ -2,7 +2,6 @@
 
 import { Env, SiteRecord } from './types';
 import { generateToken } from './auth';
-import { TRIAL_PERIOD_MS } from './constants';
 
 export const REGISTRATION_RATE_LIMIT = 5; // max new registrations per IP per hour
 export const CHALLENGE_RATE_LIMIT = 20; // max challenge requests per IP per hour
@@ -127,7 +126,6 @@ export async function handleRegistration(
 	await env.USAGE_KV.delete( `challenge:${ challengeToken }` );
 
 	// Idempotent — return the existing token if already registered.
-	// If the stored record is an expired trial, demote it to free.
 	const urlHash = await sha256( siteUrl );
 	const existingToken = await env.USAGE_KV.get( `site_url:${ urlHash }` );
 	if ( existingToken ) {
@@ -136,19 +134,6 @@ export async function handleRegistration(
 			'json'
 		);
 		if ( record ) {
-			const startedAt = record.trial_started_at ?? record.created_at;
-			if (
-				record.tier === 'trial' &&
-				Date.now() - startedAt > TRIAL_PERIOD_MS
-			) {
-				const demoted: SiteRecord = { ...record, tier: 'free' };
-				await env.USAGE_KV.put(
-					`site:${ existingToken }`,
-					JSON.stringify( demoted )
-				);
-				return jsonResponse( { token: existingToken, tier: 'free' } );
-			}
-
 			return jsonResponse( { token: existingToken, tier: record.tier } );
 		}
 	}
@@ -179,9 +164,8 @@ export async function handleRegistration(
 	const now = Date.now();
 	const record: SiteRecord = {
 		site_url: siteUrl,
-		tier: 'trial',
+		tier: 'free',
 		created_at: now,
-		trial_started_at: now,
 		tier_sync_secret: tierSyncSecret,
 	};
 
@@ -189,7 +173,7 @@ export async function handleRegistration(
 	await env.USAGE_KV.put( `site_url:${ urlHash }`, token );
 
 	return jsonResponse(
-		{ token, tier: 'trial', tier_sync_secret: tierSyncSecret },
+		{ token, tier: 'free', tier_sync_secret: tierSyncSecret },
 		201
 	);
 }

--- a/plume-proxy/src/types.ts
+++ b/plume-proxy/src/types.ts
@@ -14,7 +14,7 @@ export interface Env {
 }
 
 /** Tiers handled by this proxy (rate-limited and counted). */
-export type ProxyTier = 'free' | 'trial' | 'pro_managed';
+export type ProxyTier = 'free' | 'pro_managed';
 
 /** All possible tier values a site JWT may carry. */
 export type SiteTier = ProxyTier | 'pro_byok';
@@ -23,7 +23,6 @@ export interface SiteRecord {
 	site_url: string;
 	tier: SiteTier;
 	created_at: number;
-	trial_started_at?: number;
 	ls_licence_key?: string;
 	/**
 	 * Shared HMAC secret used to sign tier-update pushes from the Worker to the
@@ -73,6 +72,11 @@ export interface ProxyRequest {
 	system?: string | SystemBlock[];
 	tools?: ToolParam[];
 	provider?: 'claude' | 'openai' | 'gemini';
+	/**
+	 * Required, not inferred — the Worker must know what it's charging for before
+	 * the upstream call, and must never guess the feature from request shape.
+	 */
+	feature: 'chat' | 'generator' | 'seo' | 'images';
 }
 
 export interface MessageParam {

--- a/plume-proxy/test/auth.test.ts
+++ b/plume-proxy/test/auth.test.ts
@@ -62,16 +62,6 @@ describe( 'authenticateRequest', () => {
 		expect( result.tier ).toBe( 'pro_managed' );
 	} );
 
-	it( 'returns tier: trial for a trial-registered site', async () => {
-		const env = await makeEnvWithSiteToken( 'trial' );
-		const result = await authenticateRequest(
-			makeRequest( { Authorization: `Bearer ${ TEST_TOKEN }` } ),
-			env
-		);
-		expect( result.authenticated ).toBe( true );
-		expect( result.tier ).toBe( 'trial' );
-	} );
-
 	it( 'returns tier: free for a free-tier site', async () => {
 		const env = await makeEnvWithSiteToken( 'free' );
 		const result = await authenticateRequest(

--- a/plume-proxy/test/chat-proxy.test.ts
+++ b/plume-proxy/test/chat-proxy.test.ts
@@ -3,7 +3,12 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import worker from '../src/index';
 import { makeEnv } from './helpers/kv-mock';
-import { chatCredits } from '../src/credits';
+import {
+	chatCredits,
+	GENERATOR_CREDITS,
+	SEO_CREDITS,
+	IMAGE_CREDITS,
+} from '../src/credits';
 import type { SiteRecord, ToolParam } from '../src/types';
 
 afterEach( () => {
@@ -687,6 +692,46 @@ describe( 'handleChatProxy', () => {
 		expect( stored ).toBe( chatCredits( 2000, 2000, 1 ) );
 		expect( stored ).toBe( 2 );
 	} );
+
+	it.each( [
+		[ 'generator', GENERATOR_CREDITS ],
+		[ 'seo', SEO_CREDITS ],
+		[ 'images', IMAGE_CREDITS ],
+	] as const )(
+		'%s feature charges the flat credit amount (%i) regardless of token usage',
+		async ( feature, expectedCredits ) => {
+			const env = await makeEnvWithSiteToken( 'pro_managed' );
+
+			vi.stubGlobal(
+				'fetch',
+				vi.fn().mockImplementation( async () => {
+					return new Response(
+						JSON.stringify( {
+							content: [ { type: 'text', text: 'response' } ],
+							// Large token counts to prove the flat charge ignores them.
+							usage: {
+								input_tokens: 9999,
+								output_tokens: 9999,
+							},
+						} ),
+						{ status: 200 }
+					);
+				} )
+			);
+
+			const body = JSON.stringify( {
+				messages: [ { role: 'user', content: 'Hello' } ],
+				provider: 'claude',
+				feature,
+			} );
+
+			const response = await worker.fetch( makeChatRequest( body ), env );
+			expect( response.status ).toBe( 200 );
+
+			const stored = await getStoredUsage( env );
+			expect( stored ).toBe( expectedCredits );
+		}
+	);
 
 	it( 'returns 429 once monthly credit allowance is exhausted for a free-tier site', async () => {
 		const env = await makeEnvWithSiteToken( 'free' );

--- a/plume-proxy/test/chat-proxy.test.ts
+++ b/plume-proxy/test/chat-proxy.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import worker from '../src/index';
 import { makeEnv } from './helpers/kv-mock';
+import { currentMonthKey } from './helpers/month';
 import {
 	chatCredits,
 	GENERATOR_CREDITS,
@@ -49,11 +50,9 @@ function makeChatRequest( body = VALID_BODY ) {
 async function getStoredUsage(
 	env: ReturnType< typeof makeEnv >
 ): Promise< number > {
-	const month =
-		new Date().getFullYear() +
-		'-' +
-		String( new Date().getMonth() + 1 ).padStart( 2, '0' );
-	const stored = await env.USAGE_KV.get( `usage:${ TEST_TOKEN }:${ month }` );
+	const stored = await env.USAGE_KV.get(
+		`usage:${ TEST_TOKEN }:${ currentMonthKey() }`
+	);
 	return Number( stored );
 }
 
@@ -83,12 +82,8 @@ describe( 'handleChatProxy', () => {
 		const env = await makeEnvWithSiteToken( 'pro_byok' );
 		await worker.fetch( makeChatRequest(), env );
 
-		const month =
-			new Date().getFullYear() +
-			'-' +
-			String( new Date().getMonth() + 1 ).padStart( 2, '0' );
 		const stored = await env.USAGE_KV.get(
-			`usage:${ TEST_TOKEN }:${ month }`
+			`usage:${ TEST_TOKEN }:${ currentMonthKey() }`
 		);
 		expect( stored ).toBeNull();
 	} );
@@ -735,11 +730,10 @@ describe( 'handleChatProxy', () => {
 
 	it( 'returns 429 once monthly credit allowance is exhausted for a free-tier site', async () => {
 		const env = await makeEnvWithSiteToken( 'free' );
-		const month =
-			new Date().getFullYear() +
-			'-' +
-			String( new Date().getMonth() + 1 ).padStart( 2, '0' );
-		await env.USAGE_KV.put( `usage:${ TEST_TOKEN }:${ month }`, '100' );
+		await env.USAGE_KV.put(
+			`usage:${ TEST_TOKEN }:${ currentMonthKey() }`,
+			'100'
+		);
 
 		const response = await worker.fetch( makeChatRequest(), env );
 		expect( response.status ).toBe( 429 );
@@ -757,11 +751,10 @@ describe( 'handleChatProxy', () => {
 
 	it( 'returns 429 once monthly credit allowance is exhausted for a pro_managed-tier site', async () => {
 		const env = await makeEnvWithSiteToken( 'pro_managed' );
-		const month =
-			new Date().getFullYear() +
-			'-' +
-			String( new Date().getMonth() + 1 ).padStart( 2, '0' );
-		await env.USAGE_KV.put( `usage:${ TEST_TOKEN }:${ month }`, '500' );
+		await env.USAGE_KV.put(
+			`usage:${ TEST_TOKEN }:${ currentMonthKey() }`,
+			'500'
+		);
 
 		const response = await worker.fetch( makeChatRequest(), env );
 		expect( response.status ).toBe( 429 );
@@ -779,11 +772,7 @@ describe( 'handleChatProxy', () => {
 
 	it( 'allows a request at used = limit-1, then blocks the next one at used = limit', async () => {
 		const env = await makeEnvWithSiteToken( 'free' );
-		const month =
-			new Date().getFullYear() +
-			'-' +
-			String( new Date().getMonth() + 1 ).padStart( 2, '0' );
-		const usageKey = `usage:${ TEST_TOKEN }:${ month }`;
+		const usageKey = `usage:${ TEST_TOKEN }:${ currentMonthKey() }`;
 		await env.USAGE_KV.put( usageKey, '99' );
 
 		vi.stubGlobal(

--- a/plume-proxy/test/chat-proxy.test.ts
+++ b/plume-proxy/test/chat-proxy.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import worker from '../src/index';
 import { makeEnv } from './helpers/kv-mock';
+import { chatCredits } from '../src/credits';
 import type { SiteRecord, ToolParam } from '../src/types';
 
 afterEach( () => {
@@ -15,18 +16,15 @@ const TEST_TOKEN =
 const VALID_BODY = JSON.stringify( {
 	messages: [ { role: 'user', content: 'Hello' } ],
 	provider: 'claude',
+	feature: 'chat',
 } );
 
-async function makeEnvWithSiteToken(
-	tier: SiteRecord[ 'tier' ],
-	trialStartedAt?: number
-) {
+async function makeEnvWithSiteToken( tier: SiteRecord[ 'tier' ] ) {
 	const env = makeEnv();
 	const record: SiteRecord = {
 		site_url: 'https://example.com',
 		tier,
 		created_at: Date.now(),
-		trial_started_at: trialStartedAt ?? Date.now(),
 	};
 	await env.USAGE_KV.put( `site:${ TEST_TOKEN }`, JSON.stringify( record ) );
 	return env;
@@ -41,6 +39,17 @@ function makeChatRequest( body = VALID_BODY ) {
 		},
 		body,
 	} );
+}
+
+async function getStoredUsage(
+	env: ReturnType< typeof makeEnv >
+): Promise< number > {
+	const month =
+		new Date().getFullYear() +
+		'-' +
+		String( new Date().getMonth() + 1 ).padStart( 2, '0' );
+	const stored = await env.USAGE_KV.get( `usage:${ TEST_TOKEN }:${ month }` );
+	return Number( stored );
 }
 
 const mockTool: ToolParam = {
@@ -65,47 +74,49 @@ describe( 'handleChatProxy', () => {
 		} );
 	} );
 
-	it( 'demotes an expired trial to free and stores the updated record', async () => {
-		// trial_started_at is 31 days ago — past the 30-day window.
-		const thirtyOneDaysAgo = Date.now() - 31 * 24 * 60 * 60 * 1000;
-		const env = await makeEnvWithSiteToken( 'trial', thirtyOneDaysAgo );
-
-		// Stub fetch so the upstream call returns a non-2xx — the
-		// important thing is that the demote path runs before the upstream call.
-		vi.stubGlobal(
-			'fetch',
-			vi.fn().mockRejectedValue( new Error( 'upstream error' ) )
-		);
-
+	it( 'BYOK request never reaches credit charging — no usage KV write after a 403', async () => {
+		const env = await makeEnvWithSiteToken( 'pro_byok' );
 		await worker.fetch( makeChatRequest(), env );
 
-		// Record in KV must now show tier=free.
-		const updated = ( await env.USAGE_KV.get< SiteRecord >(
-			`site:${ TEST_TOKEN }`,
-			'json'
-		) ) as SiteRecord;
-		expect( updated.tier ).toBe( 'free' );
+		const month =
+			new Date().getFullYear() +
+			'-' +
+			String( new Date().getMonth() + 1 ).padStart( 2, '0' );
+		const stored = await env.USAGE_KV.get(
+			`usage:${ TEST_TOKEN }:${ month }`
+		);
+		expect( stored ).toBeNull();
 	} );
 
-	it( 'does not demote an active trial (< 30 days)', async () => {
-		const env = await makeEnvWithSiteToken( 'trial' ); // trial_started_at = now
+	it( 'returns 400 when feature field is missing from the request body', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Hello' } ],
+			provider: 'claude',
+		} );
 
-		vi.stubGlobal(
-			'fetch',
-			vi.fn().mockRejectedValue( new Error( 'upstream error' ) )
-		);
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		expect( response.status ).toBe( 400 );
+		const json = ( await response.json() ) as { error: string };
+		expect( json.error ).toMatch( /feature/i );
+	} );
 
-		await worker.fetch( makeChatRequest(), env );
+	it( 'returns 400 when feature field is an invalid value (not chat/generator/seo/images)', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Hello' } ],
+			provider: 'claude',
+			feature: 'unicorn',
+		} );
 
-		const record = ( await env.USAGE_KV.get< SiteRecord >(
-			`site:${ TEST_TOKEN }`,
-			'json'
-		) ) as SiteRecord;
-		expect( record.tier ).toBe( 'trial' );
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		expect( response.status ).toBe( 400 );
+		const json = ( await response.json() ) as { error: string };
+		expect( json.error ).toMatch( /feature/i );
 	} );
 
 	it( 'Claude adapter: sends input_schema in upstream request', async () => {
-		const env = await makeEnvWithSiteToken( 'trial' );
+		const env = await makeEnvWithSiteToken( 'free' );
 
 		let capturedBody: Record< string, unknown > | null = null;
 		vi.stubGlobal(
@@ -130,6 +141,7 @@ describe( 'handleChatProxy', () => {
 			messages: [ { role: 'user', content: 'Summarise post 140' } ],
 			provider: 'claude',
 			tools: [ mockTool ],
+			feature: 'chat',
 		} );
 
 		const response = await worker.fetch( makeChatRequest( body ), env );
@@ -151,7 +163,7 @@ describe( 'handleChatProxy', () => {
 	} );
 
 	it( 'Claude adapter: relays tool_call when Claude returns a tool_use block', async () => {
-		const env = await makeEnvWithSiteToken( 'trial' );
+		const env = await makeEnvWithSiteToken( 'free' );
 
 		vi.stubGlobal(
 			'fetch',
@@ -181,6 +193,7 @@ describe( 'handleChatProxy', () => {
 			messages: [ { role: 'user', content: 'Summarise post 42' } ],
 			provider: 'claude',
 			tools: [ mockTool ],
+			feature: 'chat',
 		} );
 
 		const response = await worker.fetch( makeChatRequest( body ), env );
@@ -205,7 +218,7 @@ describe( 'handleChatProxy', () => {
 	} );
 
 	it( 'Claude adapter: returns text-only response when no tool_use block is present', async () => {
-		const env = await makeEnvWithSiteToken( 'trial' );
+		const env = await makeEnvWithSiteToken( 'free' );
 
 		vi.stubGlobal(
 			'fetch',
@@ -234,7 +247,7 @@ describe( 'handleChatProxy', () => {
 	} );
 
 	it( 'OpenAI adapter: sends correct OpenAI-format body and returns normalised response', async () => {
-		const env = await makeEnvWithSiteToken( 'trial' );
+		const env = await makeEnvWithSiteToken( 'pro_managed' );
 
 		let capturedUrl: string | null = null;
 		let capturedBody: Record< string, unknown > | null = null;
@@ -266,6 +279,7 @@ describe( 'handleChatProxy', () => {
 			messages: [ { role: 'user', content: 'Hello OpenAI' } ],
 			provider: 'openai',
 			tools: [ mockTool ],
+			feature: 'chat',
 		} );
 
 		const response = await worker.fetch( makeChatRequest( body ), env );
@@ -300,7 +314,7 @@ describe( 'handleChatProxy', () => {
 	} );
 
 	it( 'Gemini adapter: sends correct Gemini-format body and returns normalised response', async () => {
-		const env = await makeEnvWithSiteToken( 'trial' );
+		const env = await makeEnvWithSiteToken( 'pro_managed' );
 
 		let capturedUrl: string | null = null;
 		let capturedBody: Record< string, unknown > | null = null;
@@ -336,6 +350,7 @@ describe( 'handleChatProxy', () => {
 			messages: [ { role: 'user', content: 'Hello Gemini' } ],
 			provider: 'gemini',
 			tools: [ mockTool ],
+			feature: 'chat',
 		} );
 
 		const response = await worker.fetch( makeChatRequest( body ), env );
@@ -374,7 +389,7 @@ describe( 'handleChatProxy', () => {
 	} );
 
 	it( 'returns a UUID-format tool_call id when Gemini functionCall part is returned', async () => {
-		const env = await makeEnvWithSiteToken( 'trial' );
+		const env = await makeEnvWithSiteToken( 'pro_managed' );
 
 		vi.stubGlobal(
 			'fetch',
@@ -409,6 +424,7 @@ describe( 'handleChatProxy', () => {
 			messages: [ { role: 'user', content: 'Fetch post 7' } ],
 			provider: 'gemini',
 			tools: [ mockTool ],
+			feature: 'chat',
 		} );
 
 		const response = await worker.fetch( makeChatRequest( body ), env );
@@ -434,11 +450,12 @@ describe( 'handleChatProxy', () => {
 	} );
 
 	it( 'returns 400 for unknown provider', async () => {
-		const env = await makeEnvWithSiteToken( 'trial' );
+		const env = await makeEnvWithSiteToken( 'free' );
 
 		const body = JSON.stringify( {
 			messages: [ { role: 'user', content: 'Hello' } ],
 			provider: 'groq',
+			feature: 'chat',
 		} );
 
 		const response = await worker.fetch( makeChatRequest( body ), env );
@@ -447,7 +464,7 @@ describe( 'handleChatProxy', () => {
 		expect( json.error ).toBe( 'Unknown provider' );
 	} );
 
-	it( 'returns 403 when a higher-tier OpenAI model is requested by a free site', async () => {
+	it( 'returns 200 when a higher-tier OpenAI model is requested by a free site — falls back to default', async () => {
 		const env = await makeEnvWithSiteToken( 'free' );
 
 		vi.stubGlobal(
@@ -466,59 +483,45 @@ describe( 'handleChatProxy', () => {
 		const body = JSON.stringify( {
 			messages: [ { role: 'user', content: 'Hello' } ],
 			provider: 'openai',
-			model: 'gpt-4o',
+			model: 'gpt-4.1',
+			feature: 'chat',
 		} );
 
-		// Free tier does not include gpt-4o — worker should fall back to gpt-4o-mini
-		// and succeed (200), not 403. The tier check silently falls back rather than
-		// rejecting, which matches the existing Claude behaviour.
+		// Free tier has no openai models at all — getModelForTier throws a typed
+		// 400 (empty allowed-models array), not a fallback to a different model.
 		const response = await worker.fetch( makeChatRequest( body ), env );
-		expect( response.status ).toBe( 200 );
+		expect( response.status ).toBe( 400 );
+	} );
 
-		// Verify it fell back to the allowed model, not gpt-4o
-		const sentBody = JSON.parse(
-			(
-				vi.mocked( globalThis.fetch ).mock
-					.calls[ 0 ][ 1 ] as RequestInit
-			 ).body as string
-		) as Record< string, unknown >;
-		expect( sentBody.model ).toBe( 'gpt-4o-mini' );
+	it( 'GPT-4.1 nano is not yet present in DEFAULT_TIER_MODELS.free for openai', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
+
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Hello' } ],
+			provider: 'openai',
+			model: 'gpt-4.1-nano',
+			feature: 'chat',
+		} );
+
+		// free.openai is an empty array — issue #856 tracks adding gpt-4.1-nano,
+		// not resolved by this PR.
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		expect( response.status ).toBe( 400 );
 	} );
 
 	it( 'returns 200 when a higher-tier Gemini model is requested by a free site — falls back to default', async () => {
 		const env = await makeEnvWithSiteToken( 'free' );
 
-		vi.stubGlobal(
-			'fetch',
-			vi.fn().mockImplementation( async () => {
-				return new Response(
-					JSON.stringify( {
-						candidates: [
-							{ content: { parts: [ { text: 'ok' } ] } },
-						],
-						usageMetadata: {
-							promptTokenCount: 5,
-							candidatesTokenCount: 2,
-						},
-					} ),
-					{ status: 200 }
-				);
-			} )
-		);
-
 		const body = JSON.stringify( {
 			messages: [ { role: 'user', content: 'Hello' } ],
 			provider: 'gemini',
-			model: 'gemini-2.5-pro',
+			model: 'gemini-3.1-pro',
+			feature: 'chat',
 		} );
 
-		// Free tier does not include gemini-2.5-pro — worker falls back to gemini-2.5-flash.
+		// Free tier has no gemini models at all — getModelForTier throws a typed 400.
 		const response = await worker.fetch( makeChatRequest( body ), env );
-		expect( response.status ).toBe( 200 );
-
-		const calledUrl = vi.mocked( globalThis.fetch ).mock
-			.calls[ 0 ][ 0 ] as string;
-		expect( calledUrl ).toContain( 'gemini-2.5-flash' );
+		expect( response.status ).toBe( 400 );
 	} );
 
 	it( 'uses KV model config override when config:models is set in USAGE_KV', async () => {
@@ -531,7 +534,6 @@ describe( 'handleChatProxy', () => {
 				tier_models: {
 					claude: {
 						free: [ 'claude-haiku-4-5-20251001' ],
-						trial: [ 'claude-haiku-4-5-20251001' ],
 						pro_managed: [
 							'claude-haiku-4-5-20251001',
 							'claude-opus-4-7',
@@ -548,7 +550,7 @@ describe( 'handleChatProxy', () => {
 				return new Response(
 					JSON.stringify( {
 						content: [ { type: 'text', text: 'ok' } ],
-						usage: { input_tokens: 10, output_tokens: 5 },
+						usage: { input_tokens: 2000, output_tokens: 2000 },
 					} ),
 					{ status: 200 }
 				);
@@ -559,6 +561,7 @@ describe( 'handleChatProxy', () => {
 			messages: [ { role: 'user', content: 'Hello' } ],
 			provider: 'claude',
 			model: 'claude-opus-4-7',
+			feature: 'chat',
 		} );
 
 		const response = await worker.fetch( makeChatRequest( body ), env );
@@ -573,18 +576,13 @@ describe( 'handleChatProxy', () => {
 		) as Record< string, unknown >;
 		expect( sentBody.model ).toBe( 'claude-opus-4-7' );
 
-		// Verify the KV-specified token weight (10+5=15 raw, ×20 = 300 effective)
-		const month =
-			new Date().getFullYear() +
-			'-' +
-			String( new Date().getMonth() + 1 ).padStart( 2, '0' );
-		const stored = await env.USAGE_KV.get(
-			`usage:${ TEST_TOKEN }:${ month }`
-		);
-		expect( Number( stored ) ).toBe( 300 );
+		// Verify chatCredits(input=2000, output=2000, weight=20) credits stored.
+		const stored = await getStoredUsage( env );
+		expect( stored ).toBe( chatCredits( 2000, 2000, 20 ) );
+		expect( stored ).toBe( 40 );
 	} );
 
-	it( 'token weight: effective tokens stored in KV equal raw tokens × weight for a heavy model', async () => {
+	it( 'chat credits: KV value equals chatCredits(input, output, weight) for a heavy model', async () => {
 		const env = await makeEnvWithSiteToken( 'pro_managed' );
 
 		vi.stubGlobal(
@@ -593,30 +591,176 @@ describe( 'handleChatProxy', () => {
 				return new Response(
 					JSON.stringify( {
 						content: [ { type: 'text', text: 'response' } ],
-						usage: { input_tokens: 100, output_tokens: 50 },
+						usage: { input_tokens: 10_000, output_tokens: 5_000 },
 					} ),
 					{ status: 200 }
 				);
 			} )
 		);
 
-		// claude-opus-4-6 has weight 15
+		// claude-opus-4-6 has weight 5.
 		const body = JSON.stringify( {
 			messages: [ { role: 'user', content: 'Hello' } ],
 			provider: 'claude',
 			model: 'claude-opus-4-6',
+			feature: 'chat',
 		} );
 
 		await worker.fetch( makeChatRequest( body ), env );
 
+		const stored = await getStoredUsage( env );
+		expect( stored ).toBe( chatCredits( 10_000, 5_000, 5 ) );
+		expect( stored ).toBe( 38 );
+	} );
+
+	it( 'free tier: chat call charges credits per chatCredits(input, output, weight) and stores result in usage KV', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async () => {
+				return new Response(
+					JSON.stringify( {
+						content: [ { type: 'text', text: 'response' } ],
+						usage: { input_tokens: 1000, output_tokens: 1000 },
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+
+		// claude-haiku-4-5-20251001 has weight 1.
+		const response = await worker.fetch( makeChatRequest(), env );
+		expect( response.status ).toBe( 200 );
+
+		const stored = await getStoredUsage( env );
+		expect( stored ).toBe( chatCredits( 1000, 1000, 1 ) );
+		expect( stored ).toBe( 1 );
+	} );
+
+	it( 'chat credits: Math.ceil rounding applies when (input+output)*weight is not a multiple of 2000', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async () => {
+				return new Response(
+					JSON.stringify( {
+						content: [ { type: 'text', text: 'response' } ],
+						usage: { input_tokens: 100, output_tokens: 1 },
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+
+		// weight=1, raw=101 → ceil(101/2000) = 1, not a clean division.
+		const response = await worker.fetch( makeChatRequest(), env );
+		expect( response.status ).toBe( 200 );
+
+		const stored = await getStoredUsage( env );
+		expect( stored ).toBe( chatCredits( 100, 1, 1 ) );
+		expect( stored ).toBe( 1 );
+	} );
+
+	it( 'chat credits: no spurious rounding when (input+output)*weight is an exact multiple of 2000', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async () => {
+				return new Response(
+					JSON.stringify( {
+						content: [ { type: 'text', text: 'response' } ],
+						usage: { input_tokens: 2000, output_tokens: 2000 },
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+
+		// weight=1, raw=4000 → 4000/2000 = 2 exactly.
+		const response = await worker.fetch( makeChatRequest(), env );
+		expect( response.status ).toBe( 200 );
+
+		const stored = await getStoredUsage( env );
+		expect( stored ).toBe( chatCredits( 2000, 2000, 1 ) );
+		expect( stored ).toBe( 2 );
+	} );
+
+	it( 'returns 429 once monthly credit allowance is exhausted for a free-tier site', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
 		const month =
 			new Date().getFullYear() +
 			'-' +
 			String( new Date().getMonth() + 1 ).padStart( 2, '0' );
-		const stored = await env.USAGE_KV.get(
-			`usage:${ TEST_TOKEN }:${ month }`
+		await env.USAGE_KV.put( `usage:${ TEST_TOKEN }:${ month }`, '100' );
+
+		const response = await worker.fetch( makeChatRequest(), env );
+		expect( response.status ).toBe( 429 );
+		const json = ( await response.json() ) as {
+			error: string;
+			used: number;
+			limit: number;
+		};
+		expect( json ).toEqual( {
+			error: 'Rate limit exceeded',
+			used: 100,
+			limit: 100,
+		} );
+	} );
+
+	it( 'returns 429 once monthly credit allowance is exhausted for a pro_managed-tier site', async () => {
+		const env = await makeEnvWithSiteToken( 'pro_managed' );
+		const month =
+			new Date().getFullYear() +
+			'-' +
+			String( new Date().getMonth() + 1 ).padStart( 2, '0' );
+		await env.USAGE_KV.put( `usage:${ TEST_TOKEN }:${ month }`, '500' );
+
+		const response = await worker.fetch( makeChatRequest(), env );
+		expect( response.status ).toBe( 429 );
+		const json = ( await response.json() ) as {
+			error: string;
+			used: number;
+			limit: number;
+		};
+		expect( json ).toEqual( {
+			error: 'Rate limit exceeded',
+			used: 500,
+			limit: 500,
+		} );
+	} );
+
+	it( 'allows a request at used = limit-1, then blocks the next one at used = limit', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
+		const month =
+			new Date().getFullYear() +
+			'-' +
+			String( new Date().getMonth() + 1 ).padStart( 2, '0' );
+		const usageKey = `usage:${ TEST_TOKEN }:${ month }`;
+		await env.USAGE_KV.put( usageKey, '99' );
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async () => {
+				return new Response(
+					JSON.stringify( {
+						content: [ { type: 'text', text: 'ok' } ],
+						usage: { input_tokens: 1, output_tokens: 0 },
+					} ),
+					{ status: 200 }
+				);
+			} )
 		);
-		// raw = 150, weight = 5, effective = 750
-		expect( Number( stored ) ).toBe( 750 );
+
+		// used=99 < limit=100 — allowed, charges 1 credit, used becomes 100.
+		const first = await worker.fetch( makeChatRequest(), env );
+		expect( first.status ).toBe( 200 );
+		expect( Number( await env.USAGE_KV.get( usageKey ) ) ).toBe( 100 );
+
+		// used=100 is no longer < limit=100 — blocked.
+		const second = await worker.fetch( makeChatRequest(), env );
+		expect( second.status ).toBe( 429 );
 	} );
 } );

--- a/plume-proxy/test/credits.test.ts
+++ b/plume-proxy/test/credits.test.ts
@@ -1,0 +1,71 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import { describe, it, expect } from 'vitest';
+import {
+	chatCredits,
+	GENERATOR_CREDITS,
+	SEO_CREDITS,
+	IMAGE_CREDITS,
+} from '../src/credits';
+
+describe( 'chatCredits', () => {
+	it( 'returns 1 credit for a minimal non-zero call at weight 1', () => {
+		expect( chatCredits( 1, 0, 1 ) ).toBe( 1 );
+	} );
+
+	it( 'returns the exact integer result when (input+output)*weight is a multiple of 2000', () => {
+		// weight=1: (1000+1000)*1 = 2000 → 1
+		expect( chatCredits( 1000, 1000, 1 ) ).toBe( 1 );
+		// weight=5: (200+200)*5 = 2000 → 1
+		expect( chatCredits( 200, 200, 5 ) ).toBe( 1 );
+	} );
+
+	it( 'rounds up when (input+output)*weight is not a multiple of 2000', () => {
+		// raw=100, weight=3 → 300 → ceil(300/2000) = 1
+		expect( chatCredits( 50, 50, 3 ) ).toBe( 1 );
+	} );
+
+	it( 'rounds up by exactly 1 at a boundary just over an integer multiple', () => {
+		// raw=2001, weight=1 → ceil(2001/2000) = 2
+		expect( chatCredits( 2001, 0, 1 ) ).toBe( 2 );
+	} );
+
+	it( 'weight=1 scales linearly with token count alone', () => {
+		expect( chatCredits( 4000, 0, 1 ) ).toBe( 2 );
+		expect( chatCredits( 8000, 0, 1 ) ).toBe( 4 );
+	} );
+
+	it( 'handles zero tokens — expect 0 credits, not a forced minimum of 1', () => {
+		expect( chatCredits( 0, 0, 1 ) ).toBe( 0 );
+	} );
+
+	it( 'handles a heavy model weight (e.g. weight=10) across a realistic token count', () => {
+		// raw=15000, weight=10 → ceil(150000/2000) = 75
+		expect( chatCredits( 10000, 5000, 10 ) ).toBe( 75 );
+	} );
+
+	it( 'is a pure function — identical inputs always produce identical output', () => {
+		const a = chatCredits( 1234, 567, 3 );
+		const b = chatCredits( 1234, 567, 3 );
+		expect( a ).toBe( b );
+	} );
+
+	it( 'GENERATOR_CREDITS equals 10', () => {
+		expect( GENERATOR_CREDITS ).toBe( 10 );
+	} );
+
+	it( 'SEO_CREDITS equals 1', () => {
+		expect( SEO_CREDITS ).toBe( 1 );
+	} );
+
+	it( 'IMAGE_CREDITS equals 15', () => {
+		expect( IMAGE_CREDITS ).toBe( 15 );
+	} );
+
+	it( 'GENERATOR_CREDITS, SEO_CREDITS, and IMAGE_CREDITS are all positive integers', () => {
+		for ( const value of [ GENERATOR_CREDITS, SEO_CREDITS, IMAGE_CREDITS ] ) {
+			expect( Number.isInteger( value ) ).toBe( true );
+			expect( value ).toBeGreaterThan( 0 );
+		}
+	} );
+} );

--- a/plume-proxy/test/devEndpoints.test.ts
+++ b/plume-proxy/test/devEndpoints.test.ts
@@ -102,7 +102,7 @@ describe( 'authenticateDevRequest', () => {
 	it( 'returns 401 when Authorization header is missing', async () => {
 		const env = makeDevEnv();
 		await seedSite( env );
-		const body = JSON.stringify( { tier: 'trial' } );
+		const body = JSON.stringify( { tier: 'pro_managed' } );
 		const ts = Math.floor( Date.now() / 1000 );
 		const req = new Request( 'https://worker.example.com/dev/set-tier', {
 			method: 'POST',
@@ -120,7 +120,7 @@ describe( 'authenticateDevRequest', () => {
 	it( 'returns 401 when tier_sync_secret is absent from the site record', async () => {
 		const env = makeDevEnv();
 		await seedSite( env, { tier_sync_secret: undefined } );
-		const body = JSON.stringify( { tier: 'trial' } );
+		const body = JSON.stringify( { tier: 'pro_managed' } );
 		const res = await worker.fetch(
 			makeDevRequest( '/dev/set-tier', body ),
 			env,
@@ -132,7 +132,7 @@ describe( 'authenticateDevRequest', () => {
 	it( 'returns 401 when X-Dev-Signature header is missing', async () => {
 		const env = makeDevEnv();
 		await seedSite( env );
-		const body = JSON.stringify( { tier: 'trial' } );
+		const body = JSON.stringify( { tier: 'pro_managed' } );
 		const ts = Math.floor( Date.now() / 1000 );
 		const req = new Request( 'https://worker.example.com/dev/set-tier', {
 			method: 'POST',
@@ -150,7 +150,7 @@ describe( 'authenticateDevRequest', () => {
 	it( 'returns 401 for a malformed (odd-length) hex signature', async () => {
 		const env = makeDevEnv();
 		await seedSite( env );
-		const body = JSON.stringify( { tier: 'trial' } );
+		const body = JSON.stringify( { tier: 'pro_managed' } );
 		const res = await worker.fetch(
 			makeDevRequest( '/dev/set-tier', body, { signature: 'abc' } ),
 			env,
@@ -162,7 +162,7 @@ describe( 'authenticateDevRequest', () => {
 	it( 'returns 401 when the HMAC does not match', async () => {
 		const env = makeDevEnv();
 		await seedSite( env );
-		const body = JSON.stringify( { tier: 'trial' } );
+		const body = JSON.stringify( { tier: 'pro_managed' } );
 		const res = await worker.fetch(
 			makeDevRequest( '/dev/set-tier', body, { secret: 'wrong-secret' } ),
 			env,
@@ -174,7 +174,7 @@ describe( 'authenticateDevRequest', () => {
 	it( 'returns 401 when timestamp is too far in the past (>60 s)', async () => {
 		const env = makeDevEnv();
 		await seedSite( env );
-		const body = JSON.stringify( { tier: 'trial' } );
+		const body = JSON.stringify( { tier: 'pro_managed' } );
 		const oldTs = Math.floor( Date.now() / 1000 ) - 120;
 		const res = await worker.fetch(
 			makeDevRequest( '/dev/set-tier', body, { timestamp: oldTs } ),
@@ -187,7 +187,7 @@ describe( 'authenticateDevRequest', () => {
 	it( 'returns 401 when timestamp is too far in the future (>60 s)', async () => {
 		const env = makeDevEnv();
 		await seedSite( env );
-		const body = JSON.stringify( { tier: 'trial' } );
+		const body = JSON.stringify( { tier: 'pro_managed' } );
 		const futureTs = Math.floor( Date.now() / 1000 ) + 120;
 		const res = await worker.fetch(
 			makeDevRequest( '/dev/set-tier', body, { timestamp: futureTs } ),
@@ -204,7 +204,7 @@ describe( '/dev/set-tier', () => {
 	it( 'returns 200 and updates the tier for a valid request', async () => {
 		const env = makeDevEnv();
 		await seedSite( env, { tier: 'free' } );
-		const body = JSON.stringify( { tier: 'trial' } );
+		const body = JSON.stringify( { tier: 'pro_managed' } );
 		const res = await worker.fetch(
 			makeDevRequest( '/dev/set-tier', body ),
 			env,
@@ -213,19 +213,31 @@ describe( '/dev/set-tier', () => {
 		expect( res.status ).toBe( 200 );
 		const json = ( await res.json() ) as { ok: boolean; tier: string };
 		expect( json.ok ).toBe( true );
-		expect( json.tier ).toBe( 'trial' );
+		expect( json.tier ).toBe( 'pro_managed' );
 
 		const stored = await env.USAGE_KV.get< SiteRecord >(
 			`site:${ TEST_TOKEN }`,
 			'json'
 		);
-		expect( stored?.tier ).toBe( 'trial' );
+		expect( stored?.tier ).toBe( 'pro_managed' );
 	} );
 
 	it( 'returns 400 for an invalid tier string', async () => {
 		const env = makeDevEnv();
 		await seedSite( env );
 		const body = JSON.stringify( { tier: 'super_premium' } );
+		const res = await worker.fetch(
+			makeDevRequest( '/dev/set-tier', body ),
+			env,
+			makeCtx()
+		);
+		expect( res.status ).toBe( 400 );
+	} );
+
+	it( 'returns 400 when tier is "trial" (removed tier rejected by /dev/set-tier validation)', async () => {
+		const env = makeDevEnv();
+		await seedSite( env );
+		const body = JSON.stringify( { tier: 'trial' } );
 		const res = await worker.fetch(
 			makeDevRequest( '/dev/set-tier', body ),
 			env,
@@ -259,7 +271,7 @@ describe( '/dev/set-tier', () => {
 	} );
 
 	it( 'accepts all valid SiteTier values', async () => {
-		const tiers = [ 'free', 'trial', 'pro_managed', 'pro_byok' ] as const;
+		const tiers = [ 'free', 'pro_managed', 'pro_byok' ] as const;
 		for ( const tier of tiers ) {
 			const env = makeDevEnv();
 			await seedSite( env );
@@ -285,7 +297,7 @@ describe( '/dev/reset-usage', () => {
 		const month = `${ now.getFullYear() }-${ String(
 			now.getMonth() + 1
 		).padStart( 2, '0' ) }`;
-		await env.USAGE_KV.put( `usage:${ TEST_TOKEN }:${ month }`, '99999' );
+		await env.USAGE_KV.put( `usage:${ TEST_TOKEN }:${ month }`, '95' );
 
 		const body = '{}';
 		const res = await worker.fetch(
@@ -311,7 +323,7 @@ describe( '/dev/set-usage', () => {
 	it( 'returns 200 and persists the usage value', async () => {
 		const env = makeDevEnv();
 		await seedSite( env );
-		const body = JSON.stringify( { usage: 42000 } );
+		const body = JSON.stringify( { usage: 80 } );
 		const res = await worker.fetch(
 			makeDevRequest( '/dev/set-usage', body ),
 			env,
@@ -320,7 +332,7 @@ describe( '/dev/set-usage', () => {
 		expect( res.status ).toBe( 200 );
 		const json = ( await res.json() ) as { ok: boolean; usage: number };
 		expect( json.ok ).toBe( true );
-		expect( json.usage ).toBe( 42000 );
+		expect( json.usage ).toBe( 80 );
 	} );
 
 	it( 'returns 400 for a negative usage value', async () => {

--- a/plume-proxy/test/devEndpoints.test.ts
+++ b/plume-proxy/test/devEndpoints.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from 'vitest';
 import { createHmac } from 'crypto';
 import worker from '../src/index';
 import { makeEnv } from './helpers/kv-mock';
+import { currentMonthKey } from './helpers/month';
 import type { SiteRecord } from '../src/types';
 
 const TEST_TOKEN =
@@ -293,10 +294,7 @@ describe( '/dev/reset-usage', () => {
 		const env = makeDevEnv();
 		await seedSite( env );
 
-		const now = new Date();
-		const month = `${ now.getFullYear() }-${ String(
-			now.getMonth() + 1
-		).padStart( 2, '0' ) }`;
+		const month = currentMonthKey();
 		await env.USAGE_KV.put( `usage:${ TEST_TOKEN }:${ month }`, '95' );
 
 		const body = '{}';

--- a/plume-proxy/test/helpers/month.ts
+++ b/plume-proxy/test/helpers/month.ts
@@ -1,0 +1,14 @@
+/**
+ * Derives the current month key (`YYYY-MM`) used for usage KV keys, matching
+ * getCurrentMonth() in src/index.ts. Extracted so tests do not re-inline the
+ * same date-formatting snippet across suites.
+ *
+ * @return {string} Current month key in `YYYY-MM` form.
+ */
+export function currentMonthKey(): string {
+	const now = new Date();
+	return `${ now.getFullYear() }-${ String( now.getMonth() + 1 ).padStart(
+		2,
+		'0'
+	) }`;
+}

--- a/plume-proxy/test/registration.test.ts
+++ b/plume-proxy/test/registration.test.ts
@@ -165,7 +165,7 @@ describe( 'handleRegistration', () => {
 		expect( data.error ).toMatch( /site verification failed/i );
 	} );
 
-	it( 'returns 201 and tier=trial for a valid new registration', async () => {
+	it( 'returns 201 and tier=free for a valid new registration', async () => {
 		const challenge = 'c'.repeat( 64 );
 		const env = await makeEnvWithChallenge( challenge );
 		const res = await handleRegistration(
@@ -185,7 +185,7 @@ describe( 'handleRegistration', () => {
 		};
 		expect( typeof data.token ).toBe( 'string' );
 		expect( data.token.length ).toBeGreaterThan( 0 );
-		expect( data.tier ).toBe( 'trial' );
+		expect( data.tier ).toBe( 'free' );
 		// New: secret is returned in response and is a 64-char hex token.
 		expect( data.tier_sync_secret ).toMatch( /^[0-9a-f]{64}$/ );
 
@@ -274,51 +274,6 @@ describe( 'handleRegistration', () => {
 		const data2 = ( await res2.json() ) as { token: string };
 
 		expect( data1.token ).toBe( data2.token );
-	} );
-
-	it( 'idempotent re-registration of an expired trial returns tier=free', async () => {
-		const challenge1 = '1'.repeat( 64 );
-		const env = await makeEnvWithChallenge( challenge1 );
-		const siteUrl = 'https://expired-trial.example.com';
-
-		// Initial registration — creates trial record.
-		const res1 = await handleRegistration(
-			makeRequest( {
-				body: { site_url: siteUrl, challenge_token: challenge1 },
-			} ),
-			env
-		);
-		const { token } = ( await res1.json() ) as { token: string };
-
-		// Backdate trial_started_at by 31 days.
-		const stored = ( await env.USAGE_KV.get<
-			import('../src/types').SiteRecord
-		>( `site:${ token }`, 'json' ) ) as import('../src/types').SiteRecord;
-		const expired = {
-			...stored,
-			trial_started_at: Date.now() - 31 * 24 * 60 * 60 * 1000,
-		};
-		await env.USAGE_KV.put( `site:${ token }`, JSON.stringify( expired ) );
-
-		// Re-register — must come back as free.
-		const challenge2 = '2'.repeat( 64 );
-		await env.USAGE_KV.put( `challenge:${ challenge2 }`, '1' );
-		vi.stubGlobal(
-			'fetch',
-			vi.fn().mockResolvedValue( new Response( '{}', { status: 200 } ) )
-		);
-
-		const res2 = await handleRegistration(
-			makeRequest( {
-				body: { site_url: siteUrl, challenge_token: challenge2 },
-			} ),
-			env
-		);
-		const data2 = ( await res2.json() ) as Record< string, unknown >;
-		expect( data2.token ).toBe( token );
-		expect( data2.tier ).toBe( 'free' );
-		// Secret was already stored on initial registration — must not be re-exposed.
-		expect( data2 ).not.toHaveProperty( 'tier_sync_secret' );
 	} );
 
 	it( 're-registration does not expose tier_sync_secret when it already exists', async () => {


### PR DESCRIPTION
## Summary

- Removes the time-boxed `trial` tier from the Worker entirely. `ProxyTier` is now `'free' | 'pro_managed'`; new registrations land on `free` immediately, no lazy trial-expiry downgrade logic remains.
- Replaces raw-token-based monthly quota enforcement with a per-feature **credits** system (`chat`/`generator`/`seo`/`images`), via a new pure `src/credits.ts` module (`chatCredits()`, `GENERATOR_CREDITS`, `SEO_CREDITS`, `IMAGE_CREDITS`).
- `ProxyRequest.feature` is now a required field — the Worker validates it before any auth/tier/rate-limit work and rejects malformed requests with 400.
- `DEFAULT_TIER_MODELS` / `DEFAULT_MODEL_TOKEN_WEIGHT` updated to the current model line-up (`gpt-4.1`, `gemini-3.5-flash`, `gemini-3.1-pro`, all weighted `2` per owner decision — see `docs/task-5-worker-credits-spec.md` and the implementation plan). `free` tier now has zero OpenAI/Gemini models (tracked separately as issue #856 for `gpt-4.1-nano`).
- `MONTHLY_LIMITS` (tokens) → `MONTHLY_CREDIT_LIMITS` (free=100, pro_managed=500 credits/month). `free` tier's `MAX_TOKENS` bumped from 1,000 → 2,000 to match the plugin's actual Generator request size.
- `getModelForTier()` now throws a typed 400 (not a 500) when a tier has zero allowed models for a provider; `handleChatProxy`'s catch block is now status-aware.
- `src/constants.ts` (sole export `TRIAL_PERIOD_MS`) deleted — no longer referenced anywhere.

This is **Worker-only** (`plume-proxy/**`). No plugin code (`includes/`, `src/` at repo root, `readme.txt`) is touched — that is PR 2 (Task 6), explicitly out of scope here per the implementation plan §0/§7.

Commit type is `refactor(proxy):` (not `feat`/`fix`) deliberately — `.releaserc.json` has no path scoping, so a releasing commit type here would wrongly cut a plugin version bump even though no plugin code changed.

## Test plan

- [x] `npm test` — 10 test files, 105 tests, all passing (was 9 files / 86 tests before this change; net +1 new file (`credits.test.ts`, 12 cases) and net +7 chat-proxy cases after deleting 2 trial-demotion tests and 1 registration idempotent-trial test, adding ~10 new feature/credit/rate-limit cases).
- [x] `npm run typecheck` — clean, zero errors.
- [x] TDD sequencing followed throughout: each test file's failing assertions were confirmed red for the *intended* reason (missing module, old tier literals, old constant names, missing feature validation) before the corresponding production code was written.
- [x] Manual grep confirms zero remaining `trial` literal references in `src/` (only the intentional "trial is rejected" test case remains in `test/devEndpoints.test.ts`).
- [x] `webhook.ts` confirmed untouched — verified via `grep -i trial src/webhook.ts` (zero hits before and after), matching the spec's "confirmed no-op" note.

Per the plan's post-merge gate (§5), production deployment requires a **separate, later** explicit owner go-ahead before `workflow_dispatch` on `release.yml` — not part of this PR's scope. Merging this PR only auto-deploys to the dev Worker (`plume-proxy-dev`) via the existing `deploy-proxy.yml` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #862

Closes #863

Closes #864

Closes #865