### PR TITLE
fix(core): align plugin header name with readme display name

### DIFF
--- a/plume.php
+++ b/plume.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name:       Plume
+ * Plugin Name:       Plume AI - Write and Design
  * Plugin URI:        https://wpaimind.com
  * Description:       AI-powered writing, image generation, and content design tools for WordPress.
  * Version:           1.10.3


### PR DESCRIPTION
## Summary

The wp.org review noted the plugin header name ("Plume", `plume.php`) differs from the readme display name ("Plume AI - Write and Design") and that "the dashboard name is also much broader and shorter than the directory name, which increases the chance of confusion." This aligns the `Plugin Name:` header with the readme display name so both surfaces present the same name. One-line change; the slug/text domain (`plume`) is untouched.

Part of the wp.org resubmission fixes (#829 context — the trademark finding itself is being contested by email; this only resolves the header/readme mismatch).

## Test plan

- `grep "Plugin Name" plume.php` → `Plume AI - Write and Design`, matching readme.txt line 1.
- No code paths read the display name; semantic-release's `prepareCmd` only rewrites the `Version:` line, unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsXCRQvxVyPXaW9TWvrzdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsXCRQvxVyPXaW9TWvrzdX)_