### PR TITLE
fix(ci): pass github/inputs context via env, not inline run: interpolation

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,17 +39,21 @@ jobs:
 
       - name: Resolve PR context
         id: pr_context
+        # All ${{...}} values are passed via env to avoid shell-injection paths
+        # (untrusted github/inputs context must never be interpolated into run:).
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER_INPUT: ${{ github.event.pull_request.number || inputs.pr_number }}
+          REPO: ${{ github.repository }}
         run: |
           # For pull_request events the number comes from the event payload.
           # For workflow_dispatch it must be supplied via the pr_number input.
-          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          PR_NUMBER="$PR_NUMBER_INPUT"
           if [[ -z "$PR_NUMBER" ]]; then
             echo "::error::No PR number available. Supply pr_number when triggering manually."
             exit 1
           fi
-          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}")
+          PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
           echo "pr_number=${PR_NUMBER}"                          >> "$GITHUB_OUTPUT"
           echo "pr_url=$(echo "$PR_JSON"    | jq -r '.html_url')" >> "$GITHUB_OUTPUT"
           echo "base_ref=$(echo "$PR_JSON"  | jq -r '.base.ref')" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fixes a Semgrep finding (`yaml.github-actions.security.run-shell-injection`) on the "Resolve PR context" step in `.github/workflows/claude-code-review.yml`: untrusted `github`/`inputs` context was interpolated directly into a `run:` shell block instead of through an `env:` var.
- Pre-existing since #838 — not introduced by, and unrelated to, #861. It surfaced on that PR's CI run only because Semgrep scans the whole repo on every PR, not just the diff.
- Applies the same `env:`-passthrough pattern already used later in this same file (the `repository_dispatch` step, see its existing comment "All `${{...}}` values are passed via env to avoid shell-injection paths") to this step too.

## Test plan
- [x] `semgrep scan --config=p/php --config=p/security-audit --config=p/owasp-top-ten --severity=ERROR --metrics=off` — 0 findings (was 1 blocking before this change)
- [x] YAML parses correctly
- [ ] CI's own Semgrep job goes green on this PR (will confirm once checks run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)