### PR TITLE
fix(rest): resolve wporg review findings — conversation ownership and image-upload capability

### DIFF
--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -258,7 +258,7 @@ class ChatRestController {
 
 		$conv = $store->get_conversation( $conv_id );
 		if ( ! $conv || $user_id !== (int) $conv['user_id'] ) {
-			return new \WP_REST_Response( [ 'message' => 'Forbidden.' ], 403 );
+			return new \WP_REST_Response( [ 'message' => __( 'Forbidden.', 'plume' ) ], 403 );
 		}
 
 		return rest_ensure_response( $store->get_messages( $conv_id ) );
@@ -344,7 +344,7 @@ class ChatRestController {
 		// Ownership guard.
 		$conv = $store->get_conversation( $conv_id );
 		if ( ! $conv || $user_id !== (int) $conv['user_id'] ) {
-			return new \WP_REST_Response( [ 'message' => 'Forbidden.' ], 403 );
+			return new \WP_REST_Response( [ 'message' => __( 'Forbidden.', 'plume' ) ], 403 );
 		}
 
 		$factory  = $this->make_provider_factory();

--- a/includes/Modules/Chat/ChatRestController.php
+++ b/includes/Modules/Chat/ChatRestController.php
@@ -248,11 +248,20 @@ class ChatRestController {
 	 *
 	 * @since 1.0.0
 	 * @param \WP_REST_Request $request Incoming REST request; must contain 'id' route parameter.
-	 * @return \WP_REST_Response
+	 * @return \WP_REST_Response 200 with the conversation's messages; 403 if the conversation
+	 *                           is not owned by the caller.
 	 */
 	public function get_messages( \WP_REST_Request $request ): \WP_REST_Response {
-		$store = $this->make_store();
-		return rest_ensure_response( $store->get_messages( (int) $request->get_param( 'id' ) ) );
+		$conv_id = (int) $request->get_param( 'id' );
+		$user_id = \get_current_user_id();
+		$store   = $this->make_store();
+
+		$conv = $store->get_conversation( $conv_id );
+		if ( ! $conv || $user_id !== (int) $conv['user_id'] ) {
+			return new \WP_REST_Response( [ 'message' => 'Forbidden.' ], 403 );
+		}
+
+		return rest_ensure_response( $store->get_messages( $conv_id ) );
 	}
 
 	/**

--- a/includes/Modules/Images/ImagesModule.php
+++ b/includes/Modules/Images/ImagesModule.php
@@ -104,7 +104,7 @@ class ImagesModule {
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ self::class, 'handle_generate' ],
 				'permission_callback' => function () {
-					return \current_user_can( 'edit_posts' );
+					return \current_user_can( 'upload_files' );
 				},
 				'args'                => [
 					'prompt'       => [

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -524,7 +524,7 @@ class ChatRestControllerTest extends TestCase {
 
         $this->assertInstanceOf( \WP_REST_Response::class, $response );
         $this->assertSame( 200, $response->get_status() );
-        $this->assertSame( [ [ 'content' => 'Hi' ] ], $response->get_data() );
+        $this->assertSame( [ [ 'content' => 'Hi' ] ], $response->data );
     }
 
     // ── Tool loop ──────────────────────────────────────────────────────────────

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -489,6 +489,44 @@ class ChatRestControllerTest extends TestCase {
         $this->assertSame( 403, $response->get_status() );
     }
 
+    public function test_get_messages_returns_403_when_conversation_not_owned(): void {
+        // Arrange: conversation belongs to user 999, but current user is 1.
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+        $store_mock = $this->createMock( \Plume\DB\ConversationStore::class );
+        $store_mock->method( 'get_conversation' )->willReturn( [ 'user_id' => 999 ] );
+        $store_mock->expects( $this->never() )->method( 'get_messages' );
+
+        $controller = $this->make_controller_with_store( $store_mock );
+
+        $request = new \WP_REST_Request( 'GET' );
+        $request->set_url_params( [ 'id' => '42' ] );
+
+        $response = $controller->get_messages( $request );
+
+        $this->assertInstanceOf( \WP_REST_Response::class, $response );
+        $this->assertSame( 403, $response->get_status() );
+    }
+
+    public function test_get_messages_returns_messages_when_owned(): void {
+        Functions\when( 'get_current_user_id' )->justReturn( 1 );
+
+        $store_mock = $this->createMock( \Plume\DB\ConversationStore::class );
+        $store_mock->method( 'get_conversation' )->willReturn( [ 'user_id' => 1 ] );
+        $store_mock->method( 'get_messages' )->willReturn( [ [ 'content' => 'Hi' ] ] );
+
+        $controller = $this->make_controller_with_store( $store_mock );
+
+        $request = new \WP_REST_Request( 'GET' );
+        $request->set_url_params( [ 'id' => '42' ] );
+
+        $response = $controller->get_messages( $request );
+
+        $this->assertInstanceOf( \WP_REST_Response::class, $response );
+        $this->assertSame( 200, $response->get_status() );
+        $this->assertSame( [ [ 'content' => 'Hi' ] ], $response->get_data() );
+    }
+
     // ── Tool loop ──────────────────────────────────────────────────────────────
 
     public function test_send_message_tool_loop_executes_tool_and_returns_final(): void {

--- a/tests/Unit/Modules/Chat/ChatRestControllerTest.php
+++ b/tests/Unit/Modules/Chat/ChatRestControllerTest.php
@@ -455,6 +455,7 @@ class ChatRestControllerTest extends TestCase {
 
     public function test_send_message_returns_403_when_conversation_not_owned(): void {
         // Arrange: conversation belongs to user 999, but current user is 1.
+        Functions\when( '__' )->alias( fn( $s ) => $s );
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
         Functions\when( 'sanitize_textarea_field' )->alias( fn( $v ) => $v );
         Functions\when( 'get_option' )->justReturn( 'claude' );
@@ -491,6 +492,7 @@ class ChatRestControllerTest extends TestCase {
 
     public function test_get_messages_returns_403_when_conversation_not_owned(): void {
         // Arrange: conversation belongs to user 999, but current user is 1.
+        Functions\when( '__' )->alias( fn( $s ) => $s );
         Functions\when( 'get_current_user_id' )->justReturn( 1 );
 
         $store_mock = $this->createMock( \Plume\DB\ConversationStore::class );


### PR DESCRIPTION
## Summary

Addresses the REST-API findings from WordPress.org's plugin review (R plume/niklasjohansson/22Jun26/T2 10Jul26/4.0.1):

- `ChatRestController::get_messages()` was missing the conversation-ownership check present on every sibling handler in the same file (`send_message`, `get_pending_plan`, `update_conversation`), allowing any user with `edit_posts` to read another user's conversation messages by ID (IDOR). Added the same `get_current_user_id()` vs `conversation['user_id']` guard, returning 403 on mismatch.
- `ImagesModule`'s `/images/generate` route creates media-library attachments but only checked `current_user_can('edit_posts')`. Tightened to `upload_files`, the capability that actually matches the action.
- Both 403 `'Forbidden.'` messages in `ChatRestController` are now wrapped in `__( ..., 'plume' )` for translatability (closes #950, filed during review of this PR).

The review's separate ownership-verification issue (WordPress.org account email domain vs. plugin's declared domain) is being handled directly with the Plugins Team and is out of scope for this PR.

**Split from this PR** (originally bundled, now separated by scope per review):
- njDevTools → plumeDevTools rename: see the sibling `fix(admin)` PR.
- Unrelated pre-push hook fix: see the sibling `fix(hooks)` PR.

## Test plan

- [x] Added `test_get_messages_returns_403_when_conversation_not_owned` and `test_get_messages_returns_messages_when_owned` to `ChatRestControllerTest`, following the existing `test_send_message_returns_403_when_conversation_not_owned` pattern
- [x] CI: PHPUnit, PHPCS, PHPStan, PHP Compat (8.1–8.3), JS/CSS Lint, Semgrep, CodeQL, WP Plugin Check all passing
- [ ] Manual QA against `wp-env` (403 boundary on both REST endpoints with a non-owning user) — recommend a manual pass before merging

---
_Generated by [Claude Code](https://claude.ai/code/session_012NMgpqX3FME3q8SfowzX2v)_
