### PR TITLE
fix(chat): token usage in REST response, single-use tool guard, and tool-definition caching

### DIFF
--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -401,6 +401,8 @@ class ChatRestController {
 					}
 				}
 
+				$tools = $this->strip_single_use_tools( $tools, $provider_slug, $tools_called );
+
 				// If the model included chat_response, use its message as the final text and exit.
 				if ( null !== $chat_response_tu ) {
 					$final_response = $response->with_text( $chat_response_tu['input']['message'] ?? '' );
@@ -434,12 +436,14 @@ class ChatRestController {
 
 			return rest_ensure_response(
 				[
-					'content'      => $final_response->content,
-					'model'        => $final_response->model,
-					'credits'      => $final_response->credits_charged,
-					'cost_usd'     => $final_response->cost_usd,
-					'pending_plan' => $pending_plan,
-					'tools_called' => \array_values( \array_unique( $tools_called ) ),
+					'content'           => $final_response->content,
+					'model'             => $final_response->model,
+					'credits'           => $final_response->credits_charged,
+					'cost_usd'          => $final_response->cost_usd,
+					'prompt_tokens'     => $final_response->prompt_tokens,
+					'completion_tokens' => $final_response->completion_tokens,
+					'pending_plan'      => $pending_plan,
+					'tools_called'      => \array_values( \array_unique( $tools_called ) ),
 				]
 			);
 		} catch ( ProviderException $e ) {
@@ -645,6 +649,62 @@ class ChatRestController {
 	}
 
 	// ── Private helpers ───────────────────────────────────────────────────────
+
+	/**
+	 * Removes single-use write tools from the tool list once they've been called.
+	 *
+	 * Both plan_post and plan_update instruct the model "do not call again" in their
+	 * descriptions, and the agentic loop above already breaks via $pending_plan when
+	 * either returns a pending_approval result. This is a defensive second layer: if a
+	 * call to either tool ever returns a non-pending_approval result (e.g. an error),
+	 * the loop does not break, and without this filter the tool would remain available
+	 * for the model to call again, risking a duplicate approval card. Data-gathering
+	 * tools (get_recent_posts, get_post_content, search_posts, get_pages, get_site_info)
+	 * are deliberately never stripped — PR #792 did that and #803 reverted it because it
+	 * broke multi-step sequential chains such as get_recent_posts -> get_post_content -> plan_update.
+	 *
+	 * @since NEXT_VERSION
+	 * @param array<int, array<string, mixed>> $tools         Provider-formatted tool list.
+	 * @param string                           $provider_slug Provider slug ('claude', 'openai', 'gemini', 'proxy').
+	 * @param string[]                         $tools_called  Tool names called so far this request.
+	 * @return array<int, array<string, mixed>> Filtered tool list.
+	 */
+	private function strip_single_use_tools( array $tools, string $provider_slug, array $tools_called ): array {
+		$single_use = array_intersect( [ 'plan_post', 'plan_update' ], $tools_called );
+		if ( empty( $single_use ) || empty( $tools ) ) {
+			return $tools;
+		}
+
+		if ( 'gemini' === $provider_slug ) {
+			if ( empty( $tools[0]['functionDeclarations'] ) ) {
+				return $tools;
+			}
+			$tools[0]['functionDeclarations'] = array_values(
+				array_filter(
+					$tools[0]['functionDeclarations'],
+					static fn( array $decl ): bool => ! in_array( $decl['name'] ?? '', $single_use, true )
+				)
+			);
+			return $tools;
+		}
+
+		if ( 'openai' === $provider_slug ) {
+			return array_values(
+				array_filter(
+					$tools,
+					static fn( array $t ): bool => ! in_array( $t['function']['name'] ?? '', $single_use, true )
+				)
+			);
+		}
+
+		// claude and proxy both key tool names at the top level.
+		return array_values(
+			array_filter(
+				$tools,
+				static fn( array $t ): bool => ! in_array( $t['name'] ?? '', $single_use, true )
+			)
+		);
+	}
 
 	/**
 	 * Extract every tool call from a provider response in a normalised shape.

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -670,7 +670,7 @@ class ChatRestController {
 	 * @return array<int, array<string, mixed>> Filtered tool list.
 	 */
 	private function strip_single_use_tools( array $tools, string $provider_slug, array $tools_called ): array {
-		$single_use = array_intersect( [ 'plan_post', 'plan_update' ], $tools_called );
+		$single_use = array_intersect( \Plume\Tools\ToolRegistry::SINGLE_USE_TOOLS, $tools_called );
 		if ( empty( $single_use ) || empty( $tools ) ) {
 			return $tools;
 		}

--- a/includes/Providers/ClaudeProvider.php
+++ b/includes/Providers/ClaudeProvider.php
@@ -328,6 +328,29 @@ class ClaudeProvider extends AbstractProvider {
 	}
 
 	/**
+	 * Marks the tools array for prompt caching.
+	 *
+	 * Anthropic caches everything up to and including the tool carrying cache_control
+	 * as a single prefix, mirroring how build_system_field() caches the system prompt.
+	 * Below Anthropic's per-model minimum (1,024 tokens for Sonnet 5) the API simply
+	 * skips caching rather than erroring, so no size gate is needed here: the agentic
+	 * loop in ChatRestController re-sends the full tool list on every iteration, and
+	 * tool definitions routinely exceed the minimum on their own.
+	 *
+	 * @since NEXT_VERSION
+	 * @param array<int, array<string, mixed>> $tools Claude-wire-format tool definitions.
+	 * @return array<int, array<string, mixed>> Tools with cache_control on the last entry.
+	 */
+	private function apply_tools_cache_control( array $tools ): array {
+		if ( empty( $tools ) ) {
+			return $tools;
+		}
+		$last                            = array_key_last( $tools );
+		$tools[ $last ]['cache_control'] = [ 'type' => 'ephemeral' ];
+		return $tools;
+	}
+
+	/**
 	 * Build the Anthropic API request body from a completion request.
 	 *
 	 * @since 1.0.0
@@ -344,7 +367,8 @@ class ClaudeProvider extends AbstractProvider {
 			$body['system'] = $this->build_system_field( $request->system );
 		}
 		if ( ! empty( $request->tools ) ) {
-			$body['tools'] = $request->tools; // Already in Claude wire format from ToolRegistry.
+			// Already in Claude wire format from ToolRegistry; cache_control added here.
+			$body['tools'] = $this->apply_tools_cache_control( $request->tools );
 			if ( $request->force_tool_use ) {
 				$body['tool_choice'] = [ 'type' => 'any' ];
 			}

--- a/includes/Tools/ToolRegistry.php
+++ b/includes/Tools/ToolRegistry.php
@@ -19,6 +19,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 class ToolRegistry {
 
 	/**
+	 * Write tools that may only be invoked once per conversation turn.
+	 *
+	 * Single source of truth shared by the registry, the executor dispatch map,
+	 * and ChatRestController's strip guard so a rename cannot silently desync the
+	 * guard from the tools it is meant to remove after first use.
+	 *
+	 * @since NEXT_VERSION
+	 * @var string[]
+	 */
+	public const SINGLE_USE_TOOLS = [ 'plan_post', 'plan_update' ];
+
+	/**
 	 * All registered tool definitions.
 	 *
 	 * @var ToolDefinition[]

--- a/includes/Tools/ToolRegistry.php
+++ b/includes/Tools/ToolRegistry.php
@@ -21,9 +21,9 @@ class ToolRegistry {
 	/**
 	 * Write tools that may only be invoked once per conversation turn.
 	 *
-	 * Single source of truth shared by the registry, the executor dispatch map,
-	 * and ChatRestController's strip guard so a rename cannot silently desync the
-	 * guard from the tools it is meant to remove after first use.
+	 * Consumed by ChatRestController's strip guard; defined here beside the tool
+	 * definitions so a plan-tool rename cannot silently desync the guard from the
+	 * tools it removes after first use.
 	 *
 	 * @since NEXT_VERSION
 	 * @var string[]

--- a/plume-proxy/src/index.ts
+++ b/plume-proxy/src/index.ts
@@ -99,11 +99,16 @@ async function getModelConfig( env: Env ): Promise< {
 	};
 }
 
+// Anthropic caches everything up to and including the tool carrying cache_control
+// as a single prefix, so marking only the last tool covers the whole array.
 function toClaudeTools( tools: ToolParam[] ) {
-	return tools.map( ( t ) => ( {
+	return tools.map( ( t, i ) => ( {
 		name: t.name,
 		description: t.description,
 		input_schema: t.parameters,
+		...( i === tools.length - 1
+			? { cache_control: { type: 'ephemeral' as const } }
+			: {} ),
 	} ) );
 }
 

--- a/plume-proxy/test/chat-proxy.test.ts
+++ b/plume-proxy/test/chat-proxy.test.ts
@@ -159,7 +159,52 @@ describe( 'handleChatProxy', () => {
 				properties: { post_id: { type: 'integer' } },
 				required: [ 'post_id' ],
 			},
+			cache_control: { type: 'ephemeral' },
 		} );
+	} );
+
+	it( 'Claude adapter: marks only the last tool with cache_control', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
+		const secondTool: ToolParam = {
+			name: 'get_recent_posts',
+			description: 'List recent posts',
+			parameters: { type: 'object', properties: {} },
+		};
+
+		let capturedBody: Record< string, unknown > | null = null;
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockImplementation(
+					async ( _url: string, init: RequestInit ) => {
+						capturedBody = JSON.parse( init.body as string );
+						return new Response(
+							JSON.stringify( {
+								content: [ { type: 'text', text: 'Summary' } ],
+								usage: { input_tokens: 10, output_tokens: 5 },
+							} ),
+							{ status: 200 }
+						);
+					}
+				)
+		);
+
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Summarise post 140' } ],
+			provider: 'claude',
+			tools: [ mockTool, secondTool ],
+			feature: 'chat',
+		} );
+
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		expect( response.status ).toBe( 200 );
+
+		const sentTools = ( capturedBody as Record< string, unknown > )
+			.tools as Array< Record< string, unknown > >;
+		expect( sentTools ).toHaveLength( 2 );
+		expect( sentTools[ 0 ] ).not.toHaveProperty( 'cache_control' );
+		expect( sentTools[ 1 ].cache_control ).toEqual( { type: 'ephemeral' } );
 	} );
 
 	it( 'Claude adapter: relays tool_call when Claude returns a tool_use block', async () => {

--- a/src/admin/dashboard/StatusBanner.jsx
+++ b/src/admin/dashboard/StatusBanner.jsx
@@ -32,7 +32,9 @@ export default function StatusBanner( { bannerState, urls } ) {
 					</>
 				) : (
 					<>
-						<strong>You're running low on free credits.</strong>
+						<strong>
+							You&apos;re running low on free credits.
+						</strong>
 						<span>
 							{ ' ' }
 							Add your own key for unlimited access, or upgrade to

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -564,6 +564,8 @@ class ChatRestControllerTest extends TestCase {
         $this->assertInstanceOf( \WP_REST_Response::class, $response );
         $this->assertSame( 200, $response->get_status() );
         $this->assertSame( 'Final answer', $response->data['content'] );
+        $this->assertSame( 20, $response->data['prompt_tokens'] );
+        $this->assertSame( 15, $response->data['completion_tokens'] );
     }
 
     public function test_send_message_returns_429_with_retry_after_header_on_rate_limit(): void {
@@ -1733,5 +1735,103 @@ class ChatRestControllerTest extends TestCase {
         $item = $response->data[0];
         $this->assertArrayHasKey( 'edit_link', $item );
         $this->assertSame( '', $item['edit_link'], 'edit_link must fall back to empty string when the user cannot edit the post.' );
+    }
+
+    // ── strip_single_use_tools ───────────────────────────────────────────────
+
+    /**
+     * Call the private strip_single_use_tools method via reflection.
+     */
+    private function call_strip_single_use_tools( array $tools, string $provider_slug, array $tools_called ): array {
+        $method = new \ReflectionMethod( ChatRestController::class, 'strip_single_use_tools' );
+        $method->setAccessible( true );
+        $controller = new ChatRestController( $this->tool_registry, $this->tool_executor );
+        return $method->invoke( $controller, $tools, $provider_slug, $tools_called );
+    }
+
+    public function test_strip_single_use_tools_removes_plan_post_from_claude_format(): void {
+        $tools = [
+            [ 'name' => 'get_recent_posts', 'description' => '...' ],
+            [ 'name' => 'plan_post', 'description' => '...' ],
+        ];
+
+        $result = $this->call_strip_single_use_tools( $tools, 'claude', [ 'plan_post' ] );
+
+        $this->assertCount( 1, $result );
+        $this->assertSame( 'get_recent_posts', $result[0]['name'] );
+    }
+
+    public function test_strip_single_use_tools_removes_plan_update_from_proxy_format(): void {
+        $tools = [
+            [ 'name' => 'plan_update', 'description' => '...' ],
+            [ 'name' => 'get_site_info', 'description' => '...' ],
+        ];
+
+        $result = $this->call_strip_single_use_tools( $tools, 'proxy', [ 'plan_update' ] );
+
+        $this->assertCount( 1, $result );
+        $this->assertSame( 'get_site_info', $result[0]['name'] );
+    }
+
+    public function test_strip_single_use_tools_removes_plan_post_from_openai_format(): void {
+        $tools = [
+            [ 'type' => 'function', 'function' => [ 'name' => 'plan_post' ] ],
+            [ 'type' => 'function', 'function' => [ 'name' => 'search_posts' ] ],
+        ];
+
+        $result = $this->call_strip_single_use_tools( $tools, 'openai', [ 'plan_post' ] );
+
+        $this->assertCount( 1, $result );
+        $this->assertSame( 'search_posts', $result[0]['function']['name'] );
+    }
+
+    public function test_strip_single_use_tools_removes_plan_update_from_gemini_format(): void {
+        $tools = [
+            [
+                'functionDeclarations' => [
+                    [ 'name' => 'plan_update' ],
+                    [ 'name' => 'get_pages' ],
+                ],
+            ],
+        ];
+
+        $result = $this->call_strip_single_use_tools( $tools, 'gemini', [ 'plan_update' ] );
+
+        $this->assertCount( 1, $result[0]['functionDeclarations'] );
+        $this->assertSame( 'get_pages', $result[0]['functionDeclarations'][0]['name'] );
+    }
+
+    public function test_strip_single_use_tools_never_removes_data_gathering_tools(): void {
+        // Regression guard for #803: stripping data-gathering tools breaks multi-step
+        // sequential chains like get_recent_posts -> get_post_content -> plan_update.
+        $tools = [
+            [ 'name' => 'get_recent_posts', 'description' => '...' ],
+            [ 'name' => 'get_post_content', 'description' => '...' ],
+            [ 'name' => 'search_posts', 'description' => '...' ],
+            [ 'name' => 'get_pages', 'description' => '...' ],
+            [ 'name' => 'get_site_info', 'description' => '...' ],
+            [ 'name' => 'plan_post', 'description' => '...' ],
+        ];
+
+        $result = $this->call_strip_single_use_tools( $tools, 'claude', [ 'get_recent_posts', 'get_post_content', 'plan_post' ] );
+
+        $names = array_column( $result, 'name' );
+        $this->assertContains( 'get_recent_posts', $names );
+        $this->assertContains( 'get_post_content', $names );
+        $this->assertContains( 'search_posts', $names );
+        $this->assertContains( 'get_pages', $names );
+        $this->assertContains( 'get_site_info', $names );
+        $this->assertNotContains( 'plan_post', $names );
+    }
+
+    public function test_strip_single_use_tools_returns_unchanged_when_nothing_called(): void {
+        $tools = [
+            [ 'name' => 'get_recent_posts', 'description' => '...' ],
+            [ 'name' => 'plan_post', 'description' => '...' ],
+        ];
+
+        $result = $this->call_strip_single_use_tools( $tools, 'claude', [ 'get_recent_posts' ] );
+
+        $this->assertCount( 2, $result );
     }
 }

--- a/tests/Unit/Providers/ClaudeProviderTest.php
+++ b/tests/Unit/Providers/ClaudeProviderTest.php
@@ -514,6 +514,58 @@ class ClaudeProviderTest extends TestCase {
 		$this->assertIsString( $result );
 	}
 
+	public function test_apply_tools_cache_control_marks_last_tool(): void {
+		$provider = new ClaudeProvider( 'sk-ant-test' );
+		$method   = new \ReflectionMethod( $provider, 'apply_tools_cache_control' );
+		$tools    = [
+			[ 'name' => 'get_recent_posts', 'description' => '...', 'input_schema' => [] ],
+			[ 'name' => 'plan_post', 'description' => '...', 'input_schema' => [] ],
+		];
+
+		$result = $method->invoke( $provider, $tools );
+
+		$this->assertArrayNotHasKey( 'cache_control', $result[0] );
+		$this->assertSame( [ 'type' => 'ephemeral' ], $result[1]['cache_control'] );
+	}
+
+	public function test_apply_tools_cache_control_returns_empty_array_unchanged(): void {
+		$provider = new ClaudeProvider( 'sk-ant-test' );
+		$method   = new \ReflectionMethod( $provider, 'apply_tools_cache_control' );
+
+		$result = $method->invoke( $provider, [] );
+
+		$this->assertSame( [], $result );
+	}
+
+	public function test_build_body_adds_cache_control_to_last_tool(): void {
+		$provider = new ClaudeProvider( 'sk-ant-test' );
+		$method   = new \ReflectionMethod( $provider, 'build_body' );
+		$request  = new CompletionRequest(
+			[ [ 'role' => 'user', 'content' => 'hi' ] ],
+			tools: [
+				[ 'name' => 'get_recent_posts', 'description' => '...', 'input_schema' => [] ],
+				[ 'name' => 'plan_post', 'description' => '...', 'input_schema' => [] ],
+			],
+			force_tool_use: true,
+		);
+
+		$body = $method->invoke( $provider, $request );
+
+		$this->assertArrayNotHasKey( 'cache_control', $body['tools'][0] );
+		$this->assertSame( [ 'type' => 'ephemeral' ], $body['tools'][1]['cache_control'] );
+		$this->assertSame( [ 'type' => 'any' ], $body['tool_choice'] );
+	}
+
+	public function test_build_body_omits_tools_key_when_no_tools(): void {
+		$provider = new ClaudeProvider( 'sk-ant-test' );
+		$method   = new \ReflectionMethod( $provider, 'build_body' );
+		$request  = new CompletionRequest( [ [ 'role' => 'user', 'content' => 'hi' ] ] );
+
+		$body = $method->invoke( $provider, $request );
+
+		$this->assertArrayNotHasKey( 'tools', $body );
+	}
+
 	public function test_complete_parses_cache_tokens_in_response(): void {
 		Functions\when( 'wp_remote_post' )->justReturn( [
 			'response' => [ 'code' => 200 ],
@@ -606,6 +658,8 @@ class ClaudeProviderTest extends TestCase {
 		$provider->complete( $request );
 
 		$this->assertArrayHasKey( 'tools', $captured_body );
-		$this->assertSame( $tools, $captured_body['tools'] );
+		$this->assertSame( 'get_recent_posts', $captured_body['tools'][0]['name'] );
+		$this->assertSame( 'Fetches recent posts.', $captured_body['tools'][0]['description'] );
+		$this->assertSame( [ 'type' => 'ephemeral' ], $captured_body['tools'][0]['cache_control'] );
 	}
 }


### PR DESCRIPTION
## Summary

Three related fixes to the chat agentic loop's token efficiency (Group D triage):

- **#826 — Per-request token usage**: `ChatRestController::send_message()`'s REST response now includes `prompt_tokens` and `completion_tokens` alongside the existing `credits`/`cost_usd` fields.
- **#825 — Single-use write tool guard**: `plan_post` and `plan_update` are now stripped from the tool list (across all four provider wire formats: Claude, OpenAI, Gemini, proxy) once either has been called in the current agentic loop. This is a defensive second layer behind the existing `pending_plan` break — it only matters if a call to either tool ever returns something other than `pending_approval`. Data-gathering tools (`get_recent_posts`, `get_post_content`, `search_posts`, `get_pages`, `get_site_info`) are deliberately **not** touched, per the #803 regression this must not repeat.
- **#855 — Tool definition token cost**: adds `cache_control` to the last tool in the Claude-bound tools array, so Anthropic caches the whole tool-definitions prefix. The agentic loop re-sends the full tool array on every iteration (up to 5 per message); this cuts the input-token cost of iterations 2+ by ~90% on a cache hit, and the benefit scales automatically as the tool count grows (currently 9, with plugin/theme/WooCommerce tools planned). Covers both the direct BYOK path (`ClaudeProvider::build_body()`) and the free/pro_managed path (`plume-proxy/src/index.ts`'s `toClaudeTools()`).

### Research note on #855

Per the original issue's research-first requirement: I evaluated Anthropic's "Tool Search Tool" (`tool_search_tool_regex_20251119`/`_bm25_20251119`, GA) as the architecture for scaling to 30-50 tools via on-demand `defer_loading`. Per Anthropic's own stated guidance, it's the right fit at 10+ tools or once definitions exceed ~10k tokens or selection accuracy measurably drops — none of which is true yet at today's 9 tools. Building it now, against a tool roadmap with no concrete WooCommerce/plugin/theme tools yet, would be speculative. This PR ships the caching fix (low-risk, immediate, scales with tool count) and leaves Tool Search Tool as a deliberate follow-up once the tool count actually grows.

### Note on `plume-proxy`

`plume-proxy/` is a Cloudflare Worker living in this same repo (not a submodule — only `.agents` is). It deploys independently via `wrangler.toml`/`wrangler deploy`; merging this PR does not redeploy it automatically. Flagging in case a coordinated deploy step is needed.

## Test plan

- [x] `./vendor/bin/phpunit tests/Unit/` — 433 tests pass (1 pre-existing, unrelated warning in `SeoModule`)
- [x] `./vendor/bin/phpcs --standard=phpcs.xml.dist` on all changed PHP files — clean
- [x] `./vendor/bin/phpstan analyse` on all changed PHP files — no errors
- [x] `npx vitest run` in `plume-proxy/` — 111 tests pass
- [x] `npm run typecheck` in `plume-proxy/` — clean
- [ ] Real Integration test (`tests/RealIntegration/Chat/RealChatTest.php`, BYOK path) — recommend running with `CLAUDE_API_KEY` set to confirm `cache_read_input_tokens > 0` on iteration 2+ of a real multi-tool-call exchange

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jrz7haF6A55muZ55q8CEQg)_

Closes #903