### PR TITLE
fix(tests): match typographic apostrophe in out-of-credits message

### DIFF
--- a/tests/js/ImagesWorkArea.test.jsx
+++ b/tests/js/ImagesWorkArea.test.jsx
@@ -92,7 +92,7 @@ describe( 'ImagesWorkArea — out-of-credits handling', () => {
 			container.querySelector( '.plume-out-of-credits-banner' )
 		).not.toBeNull();
 		expect( container.textContent ).toContain(
-			"You've used all your credits for this billing period."
+			'You’ve used all your credits for this billing period.'
 		);
 	} );
 

--- a/tests/js/OutOfCreditsNotice.test.jsx
+++ b/tests/js/OutOfCreditsNotice.test.jsx
@@ -37,7 +37,7 @@ describe( 'OutOfCreditsNotice', () => {
 		} );
 
 		expect( container.textContent ).toContain(
-			"You've used all your credits for this billing period."
+			'You’ve used all your credits for this billing period.'
 		);
 	} );
 


### PR DESCRIPTION
## Summary

- `OutOfCreditsNotice.jsx` (introduced in #869) renders the message with a typographic apostrophe (`You’ve`), but `OutOfCreditsNotice.test.jsx` and `ImagesWorkArea.test.jsx` assert a straight apostrophe (`You've`), so both have been failing since #869 merged.
- Fixed the tests to match the component's (correct, British-English-style) typography rather than changing the source string.

Found while rebasing #828 onto latest `main` — unrelated to that feature, split out here to keep it a clean, independent fix.

## Test plan

- [x] `npx jest tests/js/OutOfCreditsNotice.test.jsx tests/js/ImagesWorkArea.test.jsx` — 5/5 pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01THAHXfjovuL926tqWJUBiU)_