### PR TITLE
fix(credits): bill every successful agentic-loop call on real usage (closes #927, closes #905)

### DIFF
--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -318,6 +318,10 @@ class ChatRestController {
 	 *                           429 with a `Retry-After` header (seconds until next month UTC) on
 	 *                           provider rate-limit; 502 when the provider returns 401/403; 500 on
 	 *                           other provider errors or iteration-limit breach.
+	 * @throws ProviderException Re-thrown mid-loop when the Worker's quota is exhausted with no
+	 *                           prior successful iteration to gracefully finish with; caught by
+	 *                           the outer try/catch in this same method, which maps it to a
+	 *                           response rather than letting it escape.
 	 */
 	public function send_message( \WP_REST_Request $request ): \WP_REST_Response {
 		$conv_id        = (int) $request->get_param( 'id' );
@@ -536,9 +540,19 @@ class ChatRestController {
 			}
 
 			if ( null === $final_response ) {
+				if ( null === $last_successful_response ) {
+					// Unreachable in practice — MAX_TOOL_ITERATIONS > 0 guarantees at least one
+					// successful iteration completes before this fallback can be reached — but
+					// guards against a fatal error if that invariant is ever violated, and lets
+					// static analysis prove $last_successful_response is non-null below.
+					return new \WP_REST_Response(
+						[ 'message' => __( 'The assistant was unable to complete this request.', 'plume' ) ],
+						500
+					);
+				}
 				// Substitute a displayable message so the chat UI receives a 200 rather than crashing on 500.
 				$limit_message  = \__( 'The assistant reached the maximum number of steps without finishing. Please try rephrasing your request or breaking it into smaller tasks.', 'plume' );
-				$final_response = $response->with_text( $limit_message );
+				$final_response = $last_successful_response->with_text( $limit_message );
 			}
 
 			// Log the sum of the Worker's per-iteration charges exactly once per user message,

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -406,13 +406,15 @@ class ChatRestController {
 				? $this->tool_registry->get_for_provider( $provider_slug )
 				: [];
 
-			$max_iterations       = self::MAX_TOOL_ITERATIONS;
-			$iteration            = 0;
-			$final_response       = null;
-			$pending_plan         = null;
-			$pending_plan_message = '';
-			$tools_called         = [];
-			$force_submit_content = false;
+			$max_iterations           = self::MAX_TOOL_ITERATIONS;
+			$iteration                = 0;
+			$final_response           = null;
+			$pending_plan             = null;
+			$pending_plan_message     = '';
+			$tools_called             = [];
+			$force_submit_content     = false;
+			$credits_accumulated      = 0;
+			$last_successful_response = null;
 
 			while ( $iteration < $max_iterations ) {
 				++$iteration;
@@ -439,14 +441,34 @@ class ChatRestController {
 					max_tokens:     8192,
 				);
 
-				$response = $provider->complete( $req );
-
-				if ( \is_wp_error( $response ) ) {
-					return new \WP_REST_Response(
-						[ 'message' => $response->get_error_message() ],
-						502
-					);
+				try {
+					$response = $provider->complete( $req );
+				} catch ( ProviderException $e ) {
+					// The Worker's monthly credit quota was exhausted mid-loop (surfaces as a
+					// ProviderException carrying ProxyClient's 'rate_limit_exceeded' WP_Error
+					// code — complete()'s return type is CompletionResponse only, so this can
+					// never come back as is_wp_error( $response ) instead). If at least one
+					// earlier iteration this turn already succeeded (and was billed), don't hard
+					// error — finish gracefully with what's already been done, the same way the
+					// MAX_TOOL_ITERATIONS-exhaustion fallback below handles running out of steps.
+					// The iteration cap already bounds worst-case cost per turn, so this is purely
+					// about how the loop exits, not a new spending allowance: no further (billed)
+					// call is made. On the very first iteration there's nothing to gracefully wrap
+					// up, or for any other exception, rethrow so the existing outer catch block
+					// (status mapping, Retry-After, etc.) handles it exactly as before.
+					if ( 'rate_limit_exceeded' === $e->get_error_code() && null !== $last_successful_response ) {
+						$limit_message  = __( "I've reached this turn's usage limit while working on your request. Here's what I was able to complete before stopping.", 'plume' );
+						$final_response = $last_successful_response->with_text( $limit_message );
+						break;
+					}
+					throw $e;
 				}
+
+				// Every successful call this turn is billed by the Worker on its own usage
+				// (see plume-proxy/src/index.ts::handleChatProxy) — sum across all iterations
+				// so the total logged below matches what was actually charged.
+				$credits_accumulated     += $response->credits_charged;
+				$last_successful_response = $response;
 
 				// Bare text response — happens when tools are not supported by the provider.
 				if ( ! $response->is_tool_call() ) {
@@ -518,10 +540,14 @@ class ChatRestController {
 				$final_response = $response->with_text( $limit_message );
 			}
 
-			// Log the Worker's reported credit cost exactly once per user message, after all
-			// tool-call iterations are complete. ProxyClient skips logging for 'chat' to
-			// prevent per-iteration double-counting in the agentic loop.
-			UsageTracker::log_usage( $final_response->credits_charged, $user_id );
+			// Log the sum of the Worker's per-iteration charges exactly once per user message,
+			// after all tool-call iterations are complete. Every iteration was already billed
+			// individually by the Worker (see plume-proxy/src/index.ts::handleChatProxy); this
+			// keeps WordPress's local dashboard-mirror counter (UsageTracker — purely cosmetic,
+			// the Worker's KV ledger remains the sole authoritative source) in sync with the
+			// real total. ProxyClient::chat() skips logging for 'chat' so this is the only
+			// place that writes it.
+			UsageTracker::log_usage( $credits_accumulated, $user_id );
 
 			$store->add_message( $conv_id, 'assistant', $final_response->content, $final_response->model, $final_response->total_tokens );
 
@@ -541,7 +567,7 @@ class ChatRestController {
 				[
 					'content'           => $final_response->content,
 					'model'             => $final_response->model,
-					'credits'           => $final_response->credits_charged,
+					'credits'           => $credits_accumulated,
 					'cost_usd'          => $final_response->cost_usd,
 					'prompt_tokens'     => $final_response->prompt_tokens,
 					'completion_tokens' => $final_response->completion_tokens,

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -539,17 +539,10 @@ class ChatRestController {
 			}
 
 			if ( null === $final_response ) {
-				if ( null === $last_successful_response ) {
-					// Unreachable in practice — MAX_TOOL_ITERATIONS > 0 guarantees at least one
-					// successful iteration completes before this fallback can be reached — but
-					// guards against a fatal error if that invariant is ever violated, and lets
-					// static analysis prove $last_successful_response is non-null below.
-					return new \WP_REST_Response(
-						[ 'message' => __( 'The assistant was unable to complete this request.', 'plume' ) ],
-						500
-					);
-				}
-				// Substitute a displayable message so the chat UI receives a 200 rather than crashing on 500.
+				// $last_successful_response is guaranteed set here: MAX_TOOL_ITERATIONS > 0
+				// means the loop body always runs at least once, and reaching this fallback
+				// (final_response still null) means no break fired, so every iteration up to
+				// and including the last one completed the try block and reached line ~475.
 				$limit_message  = \__( 'The assistant reached the maximum number of steps without finishing. Please try rephrasing your request or breaking it into smaller tasks.', 'plume' );
 				$final_response = $last_successful_response->with_text( $limit_message );
 			}

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -313,7 +313,6 @@ class ChatRestController {
 	 *
 	 * @since 1.0.0
 	 * @param \WP_REST_Request $request Incoming REST request.
-	 * @throws ProviderException On provider failure mid-loop; caught by this method's outer handler and mapped to an HTTP status.
 	 * @return \WP_REST_Response 201 on success; 403 if the conversation is not owned by the caller;
 	 *                           429 with a `Retry-After` header (seconds until next month UTC) on
 	 *                           provider rate-limit; 502 when the provider returns 401/403; 500 on

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -313,6 +313,7 @@ class ChatRestController {
 	 *
 	 * @since 1.0.0
 	 * @param \WP_REST_Request $request Incoming REST request.
+	 * @throws ProviderException On provider failure mid-loop; caught by this method's outer handler and mapped to an HTTP status.
 	 * @return \WP_REST_Response 201 on success; 403 if the conversation is not owned by the caller;
 	 *                           429 with a `Retry-After` header (seconds until next month UTC) on
 	 *                           provider rate-limit; 502 when the provider returns 401/403; 500 on

--- a/includes/Proxy/ProxyClient.php
+++ b/includes/Proxy/ProxyClient.php
@@ -123,8 +123,10 @@ class ProxyClient {
 			return new WP_Error( 'service_error', $body['error'] ?? sprintf( __( 'Plume AI - Write and Design returned HTTP %d', 'plume' ), $code ) );
 		}
 
-		// Chat credits are logged once by ChatRestController after the full agentic loop
-		// completes, so the per-iteration ProxyClient call must not double-count them.
+		// Chat credits are logged once, as an accumulated sum across all agentic-loop
+		// iterations, by ChatRestController::send_message() after the loop completes
+		// (each iteration is billed individually by the Worker; PHP sums what it reports).
+		// The per-iteration ProxyClient call must not additionally log them here.
 		if ( isset( $body['credits_charged'] ) && 'chat' !== $feature ) {
 			UsageTracker::log_usage( (int) $body['credits_charged'], $user_id );
 		}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to function is_wp_error\\(\\) with Plume\\\\Providers\\\\CompletionResponse will always evaluate to false\\.$#"
-			count: 1
-			path: includes/Modules/Chat/ChatRestController.php
-
-		-
-			message: "#^is_wp_error\\(Plume\\\\Providers\\\\CompletionResponse\\) will always evaluate to false\\.$#"
-			count: 1
-			path: includes/Modules/Chat/ChatRestController.php
-
-		-
 			message: "#^Constant AUTH_KEY not found\\.$#"
 			count: 1
 			path: includes/Settings/ProviderSettings.php

--- a/plume-proxy/src/credits.ts
+++ b/plume-proxy/src/credits.ts
@@ -35,11 +35,37 @@ export function getCreditLimit( tier: SiteTier ): number | null {
 export const TOKENS_PER_CREDIT = 2000;
 
 /**
+ * Raw (unrounded) chat cost in credit units — the building block chatCredits()
+ * rounds. Used directly by handleChatProxy()'s per-call billing so that N calls
+ * within one agentic-loop turn are billed on their real combined token volume
+ * (via a delta-of-cumulative-ceiling against the running KV total) rather than
+ * each call independently rounding up to its own whole credit, which would
+ * overcharge multi-step turns relative to a single equivalent-sized call.
+ *
+ * @since NEXT_VERSION
+ * @param {number} inputTokens  Actual input token count returned by the provider for this call.
+ * @param {number} outputTokens Actual output token count returned by the provider for this call.
+ * @param {number} weight       Resolved per-model weight (DEFAULT_MODEL_TOKEN_WEIGHT, possibly KV-overridden).
+ * @return {number} Unrounded credit units for this call.
+ */
+export function rawChatCreditUnits(
+	inputTokens: number,
+	outputTokens: number,
+	weight: number
+): number {
+	return ( ( inputTokens + outputTokens ) * weight ) / TOKENS_PER_CREDIT;
+}
+
+/**
  * Computes the credit cost of a single chat completion, scaled by total token
  * volume and the model's relative weight (the existing per-model weight table
  * resolved by index.ts's getModelConfig(), not redefined here).
  *
  * Formula: ceil((inputTokens + outputTokens) * weight / TOKENS_PER_CREDIT).
+ *
+ * Not used by handleChatProxy()'s per-call billing path (see rawChatCreditUnits()
+ * above) — kept for tests and any caller that wants a single call's cost in
+ * isolation, rounded up.
  *
  * @since NEXT_VERSION
  * @param {number} inputTokens  Actual input token count returned by the provider for this call.
@@ -52,7 +78,5 @@ export function chatCredits(
 	outputTokens: number,
 	weight: number
 ): number {
-	return Math.ceil(
-		( ( inputTokens + outputTokens ) * weight ) / TOKENS_PER_CREDIT
-	);
+	return Math.ceil( rawChatCreditUnits( inputTokens, outputTokens, weight ) );
 }

--- a/plume-proxy/src/credits.ts
+++ b/plume-proxy/src/credits.ts
@@ -57,16 +57,19 @@ export function rawChatCreditUnits(
 }
 
 /**
- * Computes the credit cost of a single chat completion, scaled by total token
- * volume and the model's relative weight (the existing per-model weight table
- * resolved by index.ts's getModelConfig(), not redefined here).
+ * TEST-ONLY helper. Computes the credit cost of a single chat completion,
+ * scaled by total token volume and the model's relative weight (the existing
+ * per-model weight table resolved by index.ts's getModelConfig(), not redefined
+ * here).
  *
  * Formula: ceil((inputTokens + outputTokens) * weight / TOKENS_PER_CREDIT).
  *
- * Not used by handleChatProxy()'s per-call billing path (see rawChatCreditUnits()
- * above) — kept for tests and any caller that wants a single call's cost in
- * isolation, rounded up.
+ * Not used by handleChatProxy()'s per-call billing path — that bills on the raw
+ * (unrounded) running total via rawChatCreditUnits() above. This thin ceil()
+ * wrapper has no production caller and exists solely so tests can assert a
+ * single call's rounded, in-isolation cost.
  *
+ * @internal
  * @since NEXT_VERSION
  * @param {number} inputTokens  Actual input token count returned by the provider for this call.
  * @param {number} outputTokens Actual output token count returned by the provider for this call.

--- a/plume-proxy/src/index.ts
+++ b/plume-proxy/src/index.ts
@@ -15,7 +15,7 @@ import { handleActivationChallenge, handleRegistration } from './registration';
 import { handleWebhook } from './webhook';
 import { verifyHmac } from './signature';
 import {
-	chatCredits,
+	rawChatCreditUnits,
 	getCreditLimit,
 	GENERATOR_CREDITS,
 	SEO_CREDITS,
@@ -849,7 +849,9 @@ async function handleChatProxy(
 			return jsonResponse(
 				{
 					error: 'Rate limit exceeded',
-					used: rateLimitCheck.used,
+					// used is the raw (unrounded) running total internally; round up
+					// for display so this doesn't surface a fractional credit count.
+					used: Math.ceil( rateLimitCheck.used ),
 					limit: rateLimitCheck.limit,
 				},
 				429
@@ -892,31 +894,30 @@ async function handleChatProxy(
 			);
 		}
 
-		// Intermediate tool-use steps are not billed; only the final response is.
-		// The final call's usage.input_tokens naturally encompasses all prior context,
-		// so total token cost is captured without needing cross-request accumulation.
-		// Scoped to 'chat' so flat-rate features are never silently zeroed if they
-		// ever gain tool support in future.
-		const isToolUseStep =
-			feature === 'chat' && ( normalized.tool_calls?.length ?? 0 ) > 0;
+		// Every successful call is billed on its own real usage — there is no more
+		// "intermediate vs final" classification (previously hardcoded against
+		// specific tool names, which needed a new exception every time a new
+		// terminal tool was added — see #927). tool_calls surfacing below stays
+		// fully decoupled from billing: a billed response can still carry tool_calls.
+		const rawContribution =
+			feature === 'chat'
+				? rawChatCreditUnits(
+						normalized.usage.input_tokens,
+						normalized.usage.output_tokens,
+						tokenWeights[ selectedModel ] ?? 1
+				  )
+				: FLAT_FEATURE_CREDITS[ feature ];
 
-		let creditsCharged: number;
-		if ( isToolUseStep ) {
-			creditsCharged = 0;
-		} else if ( feature === 'chat' ) {
-			const weight = tokenWeights[ selectedModel ] ?? 1;
-			creditsCharged = chatCredits(
-				normalized.usage.input_tokens,
-				normalized.usage.output_tokens,
-				weight
-			);
-		} else {
-			creditsCharged = FLAT_FEATURE_CREDITS[ feature ];
-		}
+		// Delta-of-cumulative-ceiling: bills this call only what pushes the site's
+		// real running total over the next whole-credit boundary, so N calls within
+		// one agentic-loop turn summing to X tokens cost the same as one call for X
+		// tokens — never more, regardless of how many pieces the loop split the work
+		// into. (Deltas telescope: sum(ceil(Tn) - ceil(Tn-1)) === ceil(final) - ceil(start).)
+		const previousRawTotal = rateLimitCheck.used; // already read by the rate-limit check above
+		const creditsCharged =
+			Math.ceil( previousRawTotal + rawContribution ) - Math.ceil( previousRawTotal );
 
-		if ( ! isToolUseStep ) {
-			await updateUsage( siteToken, creditsCharged, env );
-		}
+		await updateUsage( siteToken, rawContribution, env );
 
 		const responseData: Record< string, unknown > = {
 			content: normalized.content,
@@ -924,7 +925,7 @@ async function handleChatProxy(
 			credits_charged: creditsCharged,
 			model: selectedModel,
 		};
-		if ( isToolUseStep ) {
+		if ( ( normalized.tool_calls?.length ?? 0 ) > 0 ) {
 			responseData.tool_calls = normalized.tool_calls;
 		}
 		return jsonResponse( responseData );
@@ -971,7 +972,10 @@ async function checkRateLimit(
 ): Promise< { allowed: boolean; used: number; limit: number } > {
 	const limit = MONTHLY_CREDIT_LIMITS[ tier ];
 	const key = `usage:${ siteToken }:${ getCurrentMonth() }`;
-	const used = parseInt( ( await env.USAGE_KV.get( key ) ) ?? '0', 10 );
+	// Stored (and read here) as a float, not a rounded integer — see updateUsage()'s
+	// comment. `used` is the precise raw running total, reused by handleChatProxy()'s
+	// delta-of-cumulative-ceiling billing so it doesn't need a second KV read.
+	const used = parseFloat( ( await env.USAGE_KV.get( key ) ) ?? '0' );
 	return { allowed: used < limit, used, limit };
 }
 
@@ -981,11 +985,19 @@ async function updateUsage(
 	env: Env
 ): Promise< void > {
 	const key = `usage:${ siteToken }:${ getCurrentMonth() }`;
+	// Stored as a float (raw weighted-token-credit units), not a rounded integer.
+	// handleChatProxy() bills each call only the delta between consecutive whole-credit
+	// roundings of this running total (see #927), so the total itself must stay
+	// unrounded, or fractional remainders would be wastefully rounded away on every
+	// call instead of carrying forward to the next one.
+	//
 	// KV does not support atomic increments, so concurrent requests perform a
 	// non-atomic read-modify-write. Under burst load this can under-count credits.
 	// Replace with a Durable Object counter (tracked in issue #312) to make
-	// enforcement fully atomic. NOT fixed by this migration — see risk list.
-	const current = parseInt( ( await env.USAGE_KV.get( key ) ) ?? '0', 10 );
+	// enforcement fully atomic. NOT fixed by this migration — and this migration bills
+	// every agentic-loop iteration instead of just the turn's final call, so this path
+	// now runs more often per turn, marginally raising the race's likelihood.
+	const current = parseFloat( ( await env.USAGE_KV.get( key ) ) ?? '0' );
 	await env.USAGE_KV.put( key, String( current + credits ), {
 		expirationTtl: getSecondsUntilNextMonth(),
 	} );

--- a/plume-proxy/test/chat-proxy.test.ts
+++ b/plume-proxy/test/chat-proxy.test.ts
@@ -1173,6 +1173,58 @@ describe( 'handleChatProxy', () => {
 		}
 	);
 
+	it.each( [
+		[ 'generator', GENERATOR_CREDITS ],
+		[ 'seo', SEO_CREDITS ],
+		[ 'images', IMAGE_CREDITS ],
+	] as const )(
+		'%s feature bills exactly its flat amount (%i) even when the running KV total is fractional',
+		async ( feature, expectedCredits ) => {
+			const env = await makeEnvWithSiteToken( 'pro_managed' );
+
+			// A prior chat turn leaves the shared usage KV holding a fractional
+			// raw total; the flat feature must still bill exactly N credits and
+			// advance the total by exactly N (relies on ceil(x+N) === ceil(x)+N
+			// for integer N — see #944).
+			const fractionalSeed = 0.5;
+			await env.USAGE_KV.put(
+				`usage:${ TEST_TOKEN }:${ currentMonthKey() }`,
+				String( fractionalSeed )
+			);
+
+			vi.stubGlobal(
+				'fetch',
+				vi.fn().mockImplementation( async () => {
+					return new Response(
+						JSON.stringify( {
+							content: [ { type: 'text', text: 'response' } ],
+							usage: {
+								input_tokens: 9999,
+								output_tokens: 9999,
+							},
+						} ),
+						{ status: 200 }
+					);
+				} )
+			);
+
+			const body = JSON.stringify( {
+				messages: [ { role: 'user', content: 'Hello' } ],
+				provider: 'claude',
+				feature,
+			} );
+
+			const response = await worker.fetch( makeChatRequest( body ), env );
+			expect( response.status ).toBe( 200 );
+
+			const json = ( await response.json() ) as { credits_charged: number };
+			expect( json.credits_charged ).toBe( expectedCredits );
+			expect( await getStoredUsage( env ) ).toBe(
+				fractionalSeed + expectedCredits
+			);
+		}
+	);
+
 	it( 'returns 429 once monthly credit allowance is exhausted for a free-tier site', async () => {
 		const env = await makeEnvWithSiteToken( 'free' );
 		await env.USAGE_KV.put(

--- a/plume-proxy/test/chat-proxy.test.ts
+++ b/plume-proxy/test/chat-proxy.test.ts
@@ -6,6 +6,7 @@ import { makeEnv } from './helpers/kv-mock';
 import { currentMonthKey } from './helpers/month';
 import {
 	chatCredits,
+	rawChatCreditUnits,
 	GENERATOR_CREDITS,
 	SEO_CREDITS,
 	IMAGE_CREDITS,
@@ -263,7 +264,133 @@ describe( 'handleChatProxy', () => {
 			},
 		] );
 		expect( json.usage ).toEqual( { input_tokens: 20, output_tokens: 10 } );
-		// Intermediate tool-use steps must not be billed.
+		// A tool-carrying response is billed like any other successful call, on its
+		// own real usage — there is no more "intermediate step" free pass (#927).
+		// First call from a fresh balance: delta === ceil(raw) === chatCredits().
+		expect( json.credits_charged ).toBe( chatCredits( 20, 10, 1 ) );
+		expect( await getStoredUsage( env ) ).toBe( rawChatCreditUnits( 20, 10, 1 ) );
+	} );
+
+	it( 'regression #927: two small agentic-loop calls bill their combined real usage, not double the naive per-call rounding', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
+		const smallUsage = { input_tokens: 150, output_tokens: 50 }; // raw = 200/2000 = 0.1 each
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async () => {
+				return new Response(
+					JSON.stringify( {
+						content: [
+							{
+								type: 'tool_use',
+								id: 'toolu_01',
+								name: 'get_post_content',
+								input: { post_id: 1 },
+							},
+						],
+						usage: smallUsage,
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'Look something up' } ],
+			provider: 'claude',
+			tools: [ mockTool ],
+			feature: 'chat',
+		} );
+
+		// Naively rounding each 0.1-raw-credit call up independently (the bug caught
+		// in review) would bill ceil(0.1)=1 twice, i.e. 2 credits for 400 combined
+		// tokens — the same as a single 2000-token call. The fair delta-of-cumulative-
+		// ceiling accounting must instead bill this pair the same as one equivalent
+		// combined-size call: ceil(0.1 + 0.1) = 1, not 2.
+		const first = await worker.fetch( makeChatRequest( body ), env );
+		const firstJson = ( await first.json() ) as { credits_charged: number };
+		expect( firstJson.credits_charged ).toBe( 1 ); // ceil(0.1) - ceil(0)
+
+		const second = await worker.fetch( makeChatRequest( body ), env );
+		const secondJson = ( await second.json() ) as { credits_charged: number };
+		expect( secondJson.credits_charged ).toBe( 0 ); // ceil(0.2) - ceil(0.1) = 1 - 1
+
+		const combined = firstJson.credits_charged + secondJson.credits_charged;
+		expect( combined ).toBe( 1 );
+		expect( combined ).toBe(
+			Math.ceil( rawChatCreditUnits( 300, 100, 1 ) ) // one equivalent 400-token call
+		);
+		expect( await getStoredUsage( env ) ).toBeCloseTo(
+			rawChatCreditUnits( 150, 50, 1 ) * 2,
+			10
+		);
+	} );
+
+	it( 'regression #927: a call that crosses a whole-credit boundary bills the crossing, calls that stay within a window bill 0', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
+		const usageKey = `usage:${ TEST_TOKEN }:${ currentMonthKey() }`;
+		// Seed a raw running total already partway through a credit window.
+		await env.USAGE_KV.put( usageKey, '0.5' );
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async () => {
+				return new Response(
+					JSON.stringify( {
+						content: [ { type: 'text', text: 'ok' } ],
+						usage: { input_tokens: 600, output_tokens: 0 }, // raw = 600/2000 = 0.3
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+
+		// 0.5 -> 0.8: still under the next whole-credit boundary (ceil(0.8) === ceil(0.5) === 1) — bills 0.
+		const first = await worker.fetch( makeChatRequest(), env );
+		expect( ( ( await first.json() ) as { credits_charged: number } ).credits_charged ).toBe( 0 );
+
+		// 0.8 -> 1.1: crosses the boundary (ceil(1.1)=2, ceil(0.8)=1) — bills 1.
+		const second = await worker.fetch( makeChatRequest(), env );
+		expect( ( ( await second.json() ) as { credits_charged: number } ).credits_charged ).toBe( 1 );
+
+		// 1.1 -> 1.4: back under the next boundary (ceil(1.4)=2=ceil(1.1)) — bills 0 again.
+		const third = await worker.fetch( makeChatRequest(), env );
+		expect( ( ( await third.json() ) as { credits_charged: number } ).credits_charged ).toBe( 0 );
+
+		expect( await getStoredUsage( env ) ).toBeCloseTo( 1.4, 10 );
+	} );
+
+	it( 'zero-token tool-use response bills 0 credits (usage-driven, not a hardcoded free pass)', async () => {
+		const env = await makeEnvWithSiteToken( 'free' );
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation( async () => {
+				return new Response(
+					JSON.stringify( {
+						content: [
+							{
+								type: 'tool_use',
+								id: 'toolu_01',
+								name: 'get_post_content',
+								input: { post_id: 1 },
+							},
+						],
+						usage: { input_tokens: 0, output_tokens: 0 },
+					} ),
+					{ status: 200 }
+				);
+			} )
+		);
+		const body = JSON.stringify( {
+			messages: [ { role: 'user', content: 'x' } ],
+			provider: 'claude',
+			tools: [ mockTool ],
+			feature: 'chat',
+		} );
+
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		expect( response.status ).toBe( 200 );
+		const json = ( await response.json() ) as { credits_charged: number };
 		expect( json.credits_charged ).toBe( 0 );
 		expect( await getStoredUsage( env ) ).toBe( 0 );
 	} );
@@ -908,11 +1035,18 @@ describe( 'handleChatProxy', () => {
 			feature: 'chat',
 		} );
 
-		await worker.fetch( makeChatRequest( body ), env );
+		const response = await worker.fetch( makeChatRequest( body ), env );
+		const json = ( await response.json() ) as { credits_charged: number };
 
+		// KV now stores the raw (unrounded) running total, not chatCredits()'s rounded
+		// value — 15,000 * 5 / 2,000 = 37.5, not a whole number. The billed amount
+		// (credits_charged), which for a first call from a fresh balance equals
+		// ceil(raw) === chatCredits(), is the one that still matches the rounded figure.
 		const stored = await getStoredUsage( env );
-		expect( stored ).toBe( chatCredits( 10_000, 5_000, 5 ) );
-		expect( stored ).toBe( 38 );
+		expect( stored ).toBe( rawChatCreditUnits( 10_000, 5_000, 5 ) );
+		expect( stored ).toBe( 37.5 );
+		expect( json.credits_charged ).toBe( chatCredits( 10_000, 5_000, 5 ) );
+		expect( json.credits_charged ).toBe( 38 );
 	} );
 
 	it( 'free tier: chat call charges credits per chatCredits(input, output, weight) and stores result in usage KV', async () => {
@@ -958,14 +1092,17 @@ describe( 'handleChatProxy', () => {
 			} )
 		);
 
-		// weight=1, raw=101 → ceil(101/2000) = 1, not a clean division.
+		// weight=1, raw=101/2000=0.0505 → ceil(0.0505) = 1, not a clean division.
 		const response = await worker.fetch( makeChatRequest(), env );
 		expect( response.status ).toBe( 200 );
 
 		const json = ( await response.json() ) as { credits_charged: number };
+		// KV stores the raw total (0.0505), not the rounded chatCredits() value;
+		// credits_charged is what's actually billed and still equals chatCredits()
+		// for this first call from a fresh balance.
 		const stored = await getStoredUsage( env );
-		expect( stored ).toBe( chatCredits( 100, 1, 1 ) );
-		expect( stored ).toBe( 1 );
+		expect( stored ).toBe( rawChatCreditUnits( 100, 1, 1 ) );
+		expect( json.credits_charged ).toBe( chatCredits( 100, 1, 1 ) );
 		expect( json.credits_charged ).toBe( 1 );
 	} );
 
@@ -1078,7 +1215,7 @@ describe( 'handleChatProxy', () => {
 		} );
 	} );
 
-	it( 'tool-use step: credits_charged is 0 in response and KV is not updated', async () => {
+	it( 'tool-use step is billed on its own real usage like any other successful call', async () => {
 		const env = await makeEnvWithSiteToken( 'free' );
 
 		vi.stubGlobal(
@@ -1115,12 +1252,13 @@ describe( 'handleChatProxy', () => {
 		const response = await worker.fetch( makeChatRequest( body ), env );
 		expect( response.status ).toBe( 200 );
 
+		// First call from a fresh balance: delta === ceil(raw) === chatCredits().
 		const json = ( await response.json() ) as { credits_charged: number };
-		expect( json.credits_charged ).toBe( 0 );
-		expect( await getStoredUsage( env ) ).toBe( 0 );
+		expect( json.credits_charged ).toBe( chatCredits( 200, 50, 1 ) );
+		expect( await getStoredUsage( env ) ).toBe( rawChatCreditUnits( 200, 50, 1 ) );
 	} );
 
-	it( 'final chat response: credits_charged in response body matches KV and chatCredits()', async () => {
+	it( 'final chat response: credits_charged in response body matches chatCredits(); KV holds the raw total', async () => {
 		const env = await makeEnvWithSiteToken( 'free' );
 
 		vi.stubGlobal(
@@ -1139,11 +1277,11 @@ describe( 'handleChatProxy', () => {
 		const response = await worker.fetch( makeChatRequest(), env );
 		expect( response.status ).toBe( 200 );
 
-		// weight=1, raw=1000 → ceil(1000/2000) = 1 credit.
-		const expected = chatCredits( 500, 500, 1 );
+		// weight=1, raw=1000/2000=0.5 → ceil(0.5) = 1 credit billed.
 		const json = ( await response.json() ) as { credits_charged: number };
-		expect( json.credits_charged ).toBe( expected );
-		expect( await getStoredUsage( env ) ).toBe( expected );
+		expect( json.credits_charged ).toBe( chatCredits( 500, 500, 1 ) );
+		// KV stores the raw (unrounded) total, not the rounded billed amount.
+		expect( await getStoredUsage( env ) ).toBe( rawChatCreditUnits( 500, 500, 1 ) );
 	} );
 
 	it( 'allows a request at used = limit-1, then blocks the next one at used = limit', async () => {
@@ -1157,14 +1295,16 @@ describe( 'handleChatProxy', () => {
 				return new Response(
 					JSON.stringify( {
 						content: [ { type: 'text', text: 'ok' } ],
-						usage: { input_tokens: 1, output_tokens: 0 },
+						// weight=1, raw = 2000/2000 = 1.0 exactly, so the running total
+						// lands precisely on the limit after this call.
+						usage: { input_tokens: 2000, output_tokens: 0 },
 					} ),
 					{ status: 200 }
 				);
 			} )
 		);
 
-		// used=99 < limit=100 — allowed, charges 1 credit, used becomes 100.
+		// used=99 < limit=100 — allowed, bills ceil(100)-ceil(99)=1 credit, raw total becomes 100.
 		const first = await worker.fetch( makeChatRequest(), env );
 		expect( first.status ).toBe( 200 );
 		expect( Number( await env.USAGE_KV.get( usageKey ) ) ).toBe( 100 );

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -1892,7 +1892,10 @@ class ChatRestControllerTest extends TestCase {
     public function test_send_message_logs_credits_once_after_loop(): void {
         // Verifies the single UsageTracker::log_usage() call added after the while loop.
         // A two-iteration exchange (tool call → final answer) must produce exactly one
-        // DB write for credits, reflecting the final response's credits_charged value.
+        // DB write for credits, reflecting the SUM of every iteration's credits_charged —
+        // every successful Worker call this turn is billed on its own usage (#927), so
+        // the local dashboard-mirror counter must match the real total, not just the
+        // final call's amount.
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
         Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );
         Functions\when( 'get_option' )->alias( fn( $key, $default = '' ) => match ( $key ) {
@@ -1969,14 +1972,16 @@ class ChatRestControllerTest extends TestCase {
         $wpdb = $original_wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
         $this->assertSame( 200, $response->get_status() );
-        $this->assertSame( 3, $response->data['credits'], 'credits field must reflect final_response->credits_charged.' );
-        $this->assertSame( 3, $captured_credits, 'log_usage must write final_response->credits_charged (3) to usermeta.' );
+        $this->assertSame( 6, $response->data['credits'], 'credits field must reflect the sum of every iteration\'s credits_charged (3 + 3).' );
+        $this->assertSame( 6, $captured_credits, 'log_usage must write the summed total (6) to usermeta, not just the final iteration\'s 3.' );
     }
 
-    public function test_send_message_logs_only_final_iteration_credits_when_amounts_differ(): void {
-        // Locks down the accounting rule (relates to #880): when intermediate and final
-        // iterations charge different amounts, the controller must log exactly the final
-        // response's credits_charged once — never the intermediate value, a sum, or 0.
+    public function test_send_message_logs_sum_of_all_iteration_credits_when_amounts_differ(): void {
+        // Locks down the accounting rule (relates to #880, revised for #927): every
+        // successful iteration is billed by the Worker on its own usage, so when
+        // intermediate and final iterations charge different amounts, the controller
+        // must log their SUM once — never just the final value, the intermediate
+        // value alone, or 0.
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
         Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );
         Functions\when( 'get_option' )->alias( fn( $key, $default = '' ) => match ( $key ) {
@@ -2002,7 +2007,7 @@ class ChatRestControllerTest extends TestCase {
             credits_charged:   3,
         );
 
-        // Iteration 2: final answer charging a DIFFERENT amount (7) — only this is logged.
+        // Iteration 2: final answer charging a DIFFERENT amount (7) — the two amounts sum to 10.
         $final_response = new CompletionResponse(
             content:           'Final answer',
             model:             'claude-3-5-sonnet',
@@ -2050,8 +2055,317 @@ class ChatRestControllerTest extends TestCase {
         $wpdb = $original_wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
         $this->assertSame( 200, $response->get_status() );
-        $this->assertSame( 7, $response->data['credits'], 'credits field must reflect the final iteration, not the intermediate 3.' );
-        $this->assertSame( 7, $logged_credits, 'usermeta must record the final iteration amount (7), not the intermediate 3, their sum (10), or 0.' );
+        $this->assertSame( 10, $response->data['credits'], 'credits field must reflect the sum of all iterations (3 + 7), not just the final 7.' );
+        $this->assertSame( 10, $logged_credits, 'usermeta must record the summed total (10), not just the final iteration (7), the intermediate alone (3), or 0.' );
+    }
+
+    public function test_send_message_sums_credits_across_three_or_more_iterations(): void {
+        // Extends the two-iteration coverage above to three, confirming the accumulator
+        // isn't accidentally limited to a single addition.
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );
+        Functions\when( 'get_option' )->alias( fn( $key, $default = '' ) => match ( $key ) {
+            'plume_default_provider' => 'claude',
+            default                  => $default,
+        } );
+        Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+
+        $store_mock = $this->createMock( \Plume\DB\ConversationStore::class );
+        $store_mock->method( 'get_conversation' )->willReturn( [ 'user_id' => 1 ] );
+        $store_mock->method( 'get_messages' )->willReturn( [
+            [ 'role' => 'user', 'content' => 'Hello' ],
+        ] );
+
+        $response_1 = new CompletionResponse(
+            content:           '',
+            model:             'claude-3-5-sonnet',
+            prompt_tokens:     10,
+            completion_tokens: 5,
+            raw:               [ 'content' => [] ],
+            tool_call:         [ 'id' => 'tc_1', 'name' => 'get_recent_posts', 'arguments' => [ 'count' => 3 ] ],
+            credits_charged:   2,
+        );
+        $response_2 = new CompletionResponse(
+            content:           '',
+            model:             'claude-3-5-sonnet',
+            prompt_tokens:     15,
+            completion_tokens: 8,
+            raw:               [ 'content' => [] ],
+            tool_call:         [ 'id' => 'tc_2', 'name' => 'get_post_content', 'arguments' => [ 'post_id' => 1 ] ],
+            credits_charged:   4,
+        );
+        $final_response = new CompletionResponse(
+            content:           'Final answer',
+            model:             'claude-3-5-sonnet',
+            prompt_tokens:     20,
+            completion_tokens: 15,
+            credits_charged:   1,
+        );
+
+        $this->tool_registry->method( 'get_for_provider' )->willReturn( [] );
+        $this->tool_executor->method( 'execute' )->willReturn( [ 'posts' => [] ] );
+
+        $provider_mock = $this->createMock( \Plume\Providers\ProviderInterface::class );
+        $provider_mock->method( 'is_available' )->willReturn( true );
+        $provider_mock->method( 'supports_tools' )->willReturn( true );
+        $provider_mock->method( 'complete' )->willReturnOnConsecutiveCalls( $response_1, $response_2, $final_response );
+
+        $factory_mock = $this->createMock( \Plume\Providers\ProviderFactory::class );
+        $factory_mock->method( 'make' )->willReturn( $provider_mock );
+
+        $voice_mock = $this->createMock( \Plume\Voice\VoiceInjector::class );
+        $voice_mock->method( 'build_system_prompt' )->willReturn( '' );
+
+        global $wpdb;
+        $original_wpdb       = $wpdb;
+        $logged_credits      = null;
+        $wpdb                = \Mockery::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+        $wpdb->usermeta      = 'wp_usermeta';
+        $wpdb->rows_affected = 1;
+        $wpdb->shouldReceive( 'prepare' )->once()->andReturnUsing(
+            function ( $sql, $credits = null ) use ( &$logged_credits ) {
+                $logged_credits = $credits;
+                return $sql;
+            }
+        );
+        $wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+        $controller = $this->make_controller( $store_mock, $factory_mock, $voice_mock );
+
+        $request = new \WP_REST_Request( 'POST' );
+        $request->set_url_params( [ 'id' => '42' ] );
+        $request->set_body_params( [ 'content' => 'Hello', 'provider' => 'claude', 'model' => '' ] );
+
+        $response = $controller->send_message( $request );
+
+        $wpdb = $original_wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+        $this->assertSame( 200, $response->get_status() );
+        $this->assertSame( 7, $response->data['credits'], '2 + 4 + 1 across three iterations, not just the final 1.' );
+        $this->assertSame( 7, $logged_credits );
+    }
+
+    public function test_send_message_sums_credits_across_all_iterations_when_max_iterations_exhausted(): void {
+        // The MAX_TOOL_ITERATIONS-exhaustion fallback (loop never gets a clean exit) still
+        // must not lose any iteration's billed credits — each of the 5 forced Worker calls
+        // was already billed individually, so the accumulator must include all of them,
+        // not just the last one reused for the fallback message.
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );
+        Functions\when( 'get_option' )->alias( fn( $key, $default = '' ) => match ( $key ) {
+            'plume_default_provider' => 'claude',
+            default                  => $default,
+        } );
+        Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+        // __() is called to build the limit message; pass strings through untranslated in unit tests.
+        Functions\when( '__' )->returnArg();
+        Functions\when( 'update_user_meta' )->justReturn( true );
+
+        $store_mock = $this->createMock( \Plume\DB\ConversationStore::class );
+        $store_mock->method( 'get_conversation' )->willReturn( [ 'user_id' => 1 ] );
+        $store_mock->method( 'get_messages' )->willReturn( [
+            [ 'role' => 'user', 'content' => 'Hi' ],
+        ] );
+        $store_mock->method( 'add_message' )->willReturn( 99 );
+
+        $tool_response = new CompletionResponse(
+            content:           '',
+            model:             'claude-3-5-sonnet',
+            prompt_tokens:     10,
+            completion_tokens: 5,
+            cost_usd:          0.0,
+            raw:               [ 'content' => [] ],
+            tool_call:         [ 'id' => 'tc_x', 'name' => 'get_site_info', 'arguments' => [] ],
+            credits_charged:   2,
+        );
+
+        $this->tool_registry->method( 'get_for_provider' )->willReturn( [] );
+        $this->tool_executor->method( 'execute' )->willReturn( [ 'name' => 'Test Site' ] );
+
+        $provider_mock = $this->createMock( \Plume\Providers\ProviderInterface::class );
+        $provider_mock->method( 'is_available' )->willReturn( true );
+        $provider_mock->method( 'supports_tools' )->willReturn( true );
+        // Always returns a (billed) tool-call response — loop exhausts MAX_TOOL_ITERATIONS (5).
+        $provider_mock->method( 'complete' )->willReturn( $tool_response );
+
+        $factory_mock = $this->createMock( \Plume\Providers\ProviderFactory::class );
+        $factory_mock->method( 'make' )->willReturn( $provider_mock );
+
+        $voice_mock = $this->createMock( \Plume\Voice\VoiceInjector::class );
+        $voice_mock->method( 'build_system_prompt' )->willReturn( '' );
+
+        global $wpdb;
+        $original_wpdb       = $wpdb;
+        $logged_credits      = null;
+        $wpdb                = \Mockery::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+        $wpdb->usermeta      = 'wp_usermeta';
+        $wpdb->rows_affected = 1;
+        $wpdb->shouldReceive( 'prepare' )->once()->andReturnUsing(
+            function ( $sql, $credits = null ) use ( &$logged_credits ) {
+                $logged_credits = $credits;
+                return $sql;
+            }
+        );
+        $wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+        $controller = $this->make_controller( $store_mock, $factory_mock, $voice_mock );
+
+        $request = new \WP_REST_Request( 'POST' );
+        $request->set_url_params( [ 'id' => '99' ] );
+        $request->set_body_params( [ 'content' => 'Hi', 'provider' => 'claude', 'model' => '' ] );
+
+        $response = $controller->send_message( $request );
+
+        $wpdb = $original_wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+        $this->assertSame( 200, $response->get_status() );
+        $this->assertStringContainsString( 'maximum number of steps', $response->data['content'] );
+        // 5 iterations (MAX_TOOL_ITERATIONS) x 2 credits each = 10, not just the last call's 2.
+        $this->assertSame( 10, $response->data['credits'] );
+        $this->assertSame( 10, $logged_credits );
+    }
+
+    public function test_send_message_finishes_gracefully_when_rate_limit_hit_mid_loop_after_prior_success(): void {
+        // #927 design decision: a Worker 429 (monthly credit quota exhausted) mid-loop,
+        // after at least one earlier iteration already succeeded, must not surface as a
+        // hard error — the turn finishes gracefully with what was already done, and the
+        // already-billed partial total is still logged (not silently dropped).
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );
+        Functions\when( 'get_option' )->alias( fn( $key, $default = '' ) => match ( $key ) {
+            'plume_default_provider' => 'claude',
+            default                  => $default,
+        } );
+        Functions\when( 'wp_json_encode' )->alias( fn( $v ) => json_encode( $v ) );
+        Functions\when( '__' )->returnArg();
+
+        $store_mock = $this->createMock( \Plume\DB\ConversationStore::class );
+        $store_mock->method( 'get_conversation' )->willReturn( [ 'user_id' => 1 ] );
+        $store_mock->method( 'get_messages' )->willReturn( [
+            [ 'role' => 'user', 'content' => 'Hello' ],
+        ] );
+
+        // Iteration 1 succeeds and is billed 3 credits.
+        $tool_response = new CompletionResponse(
+            content:           '',
+            model:             'claude-3-5-sonnet',
+            prompt_tokens:     10,
+            completion_tokens: 5,
+            raw:               [ 'content' => [] ],
+            tool_call:         [ 'id' => 'tc_1', 'name' => 'get_recent_posts', 'arguments' => [ 'count' => 3 ] ],
+            credits_charged:   3,
+        );
+
+        $this->tool_registry->method( 'get_for_provider' )->willReturn( [] );
+        $this->tool_executor->method( 'execute' )->willReturn( [ 'posts' => [] ] );
+
+        // Iteration 2 hits the Worker's exhausted quota — propagates as a ProviderException
+        // carrying ProxyClient's 'rate_limit_exceeded' code (complete()'s CompletionResponse
+        // return type means this can never come back as is_wp_error() instead).
+        $call_count    = 0;
+        $provider_mock = $this->createMock( \Plume\Providers\ProviderInterface::class );
+        $provider_mock->method( 'is_available' )->willReturn( true );
+        $provider_mock->method( 'supports_tools' )->willReturn( true );
+        $provider_mock->method( 'complete' )->willReturnCallback(
+            function () use ( &$call_count, $tool_response ) {
+                ++$call_count;
+                if ( 1 === $call_count ) {
+                    return $tool_response;
+                }
+                throw new \Plume\Providers\ProviderException(
+                    'Monthly usage limit reached.',
+                    'claude',
+                    0,
+                    [],
+                    null,
+                    'rate_limit_exceeded'
+                );
+            }
+        );
+
+        $factory_mock = $this->createMock( \Plume\Providers\ProviderFactory::class );
+        $factory_mock->method( 'make' )->willReturn( $provider_mock );
+
+        $voice_mock = $this->createMock( \Plume\Voice\VoiceInjector::class );
+        $voice_mock->method( 'build_system_prompt' )->willReturn( '' );
+
+        global $wpdb;
+        $original_wpdb       = $wpdb;
+        $logged_credits      = null;
+        $wpdb                = \Mockery::mock( 'wpdb' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+        $wpdb->usermeta      = 'wp_usermeta';
+        $wpdb->rows_affected = 1;
+        $wpdb->shouldReceive( 'prepare' )->once()->andReturnUsing(
+            function ( $sql, $credits = null ) use ( &$logged_credits ) {
+                $logged_credits = $credits;
+                return $sql;
+            }
+        );
+        $wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+        $controller = $this->make_controller( $store_mock, $factory_mock, $voice_mock );
+
+        $request = new \WP_REST_Request( 'POST' );
+        $request->set_url_params( [ 'id' => '42' ] );
+        $request->set_body_params( [ 'content' => 'Hello', 'provider' => 'claude', 'model' => '' ] );
+
+        $response = $controller->send_message( $request );
+
+        $wpdb = $original_wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+        // Normal 200 with a graceful message, not a 502.
+        $this->assertSame( 200, $response->get_status() );
+        $this->assertStringContainsString( "usage limit", $response->data['content'] );
+        // Only iteration 1's already-billed 3 credits — no charge for the rejected iteration 2.
+        $this->assertSame( 3, $response->data['credits'] );
+        $this->assertSame( 3, $logged_credits, 'the partial-turn total must still be logged, not dropped, on the graceful mid-loop exit.' );
+    }
+
+    public function test_send_message_returns_hard_error_when_rate_limit_hit_on_first_iteration(): void {
+        // With no prior progress this turn, there is nothing to gracefully finish with —
+        // the existing hard-error behavior (mapped through the outer ProviderException
+        // catch block, unchanged by #927) is still correct.
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+        Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );
+        Functions\when( 'get_option' )->justReturn( 'claude' );
+
+        $store_mock = $this->createMock( \Plume\DB\ConversationStore::class );
+        $store_mock->method( 'get_conversation' )->willReturn( [ 'user_id' => 1 ] );
+        $store_mock->method( 'get_messages' )->willReturn( [] );
+
+        $this->tool_registry->method( 'get_for_provider' )->willReturn( [] );
+
+        $provider_mock = $this->createMock( \Plume\Providers\ProviderInterface::class );
+        $provider_mock->method( 'is_available' )->willReturn( true );
+        $provider_mock->method( 'supports_tools' )->willReturn( false );
+        $provider_mock->method( 'complete' )->willThrowException(
+            new \Plume\Providers\ProviderException(
+                'Monthly usage limit reached.',
+                'claude',
+                0,
+                [],
+                null,
+                'rate_limit_exceeded'
+            )
+        );
+
+        $factory_mock = $this->createMock( \Plume\Providers\ProviderFactory::class );
+        $factory_mock->method( 'make' )->willReturn( $provider_mock );
+
+        $voice_mock = $this->createMock( \Plume\Voice\VoiceInjector::class );
+        $voice_mock->method( 'build_system_prompt' )->willReturn( '' );
+
+        $controller = $this->make_controller( $store_mock, $factory_mock, $voice_mock );
+
+        $request = new \WP_REST_Request( 'POST' );
+        $request->set_url_params( [ 'id' => '12' ] );
+        $request->set_body_params( [ 'content' => 'Hi', 'provider' => 'claude', 'model' => '' ] );
+
+        $response = $controller->send_message( $request );
+
+        $this->assertInstanceOf( \WP_REST_Response::class, $response );
+        $this->assertSame( 502, $response->get_status() );
+        $this->assertSame( 'rate_limit_exceeded', $response->data['code'] );
     }
 
     // ── search_posts ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

#927 is a follow-up to #905 ("first chat response never charged"). The unmerged #939 fixed #905 narrowly by excluding the literal tool name `chat_response` from the Worker's "is this call intermediate, don't bill it" check — but #927 showed the exact same bug recurring for `plan_post`/`submit_post_content`, because the real root cause isn't *which* tool name a response carries, it's that billing was a binary "is this the final call of the turn" classification hardcoded against specific tool names, when the agentic loop (`ChatRestController::send_message()`) makes up to 5 separate, real upstream calls per user message — each one a genuine cost to Plume regardless of whether the Worker calls it "final."

**This PR replaces that classification entirely: every successful (HTTP 200) upstream call is now billed on its own real token usage**, computed Worker-side (so PHP can never influence the charge — the Worker's KV ledger was already the sole authoritative enforcement point; that property is preserved, not introduced). This supersedes #939 rather than building on it — closing #939 with a comment pointing here.

### Worker (`plume-proxy`)
- `handleChatProxy()` bills every successful call instead of special-casing tool-carrying responses as free.
- **Correctness fix caught during design review:** naively rounding each call's credits up independently (`Math.ceil` per call) would overcharge multi-step turns — five ~200-token tool-use iterations would bill 5 credits (via 5× independent round-ups) for what a single equivalent 1,000-token call would bill as 1. Fixed by tracking the running credit total **unrounded** in KV and billing each call only the **delta between consecutive whole-credit roundings** of that total (`rawChatCreditUnits()` in `credits.ts`) — a standard fair-metering technique: the deltas telescope, so N calls summing to X tokens always cost the same as one call for X tokens, regardless of how many pieces the loop split the work into.
- `checkRateLimit()`/`updateUsage()` now read/store that running total as a float instead of an always-rounded integer.

### PHP (`ChatRestController`)
- Sums `credits_charged` across all loop iterations instead of logging only the final response's amount, so the WordPress dashboard-mirror counter (cosmetic display only — the Worker's KV ledger remains authoritative) matches what was actually charged.
- A Worker 429 (monthly quota exhausted) mid-loop, after at least one earlier iteration already succeeded, now finishes the turn gracefully with a best-effort message instead of a hard 502 — mirroring the existing `MAX_TOOL_ITERATIONS`-exhaustion fallback. The iteration cap already bounds worst-case cost per turn, so no additional spend is let through; this only changes how the loop exits gracefully vs. erroring with no visible reply.
- Implementation correction made mid-build: the original design intercepted this via `is_wp_error( $response )`, but `ProviderInterface::complete()`'s return type is `CompletionResponse` only — a Worker failure actually surfaces as a **thrown `ProviderException`** (carrying the `rate_limit_exceeded` code), never a returned `WP_Error`. Fixed to a `try`/`catch( ProviderException $e )` around the call instead; confirmed no existing test relied on the old (dead) `is_wp_error` branch.

## Test plan

- [x] `plume-proxy`: `npx vitest run` — 127/127 passing, including new regression tests for the rounding-fairness fix (two small calls billing their combined real usage, not double) and a boundary-crossing case.
- [x] `npx tsc --noEmit` — clean.
- [x] `php -l` clean on all three changed/added PHP files.
- [x] Updated `tests/Unit/Modules/Chat/ChatRestControllerTest.php`: flipped the two tests that asserted "only the final iteration's credits are logged" (now assert the sum), added 3+-iteration and `MAX_TOOL_ITERATIONS`-exhaustion sum coverage, and added both mid-loop-429-graceful-finish and first-iteration-429-still-hard-errors cases.
- [x] `./vendor/bin/phpunit` / `./vendor/bin/phpcs` — not runnable in this sandbox (GitHub API rate-limited over the network proxy during `composer install`; same limitation hit in #935); will run in CI.

## WordPress compliance checklist

- [x] No new input/output surface — billing/accounting logic only.
- [x] No escaping/sanitisation/nonce/capability changes needed.
- [x] `@since NEXT_VERSION` used for the new `rawChatCreditUnits()` export (new code, unreleased).

**Deploy note:** requires a `wrangler deploy` for `plume-proxy/**` alongside the PHP release, since billing behaviour changes on both sides together.

**Rollout risk (flagging, not blocking):** this changes real billing amounts upward — any turn needing 2+ loop iterations (a lookup then an answer, or `plan_update` → `submit_post_content`) now bills every iteration instead of only the last. Free/pro_managed monthly caps (100/500 credits) will likely be consumed faster for tool-heavy flows (post creation/editing) than plain chat Q&A. No mitigation (limit rebalancing, comms, cost-preview UI) is designed here — worth a deliberate decision before/after rollout.

---
_Generated by Claude Code_


---
_Generated by [Claude Code](https://claude.ai/code/session_01EMvQRKUiRg7agb4jmXx9SV)_

Closes #944

Closes #945