### PR TITLE
docs(readme): correct managed proxy service URL to plumewp.workers.dev

### DIFF
--- a/plume-proxy/README.md
+++ b/plume-proxy/README.md
@@ -8,7 +8,7 @@ token limits via KV, and forwards to Anthropic.
 
 ```php
 // URL of the deployed Worker (or set via WP Admin → Plume Settings)
-define( 'PLUME_PROXY_URL', 'https://plume-proxy.plume.workers.dev' );
+define( 'PLUME_PROXY_URL', 'https://plume-proxy.plumewp.workers.dev' );
 ```
 
 ## First-time setup

--- a/readme.txt
+++ b/readme.txt
@@ -54,7 +54,7 @@ chosen provider. Review each provider's privacy policy and terms of service befo
 * OpenAI: https://openai.com/policies/privacy-policy
 * Google Gemini: https://policies.google.com/privacy
 * Ollama is self-hosted; no external transmission occurs when using Ollama.
-* **Plume AI - Write and Design** (`https://plume-proxy.plume.workers.dev`): Free and managed-pro
+* **Plume AI - Write and Design** (`https://plume-proxy.plumewp.workers.dev`): Free and managed-pro
   tiers route chat requests through this service. The service receives your
   site URL (for registration) and the chat messages you send. No messages are stored
   beyond the in-flight API call. See: https://wpaimind.com/privacy-policy


### PR DESCRIPTION
## Summary

The wp.org submission review requires external services to be accurately documented (Guideline 6). `readme.txt` documented the managed proxy as `plume-proxy.plume.workers.dev`, but the plugin actually connects to `plume-proxy.plumewp.workers.dev` (`TierConfig::DEFAULT_PROXY_URL`, `includes/Tiers/TierConfig.php:42`). This corrects the documented endpoint in `readme.txt` and the same stale URL in `plume-proxy/README.md`.

Part of the wp.org resubmission fixes (see #831/#832 review context).

## Test plan

- Documentation-only change; no runtime surface.
- `grep -rn "plume.workers.dev" readme.txt plume-proxy/README.md` returns no matches; both files now name `plume-proxy.plumewp.workers.dev`, matching `TierConfig::DEFAULT_PROXY_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsXCRQvxVyPXaW9TWvrzdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsXCRQvxVyPXaW9TWvrzdX)_