### PR TITLE
ci(workflows): skip real-integration on synchronize pushes

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -596,12 +596,20 @@ jobs:
   # Makes live Anthropic API calls and real proxy requests.
   # Each test class skips (not fails) when the required secret is absent.
   # Tier-gating tests need no secrets — they run unconditionally.
+  #
+  # Skips `synchronize` (every push) — each run spends real credits against the
+  # CI site token's monthly Worker-side quota (free tier = 100/month), and the
+  # token was getting exhausted after ~8 pushes/month. Still runs on
+  # opened/reopened/ready_for_review. Other jobs in this workflow are unaffected
+  # and keep running on synchronize as normal.
   real-integration:
     name: Real Integration — live Anthropic API
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: changes
-    if: needs.changes.outputs.php == 'true' || needs.changes.outputs.proxy == 'true'
+    if: |
+      (needs.changes.outputs.php == 'true' || needs.changes.outputs.proxy == 'true')
+      && github.event.action != 'synchronize'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 


### PR DESCRIPTION
## Summary

- `real-integration` (`Real Integration — live Anthropic API`) was failing on most PR pushes with `502`/`500` errors and `"Monthly usage limit reached."`
- Root cause: `RealProxyFeatureTest` pins the CI's shared `PLUME_CI_SITE_TOKEN` to the `free` tier and burns ~12 credits per run against the Cloudflare Worker's real, server-side monthly quota (`MONTHLY_CREDIT_LIMITS.free = 100`, `plume-proxy/src/index.ts:873-876`). At 100 credits/month, that's ~8 pushes before the token is exhausted for the rest of the month.
- This is a **regression**, not a long-standing bug: commit `aa32e79` (13 Jun) deliberately dropped `synchronize` from `pr-checks.yml`'s `pull_request.types` to stop the whole suite running on every push. Commit `3fd2995` (30 Jun, an unrelated admin-notices PR) incidentally re-added `synchronize`, silently reopening the quota-exhaustion problem for `real-integration`.
- Fix: restrict `real-integration`'s `if:` condition to exclude `github.event.action == 'synchronize'`, so it still runs on `opened`/`reopened`/`ready_for_review` but skips routine pushes. All other jobs in the workflow (`phpstan`, `security`, `e2e`, etc.) are untouched and keep running on every push as before. No job depends on `real-integration`'s output, so this is safe to gate independently.

### Correction to an earlier (unverified) diagnosis
A prior investigation assumed `RealTierGatingTest` also draws from the same shared CI token's credit pool. Re-checking the code: it does **not** — it never sets `PLUME_CI_SITE_TOKEN`/the site token option, and its assertions only check permission-gate status codes (never reaching the Worker with a valid token). No action needed there; noted for the record.

### Deliberately not included in this PR
An earlier draft also proposed a CI step that calls the Worker's `/rotate-secret` then `/dev/set-tier` on every run to bump the CI token to `pro_managed` (500 credits/month). This is **not** included here:
- `/dev/set-tier` only exists when `DEV_ENDPOINTS_ENABLED=1`, which `plume-proxy/wrangler.toml` scopes explicitly to the `plume-proxy-dev` deployment ("Used by localhost (Docker) and staging4 installs only" — CI is not on that list). The production Worker returns 404 on `/dev/*` regardless of auth. If CI's `PLUME_PROXY_URL` secret points at production (which the docs/naming suggest), this step would 404 and hard-fail the job every run.
- `/rotate-secret` also isn't idempotent — every call invalidates the previous `tier_sync_secret` — so doing this on every run is unnecessary churn for something that only needs to happen once.
- This requires a production KV write with Cloudflare/`wrangler` credentials outside the scope of this PR.

**Manual one-time follow-up (needs someone with `wrangler`/Cloudflare access to the `plume-proxy` Worker):**
```bash
cd plume-proxy
# Inspect the current record for the CI site token:
wrangler kv key get --binding=USAGE_KV "site:<PLUME_CI_SITE_TOKEN value>" --remote
# (use --env dev instead of --remote if CI's PLUME_PROXY_URL actually points at plume-proxy-dev)

# Edit the JSON's "tier" field to "pro_managed", then write it back:
wrangler kv key put --binding=USAGE_KV "site:<PLUME_CI_SITE_TOKEN value>" '<edited JSON>' --remote
```
Bumping the token to `pro_managed` (500/month) gives extra headroom on top of the `synchronize` skip in this PR.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses cleanly
- [ ] After merge, confirm `real-integration` is skipped on a `synchronize` push to an existing PR, while other jobs (`phpstan`, `security`, etc.) still run
- [ ] Confirm `real-integration` still runs on PR `opened`/`ready_for_review` when `php`/`proxy` paths are touched


---
_Generated by [Claude Code](https://claude.ai/code/session_01WdN6SLJWSwcuVync4Z8g7P)_